### PR TITLE
test(frontend): harden runtime with mutation testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "24.15.0"
+          node-version: "24.19.0"
           cache: npm
           cache-dependency-path: package-lock.json
       - name: Install deps
@@ -101,6 +101,8 @@ jobs:
         run: npm run typecheck
       - name: Gate - test typecheck
         run: npm run typecheck:test
+      - name: Gate - mutation infrastructure guards
+        run: npm run test:mutation:guards
       - name: Gate - Vitest unit and DOM coverage
         run: npm run test:coverage
       - name: Gate - embedded assets are fresh

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@
 coverage.*
 /coverage/
 /.vitest/
+/.mutation-stage/
+/.stryker-tmp/
+/reports/mutation/
+/reports/stryker-incremental.json
 
 # Local tooling / editor / scratch
 .DS_Store

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,7 +1,7 @@
 # Local development toolchain. Keep this in sync with CI/Makefile pins.
 [tools]
 go = "1.26.7"
-node = "24.15.0"
+node = "24.19.0"
 golangci-lint = "2.11.2"
 make = "4.4.1"
 zig = "0.16.0"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,65 @@ It lints and typechecks both production and test TypeScript, runs Vitest with
 the enforced V8 coverage floor, rebuilds the embedded assets, and fails if the
 committed bundle is stale. Use `npm run test:watch` for the local Vitest loop.
 
+For a slower test-strength audit, first validate the Stryker sandbox and then
+run the complete mutation gate:
+
+```sh
+mise exec -- npm run test:mutation:dry
+mise exec -- npm run test:mutation:full
+```
+
+The full run includes static/load-time code and must finish with no surviving,
+uncovered, timed-out, runtime-error, ignored, or pending mutants. Reports stay
+local under `reports/mutation/`. This is intentionally a local test-strength
+audit, not part of the ordinary CI gate: a complete run takes roughly 16 minutes
+on the reference development machine.
+
+The launcher accepts only an explicit dry/full mode plus concurrency 1 or 2; it
+does not forward arbitrary Stryker CLI options. Under the mutation lock it
+copies the exact SHA-256 input snapshot into `/.mutation-stage/`, links only
+that stage's `node_modules` to the installed dependency tree, verifies that the
+mutation candidates equal the shipped esbuild runtime graph, and runs Stryker
+with the stage as its working directory. This keeps transient edits to the
+working tree from entering Stryker's own sandbox. A full attempt invalidates the
+previous JSON/HTML report first; Stryker writes its candidates inside the stage,
+and the launcher publishes each report by atomic rename only after a successful
+run, final input checks, complete process-group exit, and stage cleanup.
+
+The success attestation records SHA-256 digests for both reports and the exact
+staged input-set digest, plus a run window used to verify both files' freshness,
+production TypeScript, every Vitest test and setup file, shared runtime test
+data (including the prefs golden JSON corpus), `.mise.toml`, the Stryker,
+Vitest, and TypeScript configs, the shared production bundle recipe, embedded
+`readout.js`, the compatibility hook, package lock, and the launcher/checker
+implementation. The proof also binds the exact Node version, OS platform, and
+CPU architecture. The launcher and checker require that Node equal the exact
+`.mise.toml` pin and satisfy `package.json`'s engine range.
+`test:mutation:check` rejects a report after any of those inputs or runtime
+properties changes, or while a stage/lock/recovery claim remains. A dry run
+uses only the text reporter, cleans its stage, and cannot replace the full-run
+proof.
+
+The process-group resource guard supports POSIX macOS with BSD `ps`/`du` and
+Linux hosts with procps/coreutils-compatible commands. It resolves both tools
+through safe absolute `PATH` entries, ignoring relative paths and repository
+descendants, then probes the required `ps -axo ...` and `du -sk` forms before
+publishing a lock. It is not a Windows or BusyBox portability layer. Disk-free,
+generated-data, and aggregate process-group RSS limits are userspace samples
+(every 15 seconds by default), not kernel quotas: usage can exceed a threshold
+between samples and while the group is terminating. Generated-data accounting
+includes the complete stage and the published-report directory, including the
+initial staged input copy. The runtime limit is a launcher timer, and RSS means
+the resident memory reported for processes still in the guarded POSIX process
+group. Use the `MUTATION_*` environment variables only to make the defaults
+stricter on a smaller machine. A persisted child PGID lets the next launcher
+verify, stop, and wait for an orphaned group before it removes the deterministic
+stage and legacy temp directory. Recovery uses an atomic fixed hard-link claim,
+so concurrent launchers cannot delete a newly published owner; an abandoned
+claim or unverifiable stale lock is retained for manual inspection. If launcher
+IPC disappears, the detached child terminates its whole process group so no
+Stryker worker can continue without the resource monitor.
+
 The Playwright e2e target is intentionally heavier: `mise` provides Go/Node, but
 `make e2e` may still need privileged OS browser dependencies via `npx playwright
 install --with-deps chromium`. On machines where that is not desirable, use the

--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,12 @@
     "useIgnoreFile": true
   },
   "files": {
-    "includes": ["internal/assets/src/js/**", "scripts/**/*.mjs", "vitest.config.ts"]
+    "includes": [
+      "internal/assets/src/js/**",
+      "scripts/**/*.mjs",
+      "vitest.config.ts",
+      "stryker.config.mjs"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/internal/assets/src/js/bulk-actions.dom.test.ts
+++ b/internal/assets/src/js/bulk-actions.dom.test.ts
@@ -52,6 +52,14 @@ beforeEach(() => {
     window.history.replaceState(null, '', '/');
 });
 
+test('declares the exact delegated-event contract', () => {
+    expect(bulkBindings.map(({ event, selector, stop }) => ({ event, selector, stop }))).toEqual([
+        { event: 'click', selector: '#ro-bulk-download', stop: true },
+        { event: 'click', selector: '#ro-bulk-copy', stop: true },
+        { event: 'click', selector: '#ro-bulk-clear', stop: true },
+    ]);
+});
+
 describe('bulk copy', () => {
     test('copies every full name and keeps feedback visible for 1100ms from the latest copy', () => {
         vi.useFakeTimers();
@@ -140,6 +148,35 @@ describe('bulk download', () => {
         );
         download.handler(new MouseEvent('click'), button);
         expect(window.location.hash).toBe('#before');
+    });
+
+    test('allows exactly the 100-name cap', () => {
+        const button = document.getElementById('ro-bulk-download') as HTMLElement;
+        setSelectedEntries(
+            Array.from({ length: 100 }, (_, index) => ({
+                key: `prod/default/item-${index}`,
+                name: `item-${index}`,
+            })),
+        );
+
+        binding('#ro-bulk-download').handler(new MouseEvent('click'), button);
+
+        expect(window.location.hash).toContain('&names=item-0%2Citem-1%2C');
+        expect(window.location.hash).toContain('item-99');
+    });
+
+    test('uses full names when an all-namespaces bar has no cluster identity', () => {
+        const bar = document.getElementById('ro-bulkbar') as HTMLElement;
+        bar.dataset.bulkAllns = 'true';
+        delete bar.dataset.bulkCluster;
+        setSelectedEntries([{ key: '/team-a/api-0', name: 'api full name' }]);
+
+        binding('#ro-bulk-download').handler(
+            new MouseEvent('click'),
+            document.getElementById('ro-bulk-download'),
+        );
+
+        expect(window.location.hash).toBe('#/bulk?format=yaml&names=api%20full%20name');
     });
 
     test('does not navigate when the server did not provide a bulk href', () => {

--- a/internal/assets/src/js/bulk-actions.ts
+++ b/internal/assets/src/js/bulk-actions.ts
@@ -55,10 +55,10 @@ function bulkDownloadYAML(bar: HTMLElement | null): void {
     if (entries.length === 0 || entries.length > BULK_NAMES_MAX) {
         return; // the button is disabled in both states; belt for direct calls
     }
-    const clusterPrefix = `${bar.dataset.bulkCluster || ''}/`;
+    const cluster = bar.dataset.bulkCluster;
     const names = entries.map((entry) => {
-        if (bar.dataset.bulkAllns === 'true' && entry.key.indexOf(clusterPrefix) === 0) {
-            return entry.key.slice(clusterPrefix.length);
+        if (bar.dataset.bulkAllns === 'true' && cluster && entry.key.startsWith(`${cluster}/`)) {
+            return entry.key.slice(cluster.length + 1);
         }
         return entry.name;
     });

--- a/internal/assets/src/js/collapse-hash.test.ts
+++ b/internal/assets/src/js/collapse-hash.test.ts
@@ -27,6 +27,13 @@ test('the leading # is optional', () => {
     expect(parseCollapsedNames('collapsed=spec,status')).toStrictEqual(['spec', 'status']);
 });
 
+test('only a leading # is structural; a # inside a name is preserved', () => {
+    expect(parseCollapsedNames('collapsed=spec#details,status')).toStrictEqual([
+        'spec#details',
+        'status',
+    ]);
+});
+
 test('collapsed is selected out of a multi-param fragment', () => {
     // The fragment is a `;`-separated list of key=value params; only the
     // `collapsed` value contributes names.

--- a/internal/assets/src/js/collapse-hash.ts
+++ b/internal/assets/src/js/collapse-hash.ts
@@ -12,14 +12,10 @@
 // Returns the names in order, empty when the fragment has no usable `collapsed`.
 // No DOM, no decode -- the names are matched verbatim against `[data-name]`.
 export function parseCollapsedNames(hash: string): string[] {
-    if (!hash) {
-        return [];
-    }
     const names: string[] = [];
-    // substring(1) drops a leading '#' the same way the monolith did; a
-    // fragment with no '#' is parsed verbatim. Each param is split on '=' and
-    // only the `collapsed` key's value (the element AT index 1, mirroring the
-    // monolith's keyVal[1]) contributes names.
+    // Drop only the fragment marker at the beginning; a '#' inside a name is
+    // data and must survive verbatim. Each param is split on '=' and only the
+    // `collapsed` key's value (the element at index 1) contributes names.
     hash.replace(/^#/, '')
         .split(';')
         .forEach((param) => {

--- a/internal/assets/src/js/columns.dom.test.ts
+++ b/internal/assets/src/js/columns.dom.test.ts
@@ -55,6 +55,21 @@ function renderPopover(): HTMLElement {
     return document.getElementById('ro-cols-pop') as HTMLElement;
 }
 
+test('starts with the popover closed', () => {
+    expect(colsPopOpen()).toBe(false);
+});
+
+test('declares the exact delegated-event contract', () => {
+    expect(columnsBindings.map(({ event, selector, stop }) => ({ event, selector, stop }))).toEqual(
+        [
+            { event: 'click', selector: '[data-ro-cols-toggle]', stop: undefined },
+            { event: 'click', selector: '[data-ro-action="toggle-column"]', stop: true },
+            { event: 'click', selector: undefined, stop: undefined },
+            { event: 'submit', selector: 'form.ro-pop-form', stop: true },
+        ],
+    );
+});
+
 describe('column popover state', () => {
     beforeEach(() => {
         renderPopover();
@@ -93,6 +108,20 @@ describe('column popover state', () => {
         expect(event.defaultPrevented).toBe(true);
         expect(colsPopOpen()).toBe(true);
         expect(document.getElementById('ro-cols-pop')).toHaveClass('is-open');
+
+        binding('[data-ro-cols-toggle]').handler(targetedEvent('click', opener), opener);
+        expect(colsPopOpen()).toBe(false);
+        expect(document.getElementById('ro-cols-pop')).not.toHaveClass('is-open');
+    });
+
+    test('opener remains closed when the server did not render a popover', () => {
+        document.getElementById('ro-cols-pop')?.remove();
+        const opener = document.getElementById('ro-cols-btn') as HTMLElement;
+
+        binding('[data-ro-cols-toggle]').handler(targetedEvent('click', opener), opener);
+
+        expect(colsPopOpen()).toBe(false);
+        expect(opener).toHaveAttribute('aria-expanded', 'false');
     });
 
     test('outside click closes while clicks inside the popover do not', () => {
@@ -105,8 +134,26 @@ describe('column popover state', () => {
         outsideBinding.handler(targetedEvent('click', pop), null);
         expect(colsPopOpen()).toBe(true);
 
+        outsideBinding.handler(
+            targetedEvent('click', document.getElementById('ro-cols-btn') as HTMLElement),
+            null,
+        );
+        expect(colsPopOpen()).toBe(true);
+
         outsideBinding.handler(targetedEvent('click', outside), null);
         expect(colsPopOpen()).toBe(false);
+    });
+
+    test('closed-state outside clicks are a no-op', () => {
+        const pop = document.getElementById('ro-cols-pop') as HTMLElement;
+        const outside = document.createElement('button');
+        document.body.appendChild(outside);
+        setColsPopOpen(false);
+        pop.classList.add('is-open');
+
+        binding(undefined).handler(targetedEvent('click', outside), null);
+
+        expect(pop).toHaveClass('is-open');
     });
 });
 
@@ -168,6 +215,8 @@ describe('column form navigation', () => {
                 <input type="hidden" name="f" value="stale-hidden-copy">
                 <input name="labelcols" value="metadata.name">
                 <input name="selector" value="">
+                <select name="ignored-select"><option value="wrong" selected>wrong</option></select>
+                <input value="ignored-without-name">
             </form>
         `;
         const form = document.querySelector('form') as HTMLFormElement;

--- a/internal/assets/src/js/context-menu.dom.test.ts
+++ b/internal/assets/src/js/context-menu.dom.test.ts
@@ -60,6 +60,17 @@ beforeEach(() => {
     Object.defineProperty(window, 'innerHeight', { configurable: true, value: 600 });
 });
 
+test('declares the exact delegated-event contract', () => {
+    expect(
+        contextMenuBindings.map(({ event, selector, stop }) => ({ event, selector, stop })),
+    ).toEqual([
+        { event: 'contextmenu', selector: undefined, stop: undefined },
+        { event: 'click', selector: '#ro-ctxmenu [data-ro-action]', stop: true },
+        { event: 'click', selector: undefined, stop: undefined },
+        { event: 'keydown', selector: undefined, stop: undefined },
+    ]);
+});
+
 describe('context menu state and row binding', () => {
     test('binds row labels and hrefs, hides unavailable actions, and clamps to the viewport', () => {
         const menu = document.getElementById('ro-ctxmenu') as HTMLElement;
@@ -80,6 +91,9 @@ describe('context menu state and row binding', () => {
             'data-href',
             '#download',
         );
+        expect(menu.querySelector('[data-ro-action="open"]')).not.toHaveAttribute('hidden');
+        expect(menu.querySelector('[data-ro-action="yaml"]')).not.toHaveAttribute('hidden');
+        expect(menu.querySelector('[data-ro-action="download"]')).not.toHaveAttribute('hidden');
         expect(menu.querySelector('[data-ro-action="logs"]')).toHaveAttribute('hidden');
         expect(menu.querySelector('[data-ro-action="logs"]')).not.toHaveAttribute('data-href');
 
@@ -95,6 +109,27 @@ describe('context menu state and row binding', () => {
 
         expect(rowSelection.lastKeySegment).toHaveBeenCalledExactlyOnceWith('prod/default/api-0');
         expect(document.getElementById('ro-ctxmenu')?.dataset.name).toBe('api-0');
+    });
+
+    test('clears every unavailable row action and stale name', () => {
+        const row = document.getElementById('row') as HTMLElement;
+        const menu = document.getElementById('ro-ctxmenu') as HTMLElement;
+        menu.dataset.name = 'stale-name';
+        delete row.dataset.href;
+        delete row.dataset.yaml;
+        delete row.dataset.download;
+        delete row.dataset.name;
+        delete row.dataset.key;
+
+        openRowMenu(row, 20, 20);
+
+        for (const action of ['open', 'yaml', 'logs', 'download']) {
+            const item = menu.querySelector(`[data-ro-action="${action}"]`);
+            expect(item).toHaveAttribute('hidden');
+            expect(item).not.toHaveAttribute('data-href');
+        }
+        expect(menu).not.toHaveAttribute('data-name');
+        expect(rowSelection.lastKeySegment).not.toHaveBeenCalled();
     });
 
     test('closeRowMenu is idempotent and synchronizes class with aria-hidden', () => {
@@ -176,6 +211,21 @@ describe('context menu actions', () => {
         expect(rowSelection.roCopyText).not.toHaveBeenCalled();
     });
 
+    test('copy without a bound name closes safely without touching the clipboard', () => {
+        const menu = document.getElementById('ro-ctxmenu') as HTMLElement;
+        delete menu.dataset.name;
+        menu.classList.add('is-open');
+        const copy = menu.querySelector('[data-ro-action="copy"]') as HTMLElement;
+
+        binding('click', '#ro-ctxmenu [data-ro-action]').handler(
+            targetedMouseEvent('click', copy),
+            copy,
+        );
+
+        expect(menu).not.toHaveClass('is-open');
+        expect(rowSelection.roCopyText).not.toHaveBeenCalled();
+    });
+
     test('the unconditional click and Escape bindings dismiss without stopping sibling work', () => {
         const menu = document.getElementById('ro-ctxmenu') as HTMLElement;
         openRowMenu(document.getElementById('row') as HTMLElement, 20, 20);
@@ -186,6 +236,9 @@ describe('context menu actions', () => {
         expect(menu).not.toHaveClass('is-open');
 
         openRowMenu(document.getElementById('row') as HTMLElement, 20, 20);
+        binding('keydown').handler(new KeyboardEvent('keydown', { key: 'Enter' }), null);
+        expect(menu).toHaveClass('is-open');
+
         binding('keydown').handler(new KeyboardEvent('keydown', { key: 'Escape' }), null);
         expect(menu).not.toHaveClass('is-open');
     });

--- a/internal/assets/src/js/context-menu.ts
+++ b/internal/assets/src/js/context-menu.ts
@@ -34,7 +34,7 @@ export function openRowMenu(tr: HTMLElement, x: number, y: number): void {
     if (!menu) {
         return;
     }
-    const bind = (action: string, href: string): void => {
+    const bind = (action: string, href?: string): void => {
         const item = menu.querySelector(`[data-ro-action="${action}"]`) as HTMLElement | null;
         if (!item) {
             return;
@@ -47,11 +47,17 @@ export function openRowMenu(tr: HTMLElement, x: number, y: number): void {
             item.hidden = true; // e.g. View logs on a non-pod row
         }
     };
-    bind('open', tr.dataset.href || '');
-    bind('yaml', tr.dataset.yaml || '');
-    bind('logs', tr.dataset.logs || '');
-    bind('download', tr.dataset.download || '');
-    (menu as HTMLElement).dataset.name = tr.dataset.name || lastKeySegment(tr.dataset.key || '');
+    bind('open', tr.dataset.href);
+    bind('yaml', tr.dataset.yaml);
+    bind('logs', tr.dataset.logs);
+    bind('download', tr.dataset.download);
+    const key = tr.dataset.key;
+    const name = tr.dataset.name || (key ? lastKeySegment(key) : undefined);
+    if (name) {
+        (menu as HTMLElement).dataset.name = name;
+    } else {
+        delete (menu as HTMLElement).dataset.name;
+    }
     (menu as HTMLElement).style.left =
         `${Math.max(8, Math.min(x, window.innerWidth - CTX_CLAMP_W))}px`;
     (menu as HTMLElement).style.top =
@@ -90,13 +96,17 @@ export const contextMenuBindings: Binding[] = [
             event.preventDefault();
             const item = matched as HTMLElement;
             const menu = item.closest('#ro-ctxmenu') as HTMLElement | null;
-            const name = menu?.dataset.name || '';
-            const href = item.dataset.href || '';
             closeRowMenu();
             if (item.dataset.roAction === 'copy') {
-                roCopyText(name, () => {});
-            } else if (href) {
-                window.location.assign(href);
+                const name = menu?.dataset.name;
+                if (name !== undefined) {
+                    roCopyText(name, () => {});
+                }
+            } else {
+                const href = item.dataset.href;
+                if (href) {
+                    window.location.assign(href);
+                }
             }
             return true;
         },

--- a/internal/assets/src/js/events.ts
+++ b/internal/assets/src/js/events.ts
@@ -63,18 +63,15 @@ export interface Binding {
 // Element node (a text node from a click on a text run); we walk to the nearest
 // Element first so closest() is always defined.
 function closestElement(event: Event, selector: string): Element | null {
-    let node: Node | null = event.target as Node | null;
-    while (node && node.nodeType !== 1) {
-        node = node.parentNode;
-    }
-    return node ? (node as Element).closest(selector) : null;
+    const target = event.target;
+    const element = target instanceof Element ? target : (target as Node | null)?.parentElement;
+    return element?.closest(selector) ?? null;
 }
 
 // dispatch runs the bindings for ONE event type against ONE event instance, in
 // order, honouring per-binding match/stop/isolation per the contract above.
 function dispatch(bindings: Binding[], event: Event): void {
-    for (let i = 0; i < bindings.length; i++) {
-        const binding = bindings[i];
+    for (const binding of bindings) {
         let matched: Element | null = null;
         if (binding.selector !== undefined) {
             matched = closestElement(event, binding.selector);

--- a/internal/assets/src/js/filters-parse.test.ts
+++ b/internal/assets/src/js/filters-parse.test.ts
@@ -19,9 +19,11 @@ import {
     type ModelRow,
     mergeColParams,
     normalizeFieldName,
+    normalizeFieldWhitespace,
     rankFieldSuggestions,
     rankValueSuggestions,
     splitFilterDraft,
+    trimFilterWhitespace,
 } from './filters-parse.js';
 
 // A pod-like model: Name + the data-hint Status/Node columns, plus a synthetic
@@ -43,15 +45,34 @@ const PODS_ROWS: ModelRow[] = [
 
 // --- normalizeFieldName / fieldSuggestionText -------------------------------
 
-test('normalizeFieldName lowercases, dashes->spaces, trims', () => {
+test('normalizeFieldName lowercases, dashes->spaces, and collapses whitespace', () => {
     expect(normalizeFieldName('Nominated-Node')).toBe('nominated node');
     expect(normalizeFieldName('  NOMINATED NODE  ')).toBe('nominated node');
+    expect(normalizeFieldName('\tWorkload   \n Status\u00a0')).toBe('workload status');
+    expect(normalizeFieldName('\u0085Workload\u0085Status\u0085')).toBe('workload status');
+    expect(normalizeFieldName('\uFEFFWorkload\uFEFFStatus\uFEFF')).toBe(
+        '\uFEFFworkload\uFEFFstatus\uFEFF',
+    );
     expect(normalizeFieldName('')).toBe('');
 });
 
-test('fieldSuggestionText dashes the lowercase label', () => {
+test('header whitespace normalization uses Go unicode.IsSpace rather than JavaScript trim', () => {
+    expect(normalizeFieldWhitespace('\u0085 Workload\u00a0 Status \u0085')).toBe('Workload Status');
+    expect(normalizeFieldWhitespace('\uFEFFStatus\uFEFF')).toBe('\uFEFFStatus\uFEFF');
+    expect(trimFilterWhitespace('\u0085 status \u0085')).toBe('status');
+    expect(trimFilterWhitespace('\uFEFFstatus\uFEFF')).toBe('\uFEFFstatus\uFEFF');
+});
+
+test('fieldSuggestionText emits the dashed form of the shared field normalization', () => {
     expect(fieldSuggestionText('Nominated Node')).toBe('nominated-node');
     expect(fieldSuggestionText('Status')).toBe('status');
+    const oddWhitespaceLabel = ' \tWorkload   \n Status\u00a0 ';
+    const suggestion = fieldSuggestionText(oddWhitespaceLabel);
+    expect(suggestion).toBe('workload-status');
+    expect(normalizeFieldName(suggestion)).toBe(normalizeFieldName(oddWhitespaceLabel));
+    expect(fieldSuggestionText('Workload\u0085Status')).toBe('workload-status');
+    expect(fieldSuggestionText('Workload\uFEFFStatus')).toBe('workload\uFEFFstatus');
+    expect(fieldSuggestionText('')).toBe('');
 });
 
 // --- splitFilterDraft -------------------------------------------------------
@@ -81,16 +102,58 @@ test('!= is recognized as a two-char operator before a later single-char op', ()
     expect(splitFilterDraft('a!=b<c')).toStrictEqual({ field: 'a', op: '!=', value: 'b<c' });
 });
 
+test('field whitespace is trimmed while value whitespace is preserved', () => {
+    expect(splitFilterDraft('  status : Running ')).toStrictEqual({
+        field: 'status',
+        op: ':',
+        value: ' Running ',
+    });
+    expect(splitFilterDraft('  status != Pending')).toStrictEqual({
+        field: 'status',
+        op: '!=',
+        value: ' Pending',
+    });
+    expect(splitFilterDraft('\u0085status\u0085:Running')).toStrictEqual({
+        field: 'status',
+        op: ':',
+        value: 'Running',
+    });
+    expect(splitFilterDraft('\uFEFFstatus\uFEFF:Running')).toStrictEqual({
+        field: '\uFEFFstatus\uFEFF',
+        op: ':',
+        value: 'Running',
+    });
+});
+
+test('a lone bang or equals is data, not an operator', () => {
+    expect(splitFilterDraft('note!draft')).toBe(null);
+    expect(splitFilterDraft('note=value')).toBe(null);
+    expect(splitFilterDraft('note!:ready')).toStrictEqual({
+        field: 'note!',
+        op: ':',
+        value: 'ready',
+    });
+    expect(splitFilterDraft('note=:ready')).toStrictEqual({
+        field: 'note=',
+        op: ':',
+        value: 'ready',
+    });
+});
+
 // --- filterSuggestionFields -------------------------------------------------
 
 test('suggestion fields exclude synthetic columns and add the virtual label/cpu/memory', () => {
-    const texts = filterSuggestionFields(PODS_FIELDS).map((f) => f.text);
+    const suggestions = filterSuggestionFields(PODS_FIELDS);
+    const texts = suggestions.map((f) => f.text);
     expect(texts).toContain('status');
     expect(texts).toContain('nominated-node');
     expect(texts, 'hintless Created column is not suggested').not.toContain('created');
     expect(texts, 'label is always offered').toContain('label');
     expect(texts, 'cpu alias offered when CPU Usage exists').toContain('cpu');
     expect(texts, 'memory alias offered when Memory Usage exists').toContain('memory');
+    expect(suggestions).toContainEqual({ text: 'label', hint: 'key=value' });
+    expect(suggestions).toContainEqual({ text: 'cpu', hint: 'quantity' });
+    expect(suggestions).toContainEqual({ text: 'memory', hint: 'quantity' });
 });
 
 test('bare cpu/memory CAPACITY columns are not suggested under those names', () => {
@@ -114,12 +177,33 @@ test('label always resolves; typed columns resolve normalized; unknowns do not',
     expect(filterFieldKnown(PODS_FIELDS, 'nominated node')).toBe(true);
     expect(filterFieldKnown(PODS_FIELDS, 'bogus')).toBe(false);
     expect(filterFieldKnown(PODS_FIELDS, '')).toBe(false);
+    expect(filterFieldKnown([{ label: '', name: '', hint: 'string' }], '')).toBe(false);
+});
+
+test('a suggestion generated from an odd-whitespace header resolves back to that column', () => {
+    const fields: ModelField[] = [
+        {
+            label: ' Workload\t  Status ',
+            name: fieldSuggestionText(' Workload\t  Status '),
+            hint: 'enum',
+        },
+    ];
+    const suggestedField = filterSuggestionFields(fields)[0].text;
+
+    expect(suggestedField).toBe('workload-status');
+    expect(filterFieldKnown(fields, suggestedField)).toBe(true);
+    expect(fieldColumnIndex(fields, suggestedField)).toBe(0);
 });
 
 test('cpu/memory resolve via the joined usage columns, never the capacity columns', () => {
     expect(filterFieldKnown(PODS_FIELDS, 'cpu')).toBe(true); // CPU Usage present
-    const capacity: ModelField[] = [{ label: 'CPU', name: 'cpu', hint: 'quantity' }];
+    expect(filterFieldKnown(PODS_FIELDS, 'memory')).toBe(true); // Memory Usage present
+    const capacity: ModelField[] = [
+        { label: 'CPU', name: 'cpu', hint: 'quantity' },
+        { label: 'Memory', name: 'memory', hint: 'quantity' },
+    ];
     expect(filterFieldKnown(capacity, 'cpu')).toBe(false); // capacity-only -> unknown
+    expect(filterFieldKnown(capacity, 'memory')).toBe(false);
 });
 
 // --- fieldColumnIndex -------------------------------------------------------
@@ -149,6 +233,29 @@ test('a substring match that is not a prefix ranks after a prefix match', () => 
     expect(items.map((item) => item.label)).toContain('status');
 });
 
+test('field ranking excludes non-matches and moves prefixes ahead of earlier substrings', () => {
+    const fields: ModelField[] = [
+        { label: 'Restart Count', name: 'restart-count', hint: 'number' },
+        { label: 'Status', name: 'status', hint: 'enum' },
+        { label: 'Namespace', name: 'namespace', hint: 'string' },
+    ];
+
+    expect(rankFieldSuggestions(fields, 'sta')).toStrictEqual([
+        {
+            label: 'status',
+            hint: 'enum',
+            insert: 'status:',
+            kind: 'field',
+        },
+        {
+            label: 'restart-count',
+            hint: 'number',
+            insert: 'restart-count:',
+            kind: 'field',
+        },
+    ]);
+});
+
 // --- rankValueSuggestions ---------------------------------------------------
 
 test('value suggestions are top-N distinct by frequency descending', () => {
@@ -169,9 +276,62 @@ test('value suggestions substring-filter by the typed value', () => {
     expect(items[0].label).toBe('Pending');
 });
 
-test('value suggestions are empty for an unresolved column', () => {
-    const split = { field: 'bogus', op: ':', value: '' };
-    expect(rankValueSuggestions(PODS_FIELDS, PODS_ROWS, split)).toStrictEqual([]);
+test('value matching trims the draft and emits a canonical trimmed field', () => {
+    const split = { field: ' status ', op: ':', value: ' PEND ' };
+    expect(rankValueSuggestions(PODS_FIELDS, PODS_ROWS, split)).toStrictEqual([
+        {
+            label: 'Pending',
+            hint: '×1',
+            insert: 'status:Pending',
+            kind: 'value',
+        },
+    ]);
+});
+
+test('value suggestions rank a later frequent value first and cap distinct results at eight', () => {
+    const fields: ModelField[] = [{ label: 'Name', name: 'name', hint: 'string' }];
+    const values = ['rare', 'common', 'common', 'v1', 'v2', 'v3', 'v4', 'v5', 'v6', 'v7', 'v8'];
+    const rows = values.map((value, index) => ({
+        key: `row-${index}`,
+        name: value,
+        cells: [value],
+    }));
+
+    const items = rankValueSuggestions(fields, rows, { field: 'name', op: ':', value: '' });
+    expect(items).toHaveLength(8);
+    expect(items[0]).toMatchObject({ label: 'common', hint: '×2' });
+    expect(items.map((item) => item.label)).not.toContain('v8');
+});
+
+test('value suggestions work for a real column at index zero', () => {
+    const items = rankValueSuggestions(PODS_FIELDS, PODS_ROWS, {
+        field: 'name',
+        op: ':',
+        value: 'web-2',
+    });
+    expect(items.map((item) => item.label)).toStrictEqual(['web-2']);
+});
+
+test('fields without a model column return before reading the full row set', () => {
+    let cellReads = 0;
+    const rows: ModelRow[] = [
+        {
+            key: 'prod/default/api-0',
+            name: 'api-0',
+            get cells() {
+                cellReads++;
+                return ['api-0'];
+            },
+        },
+    ];
+
+    expect(
+        rankValueSuggestions(PODS_FIELDS, rows, { field: 'bogus', op: ':', value: '' }),
+    ).toStrictEqual([]);
+    expect(
+        rankValueSuggestions(PODS_FIELDS, rows, { field: 'label', op: ':', value: 'app=web' }),
+    ).toStrictEqual([]);
+    expect(cellReads).toBe(0);
 });
 
 // --- liveNameMatchKeys ------------------------------------------------------
@@ -180,11 +340,26 @@ test('a free-text draft narrows to the matching row keys', () => {
     const keys = liveNameMatchKeys(PODS_ROWS, 'web');
     expect(keys).not.toBeNull();
     expect([...(keys as Set<string>)].sort()).toStrictEqual(['c/ns/web-1', 'c/ns/web-2']);
+    expect([...(liveNameMatchKeys(PODS_ROWS, ' WEB ') as Set<string>)].sort()).toStrictEqual([
+        'c/ns/web-1',
+        'c/ns/web-2',
+    ]);
 });
 
 test('an empty draft or a chip-in-progress is no live filter (null)', () => {
     expect(liveNameMatchKeys(PODS_ROWS, '')).toBe(null);
     expect(liveNameMatchKeys(PODS_ROWS, 'status:Running')).toBe(null);
+});
+
+test('free-text matching trims Go whitespace without erasing U+FEFF data', () => {
+    const rows: ModelRow[] = [
+        { key: 'plain', name: 'api', cells: [] },
+        { key: 'bom', name: '\uFEFFapi', cells: [] },
+    ];
+
+    expect([...(liveNameMatchKeys(rows, '\u0085\uFEFF\u0085') as Set<string>)]).toStrictEqual([
+        'bom',
+    ]);
 });
 
 // --- mergeColParams ---------------------------------------------------------
@@ -221,4 +396,8 @@ test('an empty result query yields a bare pathname (no trailing ?)', () => {
     const owned = new Set(['labelcols', 'selector']);
     expect(mergeColParams('/p', '?selector=x', owned, [])).toBe('/p');
     expect(mergeColParams('/p', '', owned, [])).toBe('/p');
+});
+
+test('a question mark inside a raw value survives when search has no leading marker', () => {
+    expect(mergeColParams('/p', 'f=note:?ready', new Set(), [])).toBe('/p?f=note:?ready');
 });

--- a/internal/assets/src/js/filters-parse.ts
+++ b/internal/assets/src/js/filters-parse.ts
@@ -46,17 +46,38 @@ export interface ACItem {
     kind: 'field' | 'value';
 }
 
+// Go strings.Fields splits on unicode.IsSpace, whose stable White_Space set is
+// NOT JavaScript's `\s`/trim set: Go includes U+0085 (NEXT LINE) and excludes
+// U+FEFF (BOM). Keep the exact run here so client suggestions and server field
+// resolution cannot disagree at that language boundary.
+const goFieldWhitespaceRun = /\p{White_Space}+/gu;
+const goFieldWhitespaceEdges = /^\p{White_Space}+|\p{White_Space}+$/gu;
+
+// trimFilterWhitespace mirrors strings.TrimSpace for fields and values parsed
+// from a draft. In particular, it trims U+0085 and preserves U+FEFF.
+export function trimFilterWhitespace(s: string): string {
+    return (s || '').replace(goFieldWhitespaceEdges, '');
+}
+
+// normalizeFieldWhitespace collapses the same whitespace runs as
+// strings.Join(strings.Fields(s), " ") while preserving case and punctuation.
+// Header capture uses it instead of String.trim(), which would wrongly discard
+// a leading/trailing U+FEFF that the Go resolver treats as field-name data.
+export function normalizeFieldWhitespace(s: string): string {
+    return trimFilterWhitespace((s || '').replace(goFieldWhitespaceRun, ' '));
+}
+
 // normalizeFieldName mirrors the server's resolveFilterColumn: lowercase, dashes
-// to spaces, trimmed -- so "Nominated-Node" / "nominated node" / "NOMINATED NODE"
-// all resolve to the one canonical key.
+// to spaces, and Go-whitespace runs collapsed -- so "Nominated-Node" /
+// " nominated\t node " / "NOMINATED NODE" all resolve to one canonical key.
 export function normalizeFieldName(s: string): string {
-    return (s || '').toLowerCase().replace(/-/g, ' ').trim();
+    return normalizeFieldWhitespace((s || '').toLowerCase().replace(/-/g, ' '));
 }
 
 // fieldSuggestionText turns a column label into the dashed lowercase form the
 // server resolves ("Nominated Node" -> "nominated-node").
 export function fieldSuggestionText(label: string): string {
-    return (label || '').toLowerCase().trim().replace(/\s+/g, '-');
+    return normalizeFieldName(label).replace(/ /g, '-');
 }
 
 // splitFilterDraft mirrors splitFilterOperator: the FIRST operator occurrence
@@ -64,16 +85,16 @@ export function fieldSuggestionText(label: string): string {
 // checked before the single-char operators so "a!=b" splits on `!=`, not a
 // stray `<`/`>`/`:` later in the value.
 export function splitFilterDraft(s: string): DraftSplit | null {
-    for (let i = 0; i < s.length; i++) {
-        const c = s[i];
-        if (c === '!' && s[i + 1] === '=') {
-            return { field: s.slice(0, i).trim(), op: '!=', value: s.slice(i + 2) };
-        }
-        if (c === ':' || c === '>' || c === '<') {
-            return { field: s.slice(0, i).trim(), op: c, value: s.slice(i + 1) };
-        }
+    const operator = /!=|[:<>]/.exec(s);
+    if (!operator) {
+        return null;
     }
-    return null;
+    const op = operator[0];
+    return {
+        field: trimFilterWhitespace(s.slice(0, operator.index)),
+        op,
+        value: s.slice(operator.index + op.length),
+    };
 }
 
 // hasModelColumn: a filterable (hinted) column whose normalized label matches.
@@ -147,15 +168,14 @@ export function fieldColumnIndex(fields: ModelField[], field: string): number {
 // sort keeps the schema order within each tier).
 export function rankFieldSuggestions(fields: ModelField[], draft: string): ACItem[] {
     const q = normalizeFieldName(draft);
-    const matched = filterSuggestionFields(fields).filter(
-        (f) => normalizeFieldName(f.text).indexOf(q) !== -1,
-    );
-    matched.sort((a, b) => {
-        const ap = normalizeFieldName(a.text).indexOf(q) === 0 ? 0 : 1;
-        const bp = normalizeFieldName(b.text).indexOf(q) === 0 ? 0 : 1;
-        return ap - bp;
+    const ranked: { text: string; hint: string }[][] = [[], []];
+    filterSuggestionFields(fields).forEach((field) => {
+        const matchAt = normalizeFieldName(field.text).indexOf(q);
+        if (matchAt >= 0) {
+            ranked[matchAt === 0 ? 0 : 1].push(field);
+        }
     });
-    return matched.map((f) => ({
+    return [...ranked[0], ...ranked[1]].map((f) => ({
         label: f.text,
         hint: f.hint,
         insert: `${f.text}:`,
@@ -174,6 +194,9 @@ export function rankValueSuggestions(
 ): ACItem[] {
     const idx = fieldColumnIndex(fields, split.field);
     if (idx < 0) {
+        // Virtual/unknown fields have no row-model column. Besides returning no
+        // suggestions, stop before touching the complete (possibly windowed)
+        // row set: `label:` must stay O(fields), not O(all server rows).
         return [];
     }
     const freq = new Map<string, number>();
@@ -183,16 +206,15 @@ export function rankValueSuggestions(
             freq.set(v, (freq.get(v) || 0) + 1);
         }
     });
-    const typed = split.value.trim().toLowerCase();
-    let entries = Array.from(freq.entries());
-    if (typed) {
-        entries = entries.filter(([v]) => v.toLowerCase().indexOf(typed) !== -1);
-    }
+    const typed = trimFilterWhitespace(split.value).toLowerCase();
+    const entries = Array.from(freq.entries()).filter(
+        ([v]) => v.toLowerCase().indexOf(typed) !== -1,
+    );
     entries.sort((a, b) => b[1] - a[1]);
     return entries.slice(0, 8).map(([v, n]) => ({
         label: v,
         hint: `×${n}`,
-        insert: `${split.field.trim()}:${v}`,
+        insert: `${trimFilterWhitespace(split.field)}:${v}`,
         kind: 'value' as const,
     }));
 }
@@ -203,7 +225,7 @@ export function rankValueSuggestions(
 // nothing). The MATCH runs on the full row model; the DOM application is the
 // caller's job.
 export function liveNameMatchKeys(rows: ModelRow[], draft: string): Set<string> | null {
-    const text = !draft || splitFilterDraft(draft) ? '' : draft.trim().toLowerCase();
+    const text = !draft || splitFilterDraft(draft) ? '' : trimFilterWhitespace(draft).toLowerCase();
     if (!text) {
         return null;
     }

--- a/internal/assets/src/js/filters.dom.test.ts
+++ b/internal/assets/src/js/filters.dom.test.ts
@@ -158,6 +158,59 @@ describe('complete row-model capture', () => {
         expect(window.roRowModel.rows).toStrictEqual([]);
     });
 
+    test('normalizes empty header and row text without inventing model values', () => {
+        const template = document.createElement('template');
+        template.innerHTML = `
+            <table class="ro-table">
+                <thead><tr><th data-hint="string"></th></tr></thead>
+                <tbody><tr data-key="dev/pods/empty"><td class="cell-name"><a></a></td></tr></tbody>
+            </table>
+        `;
+
+        filters.captureRowModel(template.content);
+
+        expect(window.roRowModel.fields).toStrictEqual([{ label: '', name: '', hint: 'string' }]);
+        expect(window.roRowModel.rows).toStrictEqual([
+            { key: 'dev/pods/empty', name: '', cells: [''] },
+        ]);
+    });
+
+    test('header capture trims only Go unicode.IsSpace and preserves U+FEFF data', () => {
+        const template = document.createElement('template');
+        template.innerHTML = `
+            <table class="ro-table">
+                <thead><tr>
+                    <th data-hint="enum">\u0085 Workload\u0085 Status \u0085</th>
+                    <th data-hint="enum">\uFEFFBuild\uFEFFState\uFEFF</th>
+                </tr></thead>
+                <tbody>
+                    <tr data-key="dev/pods/odd">
+                        <td class="cell-name"><a>﻿api﻿</a></td>
+                        <td>﻿Ready﻿</td>
+                    </tr>
+                </tbody>
+            </table>
+        `;
+
+        filters.captureRowModel(template.content);
+
+        expect(window.roRowModel.fields).toStrictEqual([
+            { label: 'Workload Status', name: 'workload-status', hint: 'enum' },
+            {
+                label: '\uFEFFBuild\uFEFFState\uFEFF',
+                name: '\uFEFFbuild\uFEFFstate\uFEFF',
+                hint: 'enum',
+            },
+        ]);
+        expect(window.roRowModel.rows).toStrictEqual([
+            {
+                key: 'dev/pods/odd',
+                name: '\uFEFFapi\uFEFF',
+                cells: ['\uFEFFapi\uFEFF', '\uFEFFReady\uFEFF'],
+            },
+        ]);
+    });
+
     test('does not replace the complete model with a virtualized DOM window', () => {
         const { content } = renderEditor();
         filters.captureRowModelFromDocument();
@@ -225,6 +278,7 @@ describe('live filtering and autocomplete', () => {
 
     test('renders hostile cell values as text in an accessible autocomplete', () => {
         const { autocomplete, content, input } = renderEditor();
+        autocomplete.textContent = 'stale suggestion';
         const hostile = '<img src=x onerror="window.__filterAutocompleteXss = true">';
         content.querySelectorAll<HTMLElement>('[data-col="status"]').forEach((cell) => {
             cell.textContent = hostile;
@@ -237,6 +291,8 @@ describe('live filtering and autocomplete', () => {
         const option = autocomplete.querySelector('[role="option"]') as HTMLElement;
         expect(autocomplete.hidden).toBe(false);
         expect(autocomplete).toHaveAttribute('role', 'listbox');
+        expect(autocomplete.childNodes).toHaveLength(1);
+        expect(option).toHaveClass('ro-ac-item', 'active');
         expect(option).toHaveAttribute('aria-selected', 'true');
         expect(option.querySelector('.ac-name')?.textContent).toBe(hostile);
         expect(option.querySelector('.ac-hint')?.textContent).toBe('×2');
@@ -266,6 +322,12 @@ describe('live filtering and autocomplete', () => {
         const arrowUp = targetedKey(input, 'ArrowUp');
         binding('keydown').handler(arrowUp, null);
         expect(arrowUp.defaultPrevented).toBe(true);
+        expect(autocomplete.querySelectorAll('[role="option"]')[0]).not.toHaveClass('active');
+        expect(autocomplete.querySelectorAll('[role="option"]')[0]).toHaveAttribute(
+            'aria-selected',
+            'false',
+        );
+        expect(autocomplete.querySelectorAll('[role="option"]')[1]).toHaveClass('active');
         expect(autocomplete.querySelectorAll('[role="option"]')[1]).toHaveAttribute(
             'aria-selected',
             'true',
@@ -274,9 +336,19 @@ describe('live filtering and autocomplete', () => {
         const arrowDown = targetedKey(input, 'ArrowDown');
         binding('keydown').handler(arrowDown, null);
         expect(arrowDown.defaultPrevented).toBe(true);
+        expect(autocomplete.querySelectorAll('[role="option"]')[0]).toHaveClass('active');
         expect(autocomplete.querySelectorAll('[role="option"]')[0]).toHaveAttribute(
             'aria-selected',
             'true',
+        );
+        expect(autocomplete.querySelectorAll('[role="option"]')[1]).not.toHaveClass('active');
+        expect(autocomplete.querySelectorAll('[role="option"]')[1]).toHaveAttribute(
+            'class',
+            'ro-ac-item',
+        );
+        expect(autocomplete.querySelectorAll('[role="option"]')[1]).toHaveAttribute(
+            'aria-selected',
+            'false',
         );
 
         const enter = targetedKey(input, 'Enter');
@@ -324,6 +396,110 @@ describe('live filtering and autocomplete', () => {
         });
     });
 
+    test('a clicked suggestion uses and clamps its declared index without a prior hover', () => {
+        const { autocomplete, content, input } = renderEditor();
+        filters.captureRowModel(content);
+        const ajax = installHtmx();
+        window.history.replaceState(null, '', '/pods');
+        input.value = 'status:';
+        filters.updateFilterAC();
+        const second = autocomplete.querySelectorAll<HTMLElement>('[role="option"]')[1];
+        second.dataset.acIndex = '99';
+
+        const click = targetedClick(second);
+        binding('click', '#ro-filter-ac [data-ro-action="pick-suggestion"]').handler(click, second);
+
+        expect(ajax).toHaveBeenCalledExactlyOnceWith('GET', '/pods/_table?f=status%3APending', {
+            source: input,
+            target: '#resource-list-content',
+            swap: 'morph',
+        });
+    });
+
+    test('field click and value Tab acceptance fill without committing and clear live filtering', () => {
+        const { autocomplete, content, input } = renderEditor();
+        filters.captureRowModel(content);
+        const ajax = installHtmx();
+        const inputBinding = binding('input', '#ro-filter-input');
+        input.value = 'sta';
+        inputBinding.handler(new Event('input'), input);
+        expect(window.roRowModel.visibleKeys).toStrictEqual(new Set());
+        expect(content.querySelectorAll('.ro-row-filtered')).toHaveLength(2);
+
+        const fieldOption = autocomplete.querySelector<HTMLElement>(
+            '[role="option"]',
+        ) as HTMLElement;
+        binding('click', '#ro-filter-ac [data-ro-action="pick-suggestion"]').handler(
+            targetedClick(fieldOption),
+            fieldOption,
+        );
+
+        expect(input.value).toBe('status:');
+        expect(ajax).not.toHaveBeenCalled();
+        expect(window.roRowModel.visibleKeys).toBe(null);
+        expect(content.querySelectorAll('.ro-row-filtered')).toHaveLength(0);
+        expect(autocomplete.querySelectorAll('[role="option"]')).toHaveLength(2);
+
+        const tab = targetedKey(input, 'Tab');
+        binding('keydown').handler(tab, null);
+
+        expect(tab.defaultPrevented).toBe(true);
+        expect(input.value).toBe('status:Running');
+        expect(ajax).not.toHaveBeenCalled();
+    });
+
+    test('three-item keyboard navigation has directional movement and ignores unrelated keys', () => {
+        const { autocomplete, content, input } = renderEditor();
+        const tbody = content.querySelector('tbody') as HTMLTableSectionElement;
+        tbody.insertAdjacentHTML(
+            'beforeend',
+            `<tr data-key="dev/pods/done-gamma">
+                <td class="cell-name"><a>Done Gamma</a></td>
+                <td data-col="status">Succeeded</td>
+                <td>3m</td>
+            </tr>`,
+        );
+        filters.captureRowModel(content);
+        input.value = 'status:';
+        filters.updateFilterAC();
+        const options = autocomplete.querySelectorAll<HTMLElement>('[role="option"]');
+        expect(options).toHaveLength(3);
+        expect(Array.from(options, (option) => option.className)).toStrictEqual([
+            'ro-ac-item active',
+            'ro-ac-item',
+            'ro-ac-item',
+        ]);
+        expect(Array.from(options, (option) => option.getAttribute('aria-selected'))).toStrictEqual(
+            ['true', 'false', 'false'],
+        );
+
+        const unrelated = targetedKey(input, 'x');
+        binding('keydown').handler(unrelated, null);
+        expect(unrelated.defaultPrevented).toBe(false);
+        expect(options[0]).toHaveAttribute('aria-selected', 'true');
+
+        const down = targetedKey(input, 'ArrowDown');
+        binding('keydown').handler(down, null);
+        expect(options[1]).toHaveAttribute('aria-selected', 'true');
+
+        filters.updateFilterAC();
+        const up = targetedKey(input, 'ArrowUp');
+        binding('keydown').handler(up, null);
+        expect(autocomplete.querySelectorAll('[role="option"]')[2]).toHaveAttribute(
+            'aria-selected',
+            'true',
+        );
+    });
+
+    test('closed autocomplete does not hijack arrows, Tab, or Escape', () => {
+        const { input } = renderEditor();
+        for (const key of ['ArrowDown', 'ArrowUp', 'Tab', 'Escape']) {
+            const event = targetedKey(input, key);
+            binding('keydown').handler(event, null);
+            expect(event.defaultPrevented, key).toBe(false);
+        }
+    });
+
     test('closes misleading or empty autocomplete states instead of offering values', () => {
         const { autocomplete, content, input } = renderEditor();
         filters.captureRowModel(content);
@@ -339,6 +515,9 @@ describe('live filtering and autocomplete', () => {
             expect(autocomplete).toBeEmptyDOMElement();
         }
 
+        input.value = 'sta';
+        filters.updateFilterAC();
+        expect(autocomplete.hidden).toBe(false);
         content.querySelectorAll<HTMLElement>('[data-col="status"]').forEach((cell) => {
             cell.textContent = '';
         });
@@ -346,6 +525,15 @@ describe('live filtering and autocomplete', () => {
         input.value = 'status:';
         filters.updateFilterAC();
         expect(autocomplete.hidden).toBe(true);
+        expect(autocomplete).toBeEmptyDOMElement();
+
+        input.value = 'sta';
+        filters.updateFilterAC();
+        expect(autocomplete.hidden).toBe(false);
+        input.value = '   ';
+        filters.updateFilterAC();
+        expect(autocomplete.hidden).toBe(true);
+        expect(autocomplete).toBeEmptyDOMElement();
 
         input.value = 'sta';
         autocomplete.remove();
@@ -411,6 +599,32 @@ describe('live filtering and autocomplete', () => {
         ).not.toThrow();
         expect(document.activeElement).toBe(input);
     });
+
+    test('a detached stale option cannot reactivate an emptied autocomplete', () => {
+        const { autocomplete, content, input } = renderEditor();
+        filters.captureRowModel(content);
+        const ajax = installHtmx();
+        window.history.replaceState(null, '', '/pods');
+        input.value = 'sta';
+        filters.updateFilterAC();
+        const detachedOption = autocomplete.querySelector('[role="option"]') as HTMLElement;
+
+        const escapeKey = targetedKey(input, 'Escape');
+        binding('keydown').handler(escapeKey, null);
+        detachedOption.dispatchEvent(new MouseEvent('mousemove'));
+        autocomplete.hidden = false; // stale mount exposed by an interrupted morph
+        input.value = 'status:Running';
+        const enter = targetedKey(input, 'Enter');
+        binding('keydown').handler(enter, null);
+
+        expect(ajax).toHaveBeenCalledExactlyOnceWith('GET', '/pods/_table?f=status%3ARunning', {
+            source: input,
+            target: '#resource-list-content',
+            swap: 'morph',
+        });
+        expect(autocomplete.hidden).toBe(true);
+        expect(autocomplete).toBeEmptyDOMElement();
+    });
 });
 
 describe('navigation and binding contracts', () => {
@@ -424,13 +638,33 @@ describe('navigation and binding contracts', () => {
         expect(window.location.hash).toBe('#filter-help');
     });
 
+    test('falls back when either partial-loop mount is missing', () => {
+        const first = renderEditor();
+        const ajax = installHtmx();
+        window.history.replaceState(null, '', '/pods');
+        first.input.remove();
+
+        filters.issueFilterNavigation('#missing-input');
+        expect(window.location.hash).toBe('#missing-input');
+        expect(ajax).not.toHaveBeenCalled();
+
+        const second = renderEditor();
+        document.body.appendChild(second.input);
+        second.content.remove();
+        window.history.replaceState(null, '', '/pods');
+
+        filters.issueFilterNavigation('#missing-content');
+        expect(window.location.hash).toBe('#missing-content');
+        expect(ajax).not.toHaveBeenCalled();
+    });
+
     test('routes canonical list URLs through the exact htmx partial contract', () => {
         const { input } = renderEditor();
         const ajax = installHtmx();
         window.history.replaceState(null, '', '/current');
 
         filters.issueFilterNavigation(
-            '/clusters/dev/namespaces/default/pods/?sort=Name&f=status%3ARunning',
+            '/clusters/dev/namespaces/default/pods///?sort=Name&f=status%3ARunning',
         );
 
         expect(ajax).toHaveBeenCalledExactlyOnceWith(
@@ -442,6 +676,21 @@ describe('navigation and binding contracts', () => {
                 swap: 'morph',
             },
         );
+    });
+
+    test('observes the optional htmx request promise without requiring one', () => {
+        renderEditor();
+        const catchHandler = vi.fn();
+        const ajax = vi.fn(() => ({ catch: catchHandler }));
+        vi.stubGlobal('htmx', { ajax });
+
+        filters.issueFilterNavigation('/pods');
+
+        expect(catchHandler).toHaveBeenCalledOnce();
+        expect(catchHandler.mock.calls[0][0]).toBeTypeOf('function');
+
+        ajax.mockReturnValue(undefined as never);
+        expect(() => filters.issueFilterNavigation('/pods')).not.toThrow();
     });
 
     test('Enter commits a known chip while preserving sibling raw query bytes and OR commas', () => {
@@ -469,6 +718,28 @@ describe('navigation and binding contracts', () => {
         );
     });
 
+    test('Enter trims Go whitespace but preserves U+FEFF field and value data', () => {
+        const { content, input } = renderEditor();
+        const status = content.querySelectorAll('thead th')[1];
+        status.textContent = '\uFEFFStatus\uFEFF';
+        filters.captureRowModel(content);
+        const ajax = installHtmx();
+        window.history.replaceState(null, '', '/pods');
+        input.value = '\u0085\uFEFFstatus\uFEFF:\uFEFFRunning\uFEFF\u0085';
+
+        binding('keydown').handler(targetedKey(input, 'Enter'), null);
+
+        expect(ajax).toHaveBeenCalledExactlyOnceWith(
+            'GET',
+            '/pods/_table?f=%EF%BB%BFstatus%EF%BB%BF%3A%EF%BB%BFRunning%EF%BB%BF',
+            {
+                source: input,
+                target: '#resource-list-content',
+                swap: 'morph',
+            },
+        );
+    });
+
     test('Enter rejects an unknown field with schema-derived guidance', () => {
         const { content, error, input } = renderEditor();
         filters.captureRowModel(content);
@@ -483,6 +754,26 @@ describe('navigation and binding contracts', () => {
         expect(error.hidden).toBe(false);
         expect(error).toHaveTextContent('no such field — try name, status, label…');
         expect(ajax).not.toHaveBeenCalled();
+    });
+
+    test('unknown-field guidance is capped to the first three schema suggestions', () => {
+        const { content, error, input } = renderEditor();
+        const head = content.querySelector('thead tr') as HTMLTableRowElement;
+        head.insertAdjacentHTML(
+            'beforeend',
+            '<th data-hint="string">Node</th><th data-hint="string">Zone</th>',
+        );
+        content.querySelectorAll('tbody tr').forEach((row) => {
+            row.insertAdjacentHTML('beforeend', '<td>node-a</td><td>zone-a</td>');
+        });
+        filters.captureRowModel(content);
+        input.value = 'bogus:value';
+
+        binding('keydown').handler(targetedKey(input, 'Enter'), null);
+
+        expect(error).toHaveTextContent('no such field — try name, status, node…');
+        expect(error).not.toHaveTextContent('zone');
+        expect(error).not.toHaveTextContent('label');
     });
 
     test('keeps free text live-only and makes Backspace without chips a safe no-op', () => {
@@ -505,6 +796,27 @@ describe('navigation and binding contracts', () => {
         expect(ajax).not.toHaveBeenCalled();
     });
 
+    test('Backspace only pops chips for an actually empty editor', () => {
+        const chips = `
+            <span class="ro-scope-chip">
+                <a class="chip-x" data-ro-action="remove-chip" href="/pods">remove</a>
+            </span>
+        `;
+        const { input } = renderEditor(chips);
+        const ajax = installHtmx();
+        input.value = 'draft';
+        const nonemptyBackspace = targetedKey(input, 'Backspace');
+        binding('keydown').handler(nonemptyBackspace, null);
+        expect(nonemptyBackspace.defaultPrevented).toBe(false);
+        expect(ajax).not.toHaveBeenCalled();
+
+        input.value = '';
+        const unrelated = targetedKey(input, 'Delete');
+        binding('keydown').handler(unrelated, null);
+        expect(unrelated.defaultPrevented).toBe(false);
+        expect(ajax).not.toHaveBeenCalled();
+    });
+
     test('input clears a field error and immediately reapplies live visibility', () => {
         const { content, error, input } = renderEditor();
         filters.captureRowModel(content);
@@ -524,6 +836,11 @@ describe('navigation and binding contracts', () => {
         expect(content.querySelector('[data-key="dev/pods/worker-beta"]')).toHaveClass(
             'ro-row-filtered',
         );
+
+        input.value = 'sta';
+        inputBinding.handler(new Event('input'), input);
+        expect(document.getElementById('ro-filter-ac')).not.toHaveAttribute('hidden');
+        expect(document.querySelector('#ro-filter-ac .ac-name')).toHaveTextContent('status');
     });
 
     test('unknown-field handling remains safe without an error mount or captured schema', () => {
@@ -577,5 +894,41 @@ describe('navigation and binding contracts', () => {
             target: '#resource-list-content',
             swap: 'morph',
         });
+    });
+
+    test('binding descriptors preserve dispatcher routing and stop semantics', () => {
+        expect(
+            filters.filtersBindings.map(({ event, selector, stop }) => ({ event, selector, stop })),
+        ).toStrictEqual([
+            {
+                event: 'click',
+                selector: '#ro-filter-field [data-ro-action="remove-chip"]',
+                stop: true,
+            },
+            {
+                event: 'click',
+                selector: '#ro-filter-ac [data-ro-action="pick-suggestion"]',
+                stop: true,
+            },
+            { event: 'click', selector: '#ro-filter-field', stop: true },
+            { event: 'click', selector: undefined, stop: undefined },
+            { event: 'input', selector: '#ro-filter-input', stop: true },
+            { event: 'keydown', selector: undefined, stop: undefined },
+        ]);
+    });
+
+    test('field focus and keydown bindings ignore events already owned by another target', () => {
+        const { input } = renderEditor();
+        const field = document.getElementById('ro-filter-field') as HTMLElement;
+        const focus = vi.spyOn(input, 'focus');
+
+        binding('click', '#ro-filter-field').handler(targetedClick(input), field);
+        expect(focus).not.toHaveBeenCalled();
+
+        const other = document.createElement('button');
+        const enter = targetedKey(other, 'Enter');
+        binding('keydown').handler(enter, null);
+        expect(enter.defaultPrevented).toBe(false);
+        expect(input.value).toBe('');
     });
 });

--- a/internal/assets/src/js/filters.ts
+++ b/internal/assets/src/js/filters.ts
@@ -42,10 +42,11 @@ import {
     liveNameMatchKeys,
     type ModelField,
     type ModelRow,
-    normalizeFieldName,
+    normalizeFieldWhitespace,
     rankFieldSuggestions,
     rankValueSuggestions,
     splitFilterDraft,
+    trimFilterWhitespace,
 } from './filters-parse.js';
 import type { RowModelWire } from './types.js';
 import { virtualizeOnFilterChange, virtualizerActive } from './virtualizer.js';
@@ -90,7 +91,7 @@ export function captureRowModel(root: ParentNode): void {
     }
     const fields: ModelField[] = [];
     table.querySelectorAll('thead th').forEach((th) => {
-        const label = (th.textContent || '').trim();
+        const label = normalizeFieldWhitespace(th.textContent || '');
         fields.push({
             label,
             name: fieldSuggestionText(label),
@@ -101,12 +102,12 @@ export function captureRowModel(root: ParentNode): void {
     table.querySelectorAll('tbody tr[data-key]').forEach((tr) => {
         const cells: string[] = [];
         tr.querySelectorAll('td').forEach((td) => {
-            cells.push((td.textContent || '').trim());
+            cells.push(trimFilterWhitespace(td.textContent || ''));
         });
         const nameLink = tr.querySelector('td.cell-name a');
         rows.push({
             key: (tr as HTMLElement).dataset.key as string,
-            name: nameLink ? (nameLink.textContent || '').trim() : cells[0] || '',
+            name: nameLink ? trimFilterWhitespace(nameLink.textContent || '') : cells[0] || '',
             cells,
         });
     });
@@ -179,9 +180,9 @@ export function issueFilterNavigation(href: string): void {
         target: '#resource-list-content',
         swap: 'morph',
     });
-    if (request && typeof request.catch === 'function') {
-        request.catch(() => {}); // failures surface via the stale banner path
-    }
+    // failures surface through the stale-banner lifecycle; attach a rejection
+    // handler when htmx returns its optional request promise.
+    void request?.catch(() => {});
 }
 
 // commitFilterChip materializes the draft as a `?f=` chip. The raw value is
@@ -190,7 +191,7 @@ export function issueFilterNavigation(href: string): void {
 // is appended by STRING CONCATENATION so sibling raw params keep their exact wire
 // encoding (never URLSearchParams over the whole query).
 function commitFilterChip(draft: string): void {
-    const text = draft.trim();
+    const text = trimFilterWhitespace(draft);
     const parsed = splitFilterDraft(text);
     if (!parsed) {
         return; // free text never commits -- it live-matches only
@@ -239,7 +240,9 @@ function showFilterFieldHint(): void {
     const names = filterSuggestionFields(roRowModel.fields)
         .slice(0, 3)
         .map((f) => f.text);
-    el.textContent = `no such field — try ${names.length ? names.join(', ') : 'status, node, age'}…`;
+    // filterSuggestionFields always contributes the virtual `label` field, so
+    // the schema-derived list is never empty and needs no fictional fallback.
+    el.textContent = `no such field — try ${names.join(', ')}…`;
     (el as HTMLElement).hidden = false;
 }
 
@@ -257,7 +260,7 @@ function hideFilterFieldHint(): void {
 // (!= > <) autocomplete the field then leave the value free. Tab/⏎ accepts, esc
 // dismisses. All nodes are built with createElement/textContent.
 let filterACItems: ACItem[] = [];
-let filterACActive = -1;
+let filterACActive = 0;
 
 function filterACOpen(): boolean {
     const ac = document.getElementById('ro-filter-ac') as HTMLElement | null;
@@ -271,7 +274,7 @@ function closeFilterAC(): void {
         ac.textContent = '';
     }
     filterACItems = [];
-    filterACActive = -1;
+    filterACActive = 0;
 }
 
 function openFilterAC(items: ACItem[]): void {
@@ -295,12 +298,12 @@ function openFilterAC(items: ACItem[]): void {
         name.className = 'ac-name';
         name.textContent = item.label; // textContent -> hostile cell values cannot inject
         row.appendChild(name);
-        if (item.hint) {
-            const hint = document.createElement('span');
-            hint.className = 'ac-hint';
-            hint.textContent = item.hint;
-            row.appendChild(hint);
-        }
+        // Every field/value candidate produced by filters-parse carries a
+        // meaningful hint (type or frequency), so render the shape uniformly.
+        const hint = document.createElement('span');
+        hint.className = 'ac-hint';
+        hint.textContent = item.hint;
+        row.appendChild(hint);
         row.addEventListener('mousemove', () => setFilterACActive(idx));
         ac.appendChild(row);
     });
@@ -308,9 +311,6 @@ function openFilterAC(items: ACItem[]): void {
 }
 
 function setFilterACActive(index: number): void {
-    if (filterACItems.length === 0) {
-        return;
-    }
     filterACActive = Math.max(0, Math.min(filterACItems.length - 1, index));
     const ac = document.getElementById('ro-filter-ac');
     if (!ac) {
@@ -324,9 +324,6 @@ function setFilterACActive(index: number): void {
 }
 
 function moveFilterACActive(delta: number): void {
-    if (filterACItems.length === 0) {
-        return;
-    }
     setFilterACActive((filterACActive + delta + filterACItems.length) % filterACItems.length);
 }
 
@@ -338,7 +335,7 @@ export function updateFilterAC(): void {
         return;
     }
     const draft = input.value;
-    if (!draft.trim()) {
+    if (!trimFilterWhitespace(draft)) {
         closeFilterAC();
         return;
     }
@@ -348,21 +345,16 @@ export function updateFilterAC(): void {
         openFilterAC(rankFieldSuggestions(roRowModel.fields, draft));
         return;
     }
-    const isLabel = normalizeFieldName(parsed.field) === 'label';
-    if (parsed.op !== ':' || isLabel || !filterFieldKnown(roRowModel.fields, parsed.field)) {
+    if (parsed.op !== ':' || !filterFieldKnown(roRowModel.fields, parsed.field)) {
         // Operator forms leave the value free; `label` values are not in the row
-        // model (metadata.labels never renders for most kinds); unknown fields
-        // get the ⏎ hint, not suggestions.
+        // model; unknown fields get the ⏎ hint, not suggestions.
         closeFilterAC();
         return;
     }
     // Top 8 distinct values by frequency, computed from the FULL row model.
-    const items = rankValueSuggestions(roRowModel.fields, roRowModel.rows, parsed);
-    if (items.length === 0) {
-        closeFilterAC();
-        return;
-    }
-    openFilterAC(items);
+    // Virtual `label` resolves as a valid filter but has no model-column index;
+    // rankValueSuggestions returns before reading rows in that case.
+    openFilterAC(rankValueSuggestions(roRowModel.fields, roRowModel.rows, parsed));
 }
 
 // acceptFilterAC fills the input with the active suggestion. Accepting a FIELD
@@ -375,7 +367,6 @@ function acceptFilterAC(commitValues: boolean): void {
         return;
     }
     input.value = item.insert;
-    closeFilterAC();
     if (item.kind === 'value' && commitValues) {
         commitFilterChip(input.value);
     } else {
@@ -390,7 +381,7 @@ function handleFilterInputKeydown(event: KeyboardEvent): void {
     const input = event.target as HTMLInputElement;
     if (event.key === 'Enter') {
         event.preventDefault();
-        if (filterACOpen() && filterACActive >= 0) {
+        if (filterACOpen() && filterACItems.length > 0) {
             acceptFilterAC(true);
             return;
         }

--- a/internal/assets/src/js/init.dom.test.ts
+++ b/internal/assets/src/js/init.dom.test.ts
@@ -82,7 +82,7 @@ vi.mock('./yaml-folds.js', () => ({
 vi.mock('./skeleton.js', () => ({}));
 
 // Import exactly once: init.ts installs resident document/window listeners at module load.
-import './init.js';
+import { handleSortPreferenceRequest } from './init.js';
 
 interface CallTracked {
     mock: { invocationCallOrder: number[] };
@@ -114,8 +114,8 @@ function expectInitOrder(): void {
     );
 }
 
-function dispatchBeforeRequest(detail: object): void {
-    document.dispatchEvent(new CustomEvent('htmx:beforeRequest', { detail }));
+function dispatchBeforeRequest(detail?: object): void {
+    handleSortPreferenceRequest(new CustomEvent('htmx:beforeRequest', { detail }));
 }
 
 beforeEach(() => {
@@ -124,6 +124,14 @@ beforeEach(() => {
     steps.isListRefreshEvent.mockReturnValue(false);
     steps.liveState.status = 'idle';
     steps.liveState.streamPath = '';
+});
+
+test('publishes showToast through the resident window seam', () => {
+    expect(window.roToast).toBe(steps.showToast);
+
+    window.roToast?.('Detached result');
+
+    expect(steps.showToast).toHaveBeenCalledExactlyOnceWith('Detached result');
 });
 
 describe('runInit orchestration', () => {
@@ -154,6 +162,26 @@ describe('runInit orchestration', () => {
             steps.updateBulkBar,
         );
         expect(warn).toHaveBeenCalledExactlyOnceWith('readout init step failed', failure);
+    });
+
+    test('measures the sticky namespace between theme sync and full-model capture', () => {
+        document.body.innerHTML = `
+            <div class="ro-table-wrap">
+                <table class="ro-table"><tbody><tr><td class="cell-ns"></td></tr></tbody></table>
+            </div>
+        `;
+        const cell = document.querySelector('.cell-ns') as HTMLTableCellElement;
+        const measure = vi
+            .spyOn(cell, 'getBoundingClientRect')
+            .mockReturnValue({ width: 72 } as DOMRect);
+
+        document.dispatchEvent(new Event('htmx:load'));
+
+        expectCalledOnceInOrder(
+            steps.syncThemeTogglePostTarget,
+            measure,
+            steps.captureRowModelFromDocument,
+        );
     });
 });
 
@@ -214,6 +242,115 @@ describe('htmx swap lifecycle', () => {
         expect(steps.setColsPopOpen).toHaveBeenCalledExactlyOnceWith(true);
         expect(steps.liveOnListSwap).toHaveBeenCalledExactlyOnceWith(event);
     });
+
+    test('ignores an afterSwap that is not a list refresh', () => {
+        const event = new CustomEvent('htmx:afterSwap', { detail: { target: document.body } });
+
+        document.dispatchEvent(event);
+
+        expect(steps.isListRefreshEvent).toHaveBeenCalledExactlyOnceWith(event);
+        expect(steps.noteRefreshRecovery).not.toHaveBeenCalled();
+        expect(steps.clearListStale).not.toHaveBeenCalled();
+        expect(steps.reapplyRowState).not.toHaveBeenCalled();
+        expect(steps.applyLiveNameFilter).not.toHaveBeenCalled();
+        expect(steps.updateFilterAC).not.toHaveBeenCalled();
+        expect(steps.colsPopOpen).not.toHaveBeenCalled();
+        expect(steps.virtualizeAfterSwap).not.toHaveBeenCalled();
+        expect(steps.liveOnListSwap).not.toHaveBeenCalled();
+    });
+
+    test.each([
+        { name: 'missing input', input: '' },
+        {
+            name: 'focused empty input',
+            input: '<input id="ro-filter-input" value="" data-focus>',
+        },
+        {
+            name: 'unfocused non-empty input',
+            input: '<input id="ro-filter-input" value="status:">',
+        },
+    ])('runs the list pipeline but skips optional repairs for $name', ({ input }) => {
+        document.body.innerHTML = `<div id="resource-list-content">${input}</div>`;
+        const filterInput = document.getElementById('ro-filter-input') as HTMLInputElement | null;
+        if (filterInput?.hasAttribute('data-focus')) {
+            filterInput.focus();
+        }
+        steps.isListRefreshEvent.mockReturnValue(true);
+        steps.colsPopOpen.mockReturnValue(false);
+        const event = new CustomEvent('htmx:afterSwap', {
+            detail: { target: document.getElementById('resource-list-content') },
+        });
+
+        document.dispatchEvent(event);
+
+        expectCalledOnceInOrder(
+            steps.noteRefreshRecovery,
+            steps.clearListStale,
+            steps.reapplyRowState,
+            steps.applyLiveNameFilter,
+            steps.colsPopOpen,
+            steps.virtualizeAfterSwap,
+            steps.liveOnListSwap,
+        );
+        expect(steps.updateFilterAC).not.toHaveBeenCalled();
+        expect(steps.setColsPopOpen).not.toHaveBeenCalled();
+        expect(steps.liveOnListSwap).toHaveBeenCalledExactlyOnceWith(event);
+    });
+
+    test('repaints row and bulk state in order on history restore', () => {
+        document.dispatchEvent(new Event('htmx:historyRestore'));
+
+        expectCalledOnceInOrder(steps.reapplyRowState, steps.updateBulkBar);
+    });
+});
+
+describe('sticky namespace measurement', () => {
+    test('measures a real namespace row and clears stale state from other table shapes', () => {
+        document.body.innerHTML = `
+            <div class="ro-table-wrap">
+                <table id="all" class="ro-table">
+                    <tbody>
+                        <tr class="ro-vspacer"><td id="spacer" class="cell-ns"></td></tr>
+                        <tr><td id="namespace" class="cell-ns"></td></tr>
+                    </tbody>
+                </table>
+                <table id="single" class="ro-table ro-sticky2" style="--ns-col-w: 123px">
+                    <tbody><tr><td class="cell-name"></td></tr></tbody>
+                </table>
+                <table id="empty" class="ro-table ro-sticky2" style="--ns-col-w: 456px">
+                    <tbody></tbody>
+                </table>
+            </div>
+        `;
+        const all = document.getElementById('all') as HTMLTableElement;
+        const single = document.getElementById('single') as HTMLTableElement;
+        const empty = document.getElementById('empty') as HTMLTableElement;
+        const spacer = document.getElementById('spacer') as HTMLTableCellElement;
+        const namespace = document.getElementById('namespace') as HTMLTableCellElement;
+        const spacerMeasure = vi
+            .spyOn(spacer, 'getBoundingClientRect')
+            .mockReturnValue({ width: 999 } as DOMRect);
+        const namespaceMeasure = vi
+            .spyOn(namespace, 'getBoundingClientRect')
+            .mockReturnValue({ width: 72 } as DOMRect);
+
+        document.dispatchEvent(new Event('htmx:afterSettle'));
+
+        expect(spacerMeasure).not.toHaveBeenCalled();
+        expect(namespaceMeasure).toHaveBeenCalledOnce();
+        expect(all).toHaveClass('ro-sticky2');
+        expect(all.style.getPropertyValue('--ns-col-w')).toBe('72px');
+        for (const stale of [single, empty]) {
+            expect(stale).not.toHaveClass('ro-sticky2');
+            expect(stale.style.getPropertyValue('--ns-col-w')).toBe('');
+        }
+
+        namespaceMeasure.mockReturnValue({ width: 96 } as DOMRect);
+        window.dispatchEvent(new Event('resize'));
+
+        expect(namespaceMeasure).toHaveBeenCalledTimes(2);
+        expect(all.style.getPropertyValue('--ns-col-w')).toBe('96px');
+    });
 });
 
 describe('sort preference gate', () => {
@@ -260,4 +397,118 @@ describe('sort preference gate', () => {
 
         expect(steps.roPrefsSetSort).not.toHaveBeenCalled();
     });
+
+    test('accepts an encoded plural and a request with no headers', () => {
+        document.body.innerHTML = `
+            <table><thead><tr><th><a id="sort">Sort</a></th></tr></thead></table>
+            <div id="resource-list-content"></div>
+        `;
+        const sort = document.getElementById('sort') as HTMLAnchorElement;
+        const target = document.getElementById('resource-list-content') as HTMLElement;
+
+        dispatchBeforeRequest({
+            elt: sort,
+            target,
+            requestConfig: { path: '/clusters/prod/namespaces/default/%70ods/_table?sort=Name' },
+        });
+
+        expect(steps.roPrefsSetSort).toHaveBeenCalledExactlyOnceWith('pods', 'Name');
+    });
+
+    test.each([
+        { name: 'no event detail', detail: undefined },
+        { name: 'no request config', detail: {} },
+        {
+            name: 'no source element',
+            detail: {
+                target: document.createElement('div'),
+                requestConfig: { path: '/pods/_table?sort=Name' },
+            },
+        },
+        {
+            name: 'no target',
+            detail: {
+                elt: document.createElement('a'),
+                requestConfig: { path: '/pods/_table?sort=Name' },
+            },
+        },
+    ])('ignores incomplete request metadata: $name', ({ detail }) => {
+        expect(() => dispatchBeforeRequest(detail)).not.toThrow();
+        expect(steps.roPrefsSetSort).not.toHaveBeenCalled();
+    });
+
+    test.each([
+        { name: 'missing path', path: undefined },
+        { name: 'empty path', path: '' },
+        { name: 'non-table path', path: '/pods?sort=Name' },
+        { name: 'empty plural segment', path: '//_table?sort=Name' },
+        { name: 'table-like suffix', path: '/pods/_table-extra?sort=Name' },
+        { name: 'table path without sort', path: '/pods/_table' },
+        { name: 'table path with empty sort', path: '/pods/_table?sort=' },
+        { name: 'unparseable URL', path: 'http://[/pods/_table?sort=Name' },
+        { name: 'malformed plural escape', path: '/%ZZ/_table?sort=Name' },
+    ])('does not persist an untrustworthy sort request: $name', ({ path }) => {
+        document.body.innerHTML = `
+            <table><thead><tr><th><a id="sort">Sort</a></th></tr></thead></table>
+            <div id="resource-list-content"></div>
+        `;
+        const sort = document.getElementById('sort') as HTMLAnchorElement;
+        const target = document.getElementById('resource-list-content') as HTMLElement;
+
+        expect(() =>
+            dispatchBeforeRequest({
+                elt: sort,
+                target,
+                requestConfig: { headers: {}, path },
+            }),
+        ).not.toThrow();
+        expect(steps.roPrefsSetSort).not.toHaveBeenCalled();
+    });
+
+    test('ignores a source that cannot prove it came from a sort header', () => {
+        const target = document.createElement('div');
+        target.id = 'resource-list-content';
+
+        dispatchBeforeRequest({
+            elt: { closest: null },
+            target,
+            requestConfig: { headers: {}, path: '/pods/_table?sort=Name' },
+        });
+
+        expect(steps.roPrefsSetSort).not.toHaveBeenCalled();
+    });
+});
+
+test('registers every required resident document and window event at module load', async () => {
+    // The first import happens while Vitest is collecting this file, outside an
+    // individual test's coverage window. Re-evaluate the side-effect module here
+    // so registration itself is observable and mutation-covered.
+    vi.resetModules();
+    const documentAdd = vi.spyOn(document, 'addEventListener');
+    const windowAdd = vi.spyOn(window, 'addEventListener');
+    const documentStart = documentAdd.mock.calls.length;
+    const windowStart = windowAdd.mock.calls.length;
+
+    await import('./init.js');
+
+    const documentRegistrations = documentAdd.mock.calls
+        .slice(documentStart)
+        .map(([type, listener]) => ({ listener: typeof listener, type }));
+    const windowRegistrations = windowAdd.mock.calls
+        .slice(windowStart)
+        .map(([type, listener]) => ({ listener: typeof listener, type }));
+    expect(documentRegistrations).toEqual(
+        expect.arrayContaining([
+            { type: 'htmx:beforeRequest', listener: 'function' },
+            { type: 'htmx:afterSwap', listener: 'function' },
+            { type: 'htmx:beforeSwap', listener: 'function' },
+            { type: 'htmx:historyRestore', listener: 'function' },
+            { type: 'DOMContentLoaded', listener: 'function' },
+            { type: 'htmx:load', listener: 'function' },
+            { type: 'htmx:afterSettle', listener: 'function' },
+        ]),
+    );
+    expect(windowRegistrations).toEqual(
+        expect.arrayContaining([{ type: 'resize', listener: 'function' }]),
+    );
 });

--- a/internal/assets/src/js/init.ts
+++ b/internal/assets/src/js/init.ts
@@ -69,33 +69,60 @@ window.roToast = showToast;
 // filter-chip commits are sourced from the editor input -- none of them match a
 // thead ancestor. A URL that merely ARRIVES with ?sort= (deep link, history
 // restore) never passes here at all: only the direct interaction writes the pref.
-document.addEventListener('htmx:beforeRequest', (event) => {
-    const detail = (event as CustomEvent).detail;
-    const cfg = detail?.requestConfig;
-    if (!cfg || !detail.elt || !detail.target || detail.target.id !== 'resource-list-content') {
+export function handleSortPreferenceRequest(event: Event): void {
+    // htmx owns this event shape, but document-level listeners are public: tests,
+    // extensions, and browser tooling can dispatch a partial CustomEvent. Box
+    // every unknown value so property reads remain total even for null/primitives.
+    const detail = Object((event as CustomEvent).detail) as {
+        elt?: unknown;
+        requestConfig?: unknown;
+        target?: unknown;
+    };
+    const rawCfg = Object(detail.requestConfig) as { headers?: unknown; path?: unknown };
+    const cfg = {
+        ...rawCfg,
+        headers: Object(rawCfg.headers) as Record<string, unknown>,
+    };
+    const target = Object(detail.target) as { id?: unknown };
+    if (target.id !== 'resource-list-content') {
         return;
     }
-    if (cfg.headers && (cfg.headers['RO-No-Push'] || cfg.headers['HX-Preloaded'] === 'true')) {
+    if (cfg.headers['RO-No-Push'] || cfg.headers['HX-Preloaded'] === 'true') {
         return; // programmatic / warm-up traffic never writes prefs
     }
-    if (typeof detail.elt.closest !== 'function' || !detail.elt.closest('thead th')) {
+    const elt = Object(detail.elt) as { closest(selector: string): Element | null };
+    let sortHeader: Element | null = null;
+    try {
+        sortHeader = elt.closest('thead th');
+    } catch {
+        // Absent/non-Element source: keep the null sentinel below.
+    }
+    if (!sortHeader) {
         return; // not a sort-header gesture
     }
-    const pathMatch = /\/([^/]+)\/_table(?:[?#]|$)/.exec(cfg.path || '');
-    if (!pathMatch) {
-        return;
-    }
-    let sort = '';
+    let plural: string;
+    let sort: string;
     try {
-        sort = new URL(cfg.path, window.location.href).searchParams.get('sort') || '';
+        const requestURL = new URL(String(cfg.path), window.location.href);
+        const rawSort = requestURL.searchParams.get('sort');
+        if (!rawSort) {
+            return;
+        }
+        const pathMatch = /\/([^/]+)\/_table$/.exec(requestURL.pathname);
+        if (!pathMatch) {
+            return;
+        }
+        sort = rawSort;
+        // The route segment can contain percent escapes. Treat a malformed escape
+        // exactly like an unparseable URL: it is not a trustworthy preference key,
+        // and it must never throw out of the resident document listener.
+        plural = decodeURIComponent(pathMatch[1]);
     } catch {
-        return; // unparseable request URL -> nothing trustworthy to persist
+        return; // unparseable URL/route escape -> nothing trustworthy to persist
     }
-    const plural = decodeURIComponent(pathMatch[1]);
-    if (plural && sort) {
-        roPrefsSetSort(plural, sort);
-    }
-});
+    roPrefsSetSort(plural, sort);
+}
+document.addEventListener('htmx:beforeRequest', handleSortPreferenceRequest);
 
 // ---------------------------------------------------------------------------
 // Post-swap PIPELINE: htmx:afterSwap (the FIXED order of repairs).

--- a/internal/assets/src/js/keyboard.dom.test.ts
+++ b/internal/assets/src/js/keyboard.dom.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { Binding } from './events.js';
 
@@ -34,7 +34,7 @@ function binding(event: string): Binding {
 }
 
 function targetedKey(
-    target: Element,
+    target: EventTarget | null,
     key: string,
     modifiers: KeyboardEventInit = {},
 ): KeyboardEvent {
@@ -48,7 +48,7 @@ function targetedKey(
     return event;
 }
 
-function targetedClick(target: Element): MouseEvent {
+function targetedClick(target: EventTarget | null): MouseEvent {
     const event = new MouseEvent('click', { bubbles: true, cancelable: true });
     Object.defineProperty(event, 'target', { configurable: true, value: target });
     return event;
@@ -84,6 +84,7 @@ function renderKeyboard(): { first: HTMLElement; second: HTMLElement; wrap: HTML
 
 beforeEach(() => {
     renderKeyboard();
+    closeKbdOverlay();
     let focused: string | null = null;
     const state: RowState = {
         focusedKey: () => focused,
@@ -100,6 +101,24 @@ beforeEach(() => {
     window.history.replaceState(null, '', '/');
 });
 
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('binding contract', () => {
+    test('exports non-stopping click and keydown bindings with undefined returns', () => {
+        expect(
+            keyboardBindings.map(({ event, selector, stop }) => ({ event, selector, stop })),
+        ).toStrictEqual([
+            { event: 'click', selector: undefined, stop: undefined },
+            { event: 'keydown', selector: undefined, stop: undefined },
+        ]);
+
+        expect(binding('click').handler(targetedClick(document.body), null)).toBeUndefined();
+        expect(binding('keydown').handler(targetedKey(document.body, 'x'), null)).toBeUndefined();
+    });
+});
+
 describe('keyboard help overlay', () => {
     test('opens on ?, traps Tab, and restores prior focus on Escape', () => {
         const prior = document.getElementById('prior-focus') as HTMLButtonElement;
@@ -108,12 +127,17 @@ describe('keyboard help overlay', () => {
         prior.focus();
         const open = targetedKey(prior, '?');
 
-        binding('keydown').handler(open, null);
+        expect(binding('keydown').handler(open, null)).toBeUndefined();
 
         expect(open.defaultPrevented).toBe(true);
         expect(overlay).toHaveClass('open');
         expect(overlay).toHaveAttribute('aria-hidden', 'false');
         expect(card).toHaveFocus();
+
+        const other = targetedKey(card, 'x');
+        binding('keydown').handler(other, null);
+        expect(other.defaultPrevented).toBe(false);
+        expect(overlay).toHaveClass('open');
 
         const tab = targetedKey(card, 'Tab');
         binding('keydown').handler(tab, null);
@@ -128,6 +152,37 @@ describe('keyboard help overlay', () => {
         expect(prior).toHaveFocus();
     });
 
+    test('? closes an open overlay and restores prior focus', () => {
+        const prior = document.getElementById('prior-focus') as HTMLButtonElement;
+        const overlay = document.getElementById('ro-kbd-overlay') as HTMLElement;
+        const card = overlay.querySelector('.kbd-card') as HTMLElement;
+        prior.focus();
+        binding('keydown').handler(targetedKey(prior, '?'), null);
+
+        const close = targetedKey(card, '?');
+        binding('keydown').handler(close, null);
+
+        expect(close.defaultPrevented).toBe(true);
+        expect(overlay).not.toHaveClass('open');
+        expect(overlay.getAttribute('aria-hidden')).toBe('true');
+        expect(prior).toHaveFocus();
+    });
+
+    test('does not try to restore prior focus after that element detaches', () => {
+        const prior = document.getElementById('prior-focus') as HTMLButtonElement;
+        const overlay = document.getElementById('ro-kbd-overlay') as HTMLElement;
+        prior.focus();
+        binding('keydown').handler(targetedKey(prior, '?'), null);
+        const restoreFocus = vi.spyOn(prior, 'focus');
+        restoreFocus.mockClear();
+        prior.remove();
+
+        closeKbdOverlay();
+
+        expect(overlay).not.toHaveClass('open');
+        expect(restoreFocus).not.toHaveBeenCalled();
+    });
+
     test('closes only when the backdrop itself is clicked', () => {
         const overlay = document.getElementById('ro-kbd-overlay') as HTMLElement;
         const card = overlay.querySelector('.kbd-card') as HTMLElement;
@@ -136,7 +191,12 @@ describe('keyboard help overlay', () => {
         binding('click').handler(targetedClick(card), null);
         expect(overlay).toHaveClass('open');
 
-        binding('click').handler(targetedClick(overlay), null);
+        const text = document.createTextNode('not the backdrop');
+        card.append(text);
+        expect(() => binding('click').handler(targetedClick(text), null)).not.toThrow();
+        expect(overlay).toHaveClass('open');
+
+        expect(binding('click').handler(targetedClick(overlay), null)).toBeUndefined();
         expect(overlay).not.toHaveClass('open');
     });
 
@@ -176,6 +236,41 @@ describe('row keyboard navigation', () => {
         expect(second.scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' });
     });
 
+    test('j/k are inert and safe when there are no identity rows', () => {
+        const wrap = document.getElementById('table-wrap') as HTMLElement;
+        document.querySelector('#resource-list-content tbody')?.replaceChildren();
+        const setFocus = vi.fn();
+        (window as unknown as { roRowState: RowState }).roRowState = {
+            focusedKey: () => null,
+            setFocus,
+        };
+        const event = targetedKey(wrap, 'j');
+
+        expect(() => binding('keydown').handler(event, null)).not.toThrow();
+
+        expect(event.defaultPrevented).toBe(false);
+        expect(setFocus).not.toHaveBeenCalled();
+    });
+
+    test('a detached prior focus starts the rendered walk at the first visible row', () => {
+        const { first, wrap } = renderKeyboard();
+        let focused: string | null = 'detached';
+        const setFocus = vi.fn((key: string) => {
+            focused = key;
+        });
+        (window as unknown as { roRowState: RowState }).roRowState = {
+            focusedKey: () => focused,
+            setFocus,
+        };
+        const event = targetedKey(wrap, 'k');
+
+        binding('keydown').handler(event, null);
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(setFocus).toHaveBeenCalledExactlyOnceWith('one');
+        expect(first.scrollIntoView).toHaveBeenCalledExactlyOnceWith({ block: 'nearest' });
+    });
+
     test('delegates movement to the virtualizer and prevents only a handled key', () => {
         const wrap = document.getElementById('table-wrap') as HTMLElement;
         dependencies.virtualizerActive.mockReturnValue(true);
@@ -192,53 +287,178 @@ describe('row keyboard navigation', () => {
         expect(up.defaultPrevented).toBe(false);
     });
 
-    test('Enter opens the focused rendered or virtual row, never a filtered row', () => {
+    test('Enter prefers an already rendered row even while virtualization is active', () => {
         const wrap = document.getElementById('table-wrap') as HTMLElement;
-        let focused: string | null = 'two';
+        (window as unknown as { roRowState: RowState }).roRowState = {
+            focusedKey: () => 'two',
+            setFocus: vi.fn(),
+        };
+        const unrelatedVirtualRow = document.createElement('tr');
+        unrelatedVirtualRow.dataset.key = 'two';
+        unrelatedVirtualRow.dataset.href = '#wrong-virtual-row';
+        dependencies.virtualizerActive.mockReturnValue(true);
+        dependencies.virtRowByKey.mockReturnValue(unrelatedVirtualRow);
+        dependencies.virtVisible.mockReturnValue([unrelatedVirtualRow]);
+
+        const rendered = targetedKey(wrap, 'Enter');
+        binding('keydown').handler(rendered, null);
+
+        expect(rendered.defaultPrevented).toBe(true);
+        expect(window.location.hash).toBe('#two');
+        expect(dependencies.virtRowByKey).not.toHaveBeenCalled();
+    });
+
+    test('Enter ignores a focused filtered row and an absent focus key', () => {
+        const wrap = document.getElementById('table-wrap') as HTMLElement;
+        let focused: string | null = 'hidden';
         (window as unknown as { roRowState: RowState }).roRowState = {
             focusedKey: () => focused,
             setFocus: vi.fn(),
         };
 
-        const rendered = targetedKey(wrap, 'Enter');
-        binding('keydown').handler(rendered, null);
-        expect(rendered.defaultPrevented).toBe(true);
-        expect(window.location.hash).toBe('#two');
-
-        focused = 'hidden';
-        window.history.replaceState(null, '', '/');
         const hidden = targetedKey(wrap, 'Enter');
         binding('keydown').handler(hidden, null);
         expect(hidden.defaultPrevented).toBe(false);
         expect(window.location.hash).toBe('');
 
+        focused = null;
+        const absent = targetedKey(wrap, 'Enter');
+        binding('keydown').handler(absent, null);
+        expect(absent.defaultPrevented).toBe(false);
+        expect(window.location.hash).toBe('');
+    });
+
+    test('Enter opens a detached virtual row only when it is logically visible', () => {
+        const wrap = document.getElementById('table-wrap') as HTMLElement;
         const detached = document.createElement('tr');
         detached.dataset.key = 'virtual';
         detached.dataset.href = '#virtual';
-        focused = 'virtual';
+        const firstVirtual = document.createElement('tr');
+        (window as unknown as { roRowState: RowState }).roRowState = {
+            focusedKey: () => 'virtual',
+            setFocus: vi.fn(),
+        };
         dependencies.virtualizerActive.mockReturnValue(true);
         dependencies.virtRowByKey.mockReturnValue(detached);
-        dependencies.virtVisible.mockReturnValue([detached]);
+        dependencies.virtVisible.mockReturnValue([firstVirtual, detached]);
+
         const virtual = targetedKey(wrap, 'Enter');
         binding('keydown').handler(virtual, null);
+
         expect(virtual.defaultPrevented).toBe(true);
         expect(window.location.hash).toBe('#virtual');
+
+        window.history.replaceState(null, '', '/');
+        dependencies.virtVisible.mockReturnValue([firstVirtual]);
+        const filteredVirtual = targetedKey(wrap, 'Enter');
+        binding('keydown').handler(filteredVirtual, null);
+        expect(filteredVirtual.defaultPrevented).toBe(false);
+        expect(window.location.hash).toBe('');
     });
 
-    test('does not hijack text entry, chords, controls, or open surfaces', () => {
-        const input = document.createElement('input');
-        const button = document.createElement('button');
-        document.body.append(input, button);
-        const inertEvents = [
-            targetedKey(input, 'j'),
-            targetedKey(document.body, 'j', { metaKey: true }),
-            targetedKey(button, 'Enter'),
-        ];
-        for (const event of inertEvents) {
-            binding('keydown').handler(event, null);
-            expect(event.defaultPrevented).toBe(false);
-        }
+    test.each(['input', 'textarea', 'select'] as const)(
+        'does not hijack j from a focused %s',
+        (tag) => {
+            const control = document.createElement(tag);
+            document.body.append(control);
+            const event = targetedKey(control, 'j');
 
+            binding('keydown').handler(event, null);
+
+            expect(event.defaultPrevented).toBe(false);
+            expect(
+                (window as unknown as { roRowState: RowState }).roRowState.focusedKey(),
+            ).toBeNull();
+        },
+    );
+
+    test('does not hijack j from a contenteditable surface', () => {
+        const editor = document.createElement('div');
+        Object.defineProperty(editor, 'isContentEditable', {
+            configurable: true,
+            value: true,
+        });
+        document.body.append(editor);
+        const event = targetedKey(editor, 'j');
+
+        binding('keydown').handler(event, null);
+
+        expect(event.defaultPrevented).toBe(false);
+        expect((window as unknown as { roRowState: RowState }).roRowState.focusedKey()).toBeNull();
+    });
+
+    test.each([
+        ['meta', { metaKey: true }],
+        ['control', { ctrlKey: true }],
+        ['alt', { altKey: true }],
+    ] as const)('does not hijack a %s-modified j chord', (_name, modifiers) => {
+        const event = targetedKey(document.body, 'j', modifiers);
+
+        binding('keydown').handler(event, null);
+
+        expect(event.defaultPrevented).toBe(false);
+        expect((window as unknown as { roRowState: RowState }).roRowState.focusedKey()).toBeNull();
+    });
+
+    test.each(['a', 'button', 'summary'] as const)(
+        'does not hijack Enter from a descendant of %s',
+        (tag) => {
+            (window as unknown as { roRowState: RowState }).roRowState = {
+                focusedKey: () => 'two',
+                setFocus: vi.fn(),
+            };
+            const control = document.createElement(tag);
+            const child = document.createElement('span');
+            control.append(child);
+            document.body.append(control);
+            const event = targetedKey(child, 'Enter');
+
+            binding('keydown').handler(event, null);
+
+            expect(event.defaultPrevented).toBe(false);
+            expect(window.location.hash).toBe('');
+        },
+    );
+
+    test('handles non-Element targets without losing row navigation', () => {
+        const wrap = document.getElementById('table-wrap') as HTMLElement;
+        const text = document.createTextNode('plain text target');
+        wrap.append(text);
+        let focused: string | null = null;
+        (window as unknown as { roRowState: RowState }).roRowState = {
+            focusedKey: () => focused,
+            setFocus: (key) => {
+                focused = key;
+            },
+        };
+
+        const move = targetedKey(text, 'j');
+        expect(() => binding('keydown').handler(move, null)).not.toThrow();
+        expect(move.defaultPrevented).toBe(true);
+        expect(focused).toBe('one');
+
+        focused = 'two';
+        const enter = targetedKey(text, 'Enter');
+        expect(() => binding('keydown').handler(enter, null)).not.toThrow();
+        expect(enter.defaultPrevented).toBe(true);
+        expect(window.location.hash).toBe('#two');
+    });
+
+    test('does not treat an unrelated key as Enter when a row is focused', () => {
+        const wrap = document.getElementById('table-wrap') as HTMLElement;
+        (window as unknown as { roRowState: RowState }).roRowState = {
+            focusedKey: () => 'two',
+            setFocus: vi.fn(),
+        };
+        const event = targetedKey(wrap, 'x');
+
+        binding('keydown').handler(event, null);
+
+        expect(event.defaultPrevented).toBe(false);
+        expect(window.location.hash).toBe('');
+    });
+
+    test('does not hijack keys while another surface is open', () => {
         const surfaces = [
             document.getElementById('ro-palette'),
             document.getElementById('ro-ctxmenu'),

--- a/internal/assets/src/js/keyboard.ts
+++ b/internal/assets/src/js/keyboard.ts
@@ -37,12 +37,10 @@ function roRowState(): { setFocus(key: string): void; focusedKey(): string | nul
 // keyboardTargetIsTextEntry: the focused element owns typed characters, so the
 // gesture keys pass through untouched (j in the filter editor is the letter j).
 function keyboardTargetIsTextEntry(target: EventTarget | null): boolean {
-    const el = target as (Element & { isContentEditable?: boolean }) | null;
-    if (el?.nodeType !== 1) {
+    if (!(target instanceof HTMLElement)) {
         return false;
     }
-    const tag = el.tagName;
-    return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || !!el.isContentEditable;
+    return target.matches('input, textarea, select') || target.isContentEditable;
 }
 
 // keyboardSurfaceBusy: an open palette / context menu / namespace dropdown /
@@ -101,12 +99,12 @@ function openFocusedRow(): boolean {
     if (!key) {
         return false;
     }
-    let row: HTMLElement | null = visibleKeyRows().find((tr) => tr.dataset.key === key) || null;
+    let row: HTMLElement | null = visibleKeyRows().find((tr) => tr.dataset.key === key) ?? null;
     if (!row && virtualizerActive()) {
         // Windowed: the focused row may have scrolled out of the
         // rendered window -- it is still logically visible.
         const tr = virtRowByKey(key);
-        if (tr && virtVisible().indexOf(tr) !== -1) {
+        if (tr && virtVisible().includes(tr)) {
             row = tr;
         }
     }
@@ -157,7 +155,7 @@ export function closeKbdOverlay(): void {
     overlay.classList.remove('open');
     overlay.setAttribute('aria-hidden', 'true');
     const prior = kbdPriorFocus as HTMLElement | null;
-    if (prior && document.contains(prior) && typeof prior.focus === 'function') {
+    if (prior && document.contains(prior)) {
         prior.focus();
     }
     kbdPriorFocus = null;
@@ -170,7 +168,7 @@ export const keyboardBindings: Binding[] = [
     {
         event: 'click',
         handler: (event) => {
-            if ((event.target as Element).id === 'ro-kbd-overlay') {
+            if (event.target === kbdOverlayEl()) {
                 closeKbdOverlay();
             }
         },
@@ -216,8 +214,8 @@ export const keyboardBindings: Binding[] = [
                 // control (a focused sort-header link, button, or summary keeps
                 // its native activation; the focusable table wrap is intentionally
                 // NOT excluded -- ⏎ there is the aria-activedescendant pattern).
-                const target = e.target as Element | null;
-                if (target?.closest?.('a, button, summary')) {
+                const target = e.target;
+                if (target instanceof Element && target.closest('a, button, summary')) {
                     return;
                 }
                 if (openFocusedRow()) {

--- a/internal/assets/src/js/live-policy.test.ts
+++ b/internal/assets/src/js/live-policy.test.ts
@@ -31,6 +31,8 @@ test('a chosen numeric interval wins over everything', () => {
 test('Off with no interval polls never', () => {
     expect(effectivePollSeconds('Off', 0, 0)).toBe(0);
     expect(effectivePollSeconds('', 0, 0)).toBe(0);
+    // A stale fallback value must not make a non-Live mode start polling.
+    expect(effectivePollSeconds('Off', 0, 5)).toBe(0);
 });
 
 test('Live with a riding stream (fallback 0) self-disarms the poll chain', () => {

--- a/internal/assets/src/js/live-policy.ts
+++ b/internal/assets/src/js/live-policy.ts
@@ -46,14 +46,12 @@ export function effectivePollSeconds(
 // 3 (where it stays) quadruples it, the backoff wait capped at 60s. A
 // non-positive cadence means "no timer" -> 0 (the chain disarms).
 export function refreshDelaySeconds(effectiveSeconds: number, failureStage: number): number {
-    if (effectiveSeconds <= 0) {
-        return 0;
-    }
+    const baseSeconds = Math.max(effectiveSeconds, 0);
     if (failureStage <= 1) {
-        return effectiveSeconds;
+        return baseSeconds;
     }
     const factor = failureStage === 2 ? 2 : 4;
-    return Math.min(effectiveSeconds * factor, 60);
+    return Math.min(baseSeconds * factor, 60);
 }
 
 // nextFailureStage escalates the consecutive-failure counter one notch, clamped

--- a/internal/assets/src/js/live.dom.test.ts
+++ b/internal/assets/src/js/live.dom.test.ts
@@ -30,21 +30,28 @@ vi.mock('./stale.js', () => ({
 
 import { liveApply, liveFallbackSeconds, liveOnListSwap, liveState, liveTeardown } from './live.js';
 
+const importedLiveState = { ...liveState };
+const importedLiveDiscards = window.roLive.discards();
+const importedFallbackSeconds = liveFallbackSeconds();
+
 interface HtmxHarness {
     swap: ReturnType<typeof vi.fn>;
 }
 
 interface Deferred<T> {
     promise: Promise<T>;
+    reject(reason: unknown): void;
     resolve(value: T): void;
 }
 
 function deferred<T>(): Deferred<T> {
     let resolve!: (value: T) => void;
-    const promise = new Promise<T>((done) => {
+    let reject!: (reason: unknown) => void;
+    const promise = new Promise<T>((done, fail) => {
         resolve = done;
+        reject = fail;
     });
-    return { promise, resolve };
+    return { promise, reject, resolve };
 }
 
 function xhrAt(readyState: number): XMLHttpRequest {
@@ -69,24 +76,61 @@ function installHtmx(): HtmxHarness {
     return htmx;
 }
 
-function streamResponse(parts: Array<string | Error>): Response {
-    const queue = [...parts];
-    const reader = {
-        read: vi.fn(async () => {
-            const next = queue.shift();
-            if (next instanceof Error) {
-                throw next;
+function streamResponse(parts: Array<string | Uint8Array | Error>, status = 200): Response {
+    const encoder = new TextEncoder();
+    const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+            for (const part of parts) {
+                if (part instanceof Error) {
+                    controller.error(part);
+                    return;
+                }
+                controller.enqueue(typeof part === 'string' ? encoder.encode(part) : part);
             }
-            if (next === undefined) {
-                return { done: true, value: undefined };
-            }
-            return { done: false, value: new TextEncoder().encode(next) };
+            controller.close();
+        },
+    });
+    return {
+        status,
+        body,
+    } as unknown as Response;
+}
+
+function readerOnlyResponse(parts: string[]): Response {
+    const encoder = new TextEncoder();
+    const queue = parts.map((part) => encoder.encode(part));
+    const body = {
+        getReader: () => ({
+            read: vi.fn(async () => {
+                const value = queue.shift();
+                return value === undefined
+                    ? { done: true as const, value: undefined }
+                    : { done: false as const, value };
+            }),
         }),
     };
+    return { status: 200, body } as unknown as Response;
+}
+
+interface ControlledStream {
+    close(): void;
+    enqueue(text: string): void;
+    response: Response;
+}
+
+function controlledStream(): ControlledStream {
+    const encoder = new TextEncoder();
+    let streamController!: ReadableStreamDefaultController<Uint8Array>;
+    const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+            streamController = controller;
+        },
+    });
     return {
-        status: 200,
-        body: { getReader: () => reader },
-    } as unknown as Response;
+        close: () => streamController.close(),
+        enqueue: (text) => streamController.enqueue(encoder.encode(text)),
+        response: { status: 200, body } as unknown as Response,
+    };
 }
 
 function statusResponse(status: number): Response {
@@ -133,11 +177,22 @@ afterEach(async () => {
     await Promise.resolve();
 });
 
+test('starts from a clean, idle stream state', () => {
+    expect(importedLiveState).toStrictEqual({
+        status: 'idle',
+        abort: null,
+        gen: '',
+        streamPath: '',
+    });
+    expect(importedLiveDiscards).toBe(0);
+    expect(importedFallbackSeconds).toBe(0);
+});
+
 test('liveApply derives the raw stream URL, is idempotent, force-reopens, and tears down', () => {
     window.history.replaceState(
         null,
         '',
-        '/clusters/prod/namespaces/default/pods/?f=status:Running,Pending&sort=Age%3Adesc',
+        '/clusters/prod/namespaces/default/pods///?f=status:Running,Pending&sort=Age%3Adesc',
     );
     renderLivePage();
     const fetchMock = installAbortablePendingFetch();
@@ -150,6 +205,8 @@ test('liveApply derives the raw stream URL, is idempotent, force-reopens, and te
     expect(liveState.status).toBe('connecting');
     expect(liveState.streamPath).toBe(base);
     expect(first).not.toBeNull();
+    const firstGeneration = liveState.gen;
+    expect(firstGeneration).not.toBe('');
     expect(fetchMock).toHaveBeenCalledExactlyOnceWith(`${base}&g=${liveState.gen}`, {
         signal: first?.signal,
     });
@@ -162,6 +219,7 @@ test('liveApply derives the raw stream URL, is idempotent, force-reopens, and te
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(first?.signal.aborted).toBe(true);
     expect(liveState.abort).not.toBe(first);
+    expect(liveState.gen).not.toBe(firstGeneration);
 
     const second = liveState.abort;
     liveTeardown();
@@ -175,50 +233,191 @@ test('liveApply derives the raw stream URL, is idempotent, force-reopens, and te
     expect(liveState.streamPath).toBe('');
 });
 
-test('an unsupported Live page degrades to polling without opening a stream', () => {
+test('a queryless stream URL uses the first query delimiter for its generation', () => {
+    window.history.replaceState(null, '', '/clusters/prod/pods');
+    renderLivePage();
+    const fetchMock = installAbortablePendingFetch();
+
+    liveApply();
+
+    expect(fetchMock).toHaveBeenCalledExactlyOnceWith(
+        `/clusters/prod/pods/_stream?g=${liveState.gen}`,
+        { signal: liveState.abort?.signal },
+    );
+});
+
+describe('unsupported Live pages', () => {
+    test.each([
+        ['disabled option', () => renderLivePage(true), 5],
+        [
+            'missing option',
+            () => {
+                const content = document.createElement('div');
+                content.id = 'resource-list-content';
+                content.dataset.liveUrl = 'location';
+                document.body.append(content);
+            },
+            5,
+        ],
+        [
+            'wrong live contract',
+            () => {
+                const content = renderLivePage();
+                content.dataset.liveUrl = 'baked';
+            },
+            5,
+        ],
+        [
+            'missing list container',
+            () => {
+                const option = document.createElement('button');
+                option.dataset.roAction = 'set-refresh';
+                option.dataset.roInterval = 'Live';
+                document.body.append(option);
+            },
+            0,
+        ],
+    ] as const)('%s degrades without opening a stream', (_name, render, fallbackSeconds) => {
+        render();
+        const fetchMock = installAbortablePendingFetch();
+
+        liveApply();
+
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(liveState.status).toBe('fallback');
+        expect(liveState.streamPath).toBe('');
+        expect(liveFallbackSeconds()).toBe(fallbackSeconds);
+        expect(dependencies.scheduleRefreshTick).toHaveBeenCalledOnce();
+        expect(dependencies.markListStale).not.toHaveBeenCalled();
+    });
+});
+
+test('an idle state with the same page identity still opens a stream', () => {
+    window.history.replaceState(null, '', '/clusters/prod/pods');
+    renderLivePage();
+    const fetchMock = installAbortablePendingFetch();
+    liveState.status = 'idle';
+    liveState.streamPath = '/clusters/prod/pods/_stream';
+
+    liveApply();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(liveState.status).toBe('connecting');
+    expect(liveState.abort).not.toBeNull();
+});
+
+test('a changed page identity reopens without an explicit force', () => {
+    window.history.replaceState(null, '', '/clusters/prod/pods');
+    renderLivePage();
+    const fetchMock = installAbortablePendingFetch();
+    liveApply();
+    const first = liveState.abort;
+    window.history.replaceState(null, '', '/clusters/prod/services?sort=Name');
+
+    liveApply();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(first?.signal.aborted).toBe(true);
+    expect(liveState.streamPath).toBe('/clusters/prod/services/_stream?sort=Name');
+});
+
+test('a standing fallback is idempotent until an explicit retry', () => {
     renderLivePage(true);
     const fetchMock = installAbortablePendingFetch();
+    liveApply();
 
     liveApply();
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(liveState.status).toBe('fallback');
-    expect(liveState.streamPath).toBe('');
     expect(liveFallbackSeconds()).toBe(5);
     expect(dependencies.scheduleRefreshTick).toHaveBeenCalledOnce();
-    expect(dependencies.markListStale).not.toHaveBeenCalled();
 });
 
-test('liveOnListSwap ignores pushes and reopens from the exact request path', () => {
+test('switching Off cleans even an inconsistent idle fallback state', () => {
+    renderLivePage(true);
+    installAbortablePendingFetch();
+    liveApply();
+    expect(liveFallbackSeconds()).toBe(5);
+    liveState.status = 'idle';
+    dependencies.refreshMode.mockReturnValue('Off');
+
+    liveApply();
+
+    expect(liveState.status).toBe('idle');
+    expect(liveState.streamPath).toBe('');
+    expect(liveState.abort).toBeNull();
+    expect(liveFallbackSeconds()).toBe(0);
+});
+
+test('liveOnListSwap ignores pushes and every non-riding state', () => {
     window.history.replaceState(null, '', '/clusters/prod/pods?sort=Name');
     renderLivePage();
     const fetchMock = installAbortablePendingFetch();
     liveApply();
-    const first = liveState.abort;
 
     liveOnListSwap(new CustomEvent('htmx:afterSwap', { detail: { roLivePush: true } }));
     expect(fetchMock).toHaveBeenCalledOnce();
 
-    liveOnListSwap(
-        new CustomEvent('htmx:afterSwap', {
-            detail: {
-                pathInfo: {
-                    finalRequestPath: '/clusters/prod/pods/_table?f=status:Running,Pending',
-                },
+    for (const status of ['idle', 'fallback', 'hidden'] as const) {
+        liveState.status = status;
+        liveOnListSwap(new CustomEvent('htmx:afterSwap'));
+    }
+    expect(fetchMock).toHaveBeenCalledOnce();
+});
+
+describe.each(['connecting', 'open'] as const)('%s list swaps', (status) => {
+    test.each([
+        [
+            'prefers the final request path and preserves its raw query',
+            {
+                finalRequestPath: '/clusters/prod/pods/_table?f=status:Running,Pending',
+                requestPath: '/clusters/prod/pods/_table?f=wrong',
             },
-        }),
-    );
+            '/clusters/prod/pods/_stream?f=status:Running,Pending',
+        ],
+        [
+            'falls back to a queryless request path',
+            { requestPath: '/clusters/prod/services/_table' },
+            '/clusters/prod/services/_stream',
+        ],
+        [
+            'does not rewrite a table-looking query value',
+            { finalRequestPath: '/clusters/prod/pods?next=/_table' },
+            '/clusters/prod/pods/_stream?sort=Name',
+        ],
+        [
+            'uses the live location when pathInfo is absent',
+            undefined,
+            '/clusters/prod/pods/_stream?sort=Name',
+        ],
+        [
+            'uses the live location when the request path is not a string',
+            { finalRequestPath: 42 },
+            '/clusters/prod/pods/_stream?sort=Name',
+        ],
+        [
+            'uses the live location when a present detail has no path info',
+            null,
+            '/clusters/prod/pods/_stream?sort=Name',
+        ],
+    ] as const)('%s', (_name, pathInfo, expectedBase) => {
+        window.history.replaceState(null, '', '/clusters/prod/pods?sort=Name');
+        renderLivePage();
+        const fetchMock = installAbortablePendingFetch();
+        liveApply();
+        liveState.status = status;
+        const first = liveState.abort;
+        const detail = pathInfo === undefined ? undefined : { pathInfo: pathInfo ?? undefined };
 
-    const base = '/clusters/prod/pods/_stream?f=status:Running,Pending';
-    expect(first?.signal.aborted).toBe(true);
-    expect(liveState.streamPath).toBe(base);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(fetchMock.mock.calls[1][0]).toBe(`${base}&g=${liveState.gen}`);
+        liveOnListSwap(new CustomEvent('htmx:afterSwap', { detail }));
 
-    liveTeardown();
-    liveState.status = 'fallback';
-    liveOnListSwap(new CustomEvent('htmx:afterSwap'));
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(first?.signal.aborted).toBe(true);
+        expect(liveState.streamPath).toBe(expectedBase);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        const separator = expectedBase.includes('?') ? '&' : '?';
+        expect(fetchMock.mock.calls[1][0]).toBe(`${expectedBase}${separator}g=${liveState.gen}`);
+    });
 });
 
 test('a fetch connection failure enters silent polling fallback', async () => {
@@ -228,21 +427,123 @@ test('a fetch connection failure enters silent polling fallback', async () => {
     });
 
     liveApply();
+    const ctrl = liveState.abort;
 
     await vi.waitFor(() => expect(liveState.status).toBe('fallback'));
+    expect(ctrl?.signal.aborted).toBe(true);
+    expect(liveState.abort).toBeNull();
     expect(liveFallbackSeconds()).toBe(5);
     expect(dependencies.markListStale).not.toHaveBeenCalled();
     expect(dependencies.scheduleRefreshTick).toHaveBeenCalledTimes(2);
 });
 
-test.each([204, 429])('HTTP %s enters silent polling fallback', async (status) => {
+test.each([
+    ['HTTP 204 with no body', () => statusResponse(204)],
+    ['HTTP 429 with no body', () => statusResponse(429)],
+    ['HTTP 200 with no body', () => statusResponse(200)],
+    ['HTTP 503 even with a body', () => streamResponse([], 503)],
+] as const)('%s enters silent polling fallback', async (_name, response) => {
     renderLivePage();
-    installFetch(async () => statusResponse(status));
+    installFetch(async () => response());
 
     liveApply();
+    const ctrl = liveState.abort;
 
     await vi.waitFor(() => expect(liveState.status).toBe('fallback'));
+    expect(ctrl?.signal.aborted).toBe(true);
+    expect(liveState.abort).toBeNull();
     expect(liveFallbackSeconds()).toBe(5);
+    expect(dependencies.markListStale).not.toHaveBeenCalled();
+});
+
+test.each(['rejects', 'resolves'] as const)(
+    'a superseded connection that later %s cannot alter the replacement stream',
+    async (outcome) => {
+        const firstResponse = deferred<Response>();
+        const replacement = controlledStream();
+        renderLivePage();
+        let fetchCount = 0;
+        installFetch(() => {
+            fetchCount += 1;
+            return fetchCount === 1 ? firstResponse.promise : Promise.resolve(replacement.response);
+        });
+
+        liveApply();
+        const first = liveState.abort;
+        liveApply(true);
+        const second = liveState.abort;
+        await vi.waitFor(() => expect(liveState.status).toBe('open'));
+
+        if (outcome === 'rejects') {
+            firstResponse.reject(new Error('old connection failed'));
+        } else {
+            firstResponse.resolve(statusResponse(429));
+        }
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(first?.signal.aborted).toBe(true);
+        expect(second).not.toBeNull();
+        expect(liveState.abort).toBe(second);
+        expect(liveState.status).toBe('open');
+        expect(liveFallbackSeconds()).toBe(0);
+        expect(dependencies.scheduleRefreshTick).toHaveBeenCalledTimes(2);
+        expect(dependencies.markListStale).not.toHaveBeenCalled();
+        liveTeardown();
+        replacement.close();
+    },
+);
+
+test('a superseded reader goes inert before dispatching its next chunk', async () => {
+    const oldStream = controlledStream();
+    const replacement = controlledStream();
+    const content = renderLivePage();
+    const htmx = installHtmx();
+    let fetchCount = 0;
+    installFetch(async () => {
+        fetchCount += 1;
+        return fetchCount === 1 ? oldStream.response : replacement.response;
+    });
+
+    liveApply();
+    await vi.waitFor(() => expect(liveState.status).toBe('open'));
+    liveApply(true);
+    const replacementController = liveState.abort;
+    await vi.waitFor(() => expect(liveState.status).toBe('open'));
+
+    oldStream.enqueue(
+        `event: ro-table\ndata: ${JSON.stringify({ g: liveState.gen, html: '<p>old</p>' })}\n\n`,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(document.getElementById('resource-list-content')).toBe(content);
+    expect(htmx.swap).not.toHaveBeenCalled();
+    expect(liveState.abort).toBe(replacementController);
+    expect(liveState.status).toBe('open');
+    expect(liveFallbackSeconds()).toBe(0);
+    expect(dependencies.markListStale).not.toHaveBeenCalled();
+    liveTeardown();
+    replacement.close();
+});
+
+test('a stream closed after teardown cannot engage EOF fallback', async () => {
+    const stream = controlledStream();
+    renderLivePage();
+    installFetch(async () => stream.response);
+    liveApply();
+    await vi.waitFor(() => expect(liveState.status).toBe('open'));
+
+    liveTeardown();
+    liveState.status = 'hidden';
+    stream.close();
+    // Let the reader's EOF continuation finish, not merely the close promise's
+    // first microtask. The post-read supersession guard must own the outcome.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(liveState.status).toBe('hidden');
+    expect(liveFallbackSeconds()).toBe(0);
+    expect(dependencies.scheduleRefreshTick).toHaveBeenCalledOnce();
     expect(dependencies.markListStale).not.toHaveBeenCalled();
 });
 
@@ -254,23 +555,34 @@ test.each([
     installFetch(async () => streamResponse([...parts]));
 
     liveApply();
+    const ctrl = liveState.abort;
 
     await vi.waitFor(() => expect(liveState.status).toBe('fallback'));
+    expect(ctrl?.signal.aborted).toBe(true);
+    expect(liveState.abort).toBeNull();
     expect(liveFallbackSeconds()).toBe(5);
     expect(dependencies.markListStale).toHaveBeenCalledOnce();
 });
 
 test('an ro-terminal frame stops reading and enters banner polling fallback', async () => {
     renderLivePage();
-    installFetch(async () =>
-        streamResponse(['event: ro-terminal\r\ndata: {"g":"server","reason":"auth"}\r\n\r\n']),
-    );
+    const htmx = installHtmx();
+    installFetch(async () => {
+        const laterTable = JSON.stringify({ g: liveState.gen, html: '<p>must-not-land</p>' });
+        return streamResponse([
+            `event: ro-terminal\r\ndata: {"g":"server","reason":"auth"}\r\n\r\nevent: ro-table\r\ndata: ${laterTable}\r\n\r\n`,
+        ]);
+    });
 
     liveApply();
+    const ctrl = liveState.abort;
 
     await vi.waitFor(() => expect(liveState.status).toBe('fallback'));
+    expect(ctrl?.signal.aborted).toBe(true);
+    expect(liveState.abort).toBeNull();
     expect(liveFallbackSeconds()).toBe(5);
     expect(dependencies.markListStale).toHaveBeenCalledOnce();
+    expect(htmx.swap).not.toHaveBeenCalled();
 });
 
 test('parses split CRLF and multi-data frames, skips malformed payloads, and swaps exactly', async () => {
@@ -303,35 +615,300 @@ test('parses split CRLF and multi-data frames, skips malformed payloads, and swa
     );
 });
 
-describe.each(['stale-generation', 'wrong-page', 'request-in-flight'] as const)(
-    '%s discard',
-    (reason) => {
-        test('drops the full frame before htmx.swap and increments observability', async () => {
-            const response = deferred<Response>();
-            renderLivePage();
-            const htmx = installHtmx();
-            installFetch(() => response.promise);
-            window.history.replaceState(null, '', '/clusters/prod/pods');
-            liveApply();
-            const before = window.roLive.discards();
-            const generation =
-                reason === 'stale-generation' ? `${liveState.gen}.old` : liveState.gen;
+test('preserves split UTF-8 and data lines without the optional leading space', async () => {
+    const content = renderLivePage();
+    const htmx = installHtmx();
+    installFetch(async () => {
+        const frame = `event: ro-table\ndata:${JSON.stringify({
+            g: liveState.gen,
+            html: '<p>pod-🐝 keeps this space</p>',
+        })}\n\n`;
+        const encoded = new TextEncoder().encode(frame);
+        const beeStart = frame.indexOf('🐝');
+        const byteSplit = new TextEncoder().encode(frame.slice(0, beeStart)).length + 2;
+        return streamResponse([encoded.slice(0, byteSplit), encoded.slice(byteSplit)]);
+    });
 
-            if (reason === 'wrong-page') {
-                window.history.replaceState(null, '', '/clusters/prod/services');
-            }
-            if (reason === 'request-in-flight') {
-                dependencies.userRequests.add(xhrAt(1));
-            }
-            response.resolve(
-                streamResponse([
-                    `event: ro-table\ndata: ${JSON.stringify({ g: generation, html: '<p>wrong</p>' })}\n\n`,
-                ]),
-            );
+    liveApply();
 
-            await vi.waitFor(() => expect(window.roLive.discards()).toBe(before + 1));
-            expect(htmx.swap).not.toHaveBeenCalled();
-            expect(dependencies.pruneSettledListRequests).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() => expect(htmx.swap).toHaveBeenCalledOnce());
+    expect(htmx.swap).toHaveBeenCalledWith(
+        content,
+        '<p>pod-🐝 keeps this space</p>',
+        expect.anything(),
+        expect.anything(),
+    );
+});
+
+test('reads a Fetch body that exposes getReader without an async iterator', async () => {
+    const content = renderLivePage();
+    const htmx = installHtmx();
+    installFetch(async () => {
+        const payload = JSON.stringify({ g: liveState.gen, html: '<p>reader-only</p>' });
+        const response = readerOnlyResponse([`event: ro-table\ndata: ${payload}\n\n`]);
+        expect(Symbol.asyncIterator in (response.body as unknown as object)).toBe(false);
+        return response;
+    });
+
+    liveApply();
+
+    await vi.waitFor(() => expect(htmx.swap).toHaveBeenCalledOnce());
+    expect(htmx.swap).toHaveBeenCalledWith(
+        content,
+        '<p>reader-only</p>',
+        expect.anything(),
+        expect.anything(),
+    );
+});
+
+test('rejects JSON made valid only by illegally concatenating SSE data lines', async () => {
+    renderLivePage();
+    const htmx = installHtmx();
+    installFetch(async () => {
+        const invalid = JSON.stringify({
+            g: liveState.gen,
+            html: '<p>must-not-land</p>',
         });
+        const split = invalid.indexOf('not-land');
+        const valid = JSON.stringify({ g: liveState.gen, html: '<p>fresh</p>' });
+        return streamResponse([
+            `event: ro-table\ndata:${invalid.slice(0, split)}\ndata:${invalid.slice(split)}\n\n` +
+                `event: ro-table\ndata:${valid}\n\n`,
+        ]);
+    });
+
+    liveApply();
+
+    await vi.waitFor(() => expect(liveState.status).toBe('fallback'));
+    expect(htmx.swap).toHaveBeenCalledExactlyOnceWith(
+        expect.any(Element),
+        '<p>fresh</p>',
+        expect.anything(),
+        expect.anything(),
+    );
+});
+
+test('skips empty, malformed, wrong-event, and schema-invalid frames, then keeps reading', async () => {
+    renderLivePage();
+    const htmx = installHtmx();
+    installFetch(async () => {
+        const invalidFrames = [
+            'event: ro-terminal\ndata: []\n\n',
+            'event: ro-terminal\ndata: "scalar"\n\n',
+            'event: ro-table\ndata: null\n\n',
+            'event: ro-table\ndata: "scalar"\n\n',
+            'event: ro-table\ndata: {}\n\n',
+            `event: ro-table\ndata: ${JSON.stringify({ g: 7, html: '<p>number-g</p>' })}\n\n`,
+            `event: ro-table\ndata: ${JSON.stringify({ g: liveState.gen })}\n\n`,
+            `event: ro-table\ndata: ${JSON.stringify({ g: liveState.gen, html: null })}\n\n`,
+            `event: ignored\ndata: ${JSON.stringify({ g: liveState.gen, html: '<p>wrong-event</p>' })}\n\n`,
+            `event: ro-table\njunk:${JSON.stringify({ g: liveState.gen, html: '<p>wrong-field</p>' })}\n\n`,
+            'event: ro-table\n\n',
+            'event: ro-table\ndata: {broken}\n\n',
+        ];
+        const first = JSON.stringify({ g: liveState.gen, html: '<p>first-valid</p>' });
+        const second = JSON.stringify({ g: liveState.gen, html: '<p>second-valid</p>' });
+        return streamResponse([
+            `${invalidFrames.join('')}event: ro-table\ndata: ${first}\n\nevent: ro-table\ndata: ${second}\n\n`,
+        ]);
+    });
+
+    liveApply();
+
+    await vi.waitFor(() => expect(htmx.swap).toHaveBeenCalledTimes(2));
+    expect(htmx.swap.mock.calls.map((call) => call[1])).toStrictEqual([
+        '<p>first-valid</p>',
+        '<p>second-valid</p>',
+    ]);
+});
+
+test('a discarded generation does not stop the following fresh snapshot', async () => {
+    renderLivePage();
+    const htmx = installHtmx();
+    const before = window.roLive.discards();
+    installFetch(async () => {
+        const stale = JSON.stringify({ g: `${liveState.gen}.old`, html: '<p>old</p>' });
+        const fresh = JSON.stringify({ g: liveState.gen, html: '<p>fresh</p>' });
+        return streamResponse([
+            `event: ro-table\ndata: ${stale}\n\nevent: ro-table\ndata: ${fresh}\n\n`,
+        ]);
+    });
+
+    liveApply();
+
+    await vi.waitFor(() => expect(htmx.swap).toHaveBeenCalledOnce());
+    expect(window.roLive.discards()).toBe(before + 1);
+    expect(htmx.swap.mock.calls[0][1]).toBe('<p>fresh</p>');
+});
+
+test.each(['missing-content', 'missing-htmx', 'non-callable-swap'] as const)(
+    '%s safely ignores an otherwise valid pushed fragment',
+    async (missing) => {
+        const content = renderLivePage();
+        const stream = controlledStream();
+        const swap = vi.fn();
+        if (missing === 'missing-htmx') {
+            delete (window as unknown as { htmx?: HtmxHarness }).htmx;
+        } else if (missing === 'non-callable-swap') {
+            (window as unknown as { htmx: { swap: null } }).htmx = { swap: null };
+        } else {
+            (window as unknown as { htmx: HtmxHarness }).htmx = { swap };
+        }
+        installFetch(async () => stream.response);
+        liveApply();
+        await vi.waitFor(() => expect(liveState.status).toBe('open'));
+        if (missing === 'missing-content') {
+            content.remove();
+        }
+
+        stream.enqueue(
+            `event: ro-table\ndata: ${JSON.stringify({ g: liveState.gen, html: '<p>fresh</p>' })}\n\n`,
+        );
+
+        await vi.waitFor(() =>
+            expect(dependencies.pruneSettledListRequests).toHaveBeenCalledTimes(2),
+        );
+        await Promise.resolve();
+        expect(swap).not.toHaveBeenCalled();
+        expect(liveState.status).toBe('open');
+        expect(liveFallbackSeconds()).toBe(0);
+        liveTeardown();
+        stream.close();
     },
 );
+
+describe.each([
+    'stale-generation',
+    'wrong-page',
+    'user-request-in-flight',
+    'container-request-in-flight',
+] as const)('%s discard', (reason) => {
+    test('drops the full frame before htmx.swap and increments observability', async () => {
+        const response = deferred<Response>();
+        renderLivePage();
+        const htmx = installHtmx();
+        installFetch(() => response.promise);
+        window.history.replaceState(null, '', '/clusters/prod/pods');
+        liveApply();
+        const before = window.roLive.discards();
+        const generation = reason === 'stale-generation' ? `${liveState.gen}.old` : liveState.gen;
+
+        if (reason === 'wrong-page') {
+            window.history.replaceState(null, '', '/clusters/prod/services');
+        }
+        if (reason === 'user-request-in-flight') {
+            dependencies.userRequests.add(xhrAt(1));
+        }
+        if (reason === 'container-request-in-flight') {
+            dependencies.containerRequests.add(xhrAt(1));
+        }
+        response.resolve(
+            streamResponse([
+                `event: ro-table\ndata: ${JSON.stringify({ g: generation, html: '<p>wrong</p>' })}\n\n`,
+            ]),
+        );
+
+        await vi.waitFor(() => expect(window.roLive.discards()).toBe(before + 1));
+        expect(htmx.swap).not.toHaveBeenCalled();
+        expect(dependencies.pruneSettledListRequests).toHaveBeenCalledTimes(2);
+    });
+});
+
+test('settled requests are pruned and do not block a fresh frame', async () => {
+    renderLivePage();
+    const htmx = installHtmx();
+    dependencies.userRequests.add(xhrAt(4));
+    dependencies.containerRequests.add(xhrAt(0));
+    installFetch(async () => {
+        const payload = JSON.stringify({ g: liveState.gen, html: '<p>fresh</p>' });
+        return streamResponse([`event: ro-table\ndata: ${payload}\n\n`]);
+    });
+
+    liveApply();
+
+    await vi.waitFor(() => expect(htmx.swap).toHaveBeenCalledOnce());
+    expect(dependencies.userRequests).toHaveLength(0);
+    expect(dependencies.containerRequests).toHaveLength(0);
+    expect(dependencies.pruneSettledListRequests).toHaveBeenCalledTimes(2);
+});
+
+describe('visibility lifecycle', () => {
+    test.each(['open', 'connecting'] as const)('hiding a %s stream closes it', (status) => {
+        vi.spyOn(document, 'hidden', 'get').mockReturnValue(true);
+        const ctrl = new AbortController();
+        liveState.status = status;
+        liveState.abort = ctrl;
+        liveState.streamPath = '/clusters/prod/pods/_stream';
+
+        document.dispatchEvent(new Event('visibilitychange'));
+
+        expect(ctrl.signal.aborted).toBe(true);
+        expect(liveState.abort).toBeNull();
+        expect(liveState.status).toBe('hidden');
+        expect(liveFallbackSeconds()).toBe(0);
+    });
+
+    test.each(['idle', 'fallback', 'hidden'] as const)(
+        'hiding leaves the %s state untouched',
+        (status) => {
+            vi.spyOn(document, 'hidden', 'get').mockReturnValue(true);
+            const ctrl = new AbortController();
+            liveState.status = status;
+            liveState.abort = ctrl;
+
+            document.dispatchEvent(new Event('visibilitychange'));
+
+            expect(ctrl.signal.aborted).toBe(false);
+            expect(liveState.abort).toBe(ctrl);
+            expect(liveState.status).toBe(status);
+        },
+    );
+
+    test('showing a hidden Live stream reopens it', () => {
+        vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+        window.history.replaceState(null, '', '/clusters/prod/pods?sort=Name');
+        renderLivePage();
+        const fetchMock = installAbortablePendingFetch();
+        liveState.status = 'hidden';
+        liveState.streamPath = '/clusters/prod/pods/_stream?sort=Name';
+
+        document.dispatchEvent(new Event('visibilitychange'));
+
+        expect(fetchMock).toHaveBeenCalledOnce();
+        expect(liveState.status).toBe('connecting');
+        expect(liveState.streamPath).toBe('/clusters/prod/pods/_stream?sort=Name');
+    });
+
+    test.each([
+        ['hidden but Off', 'hidden', 'Off'],
+        ['fallback while Live', 'fallback', 'Live'],
+        ['idle while Live', 'idle', 'Live'],
+    ] as const)('showing %s does not open a stream', (_name, status, mode) => {
+        vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+        renderLivePage();
+        const fetchMock = installAbortablePendingFetch();
+        dependencies.refreshMode.mockReturnValue(mode);
+        liveState.status = status;
+
+        document.dispatchEvent(new Event('visibilitychange'));
+
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(liveState.status).toBe(status);
+    });
+
+    test('showing a hidden stream on a now-unsupported page enters fallback', () => {
+        vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+        renderLivePage(true);
+        const fetchMock = installAbortablePendingFetch();
+        liveState.status = 'hidden';
+        liveState.streamPath = '/clusters/prod/pods/_stream';
+
+        document.dispatchEvent(new Event('visibilitychange'));
+
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(liveState.status).toBe('fallback');
+        expect(liveState.streamPath).toBe('');
+        expect(liveFallbackSeconds()).toBe(5);
+        expect(dependencies.scheduleRefreshTick).toHaveBeenCalledOnce();
+    });
+});

--- a/internal/assets/src/js/live.module.dom.test.ts
+++ b/internal/assets/src/js/live.module.dom.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import { expect, test, vi } from 'vitest';
+
+const dependencies = vi.hoisted(() => ({
+    containerRequests: new Set<XMLHttpRequest>(),
+    markListStale: vi.fn(),
+    pruneSettledListRequests: vi.fn(),
+    refreshMode: vi.fn(() => 'Live'),
+    scheduleRefreshTick: vi.fn(),
+    userRequests: new Set<XMLHttpRequest>(),
+}));
+
+vi.mock('./refresh.js', () => ({
+    containerListRequestsInFlight: dependencies.containerRequests,
+    pruneSettledListRequests: dependencies.pruneSettledListRequests,
+    refreshMode: dependencies.refreshMode,
+    scheduleRefreshTick: dependencies.scheduleRefreshTick,
+    userListRequestsInFlight: dependencies.userRequests,
+}));
+vi.mock('./stale.js', () => ({
+    markListStale: dependencies.markListStale,
+}));
+
+test('module load publishes clean state and registers the visibility lifecycle', async () => {
+    vi.resetModules();
+    const addEventListener = vi.spyOn(document, 'addEventListener');
+
+    const { liveFallbackSeconds, liveState } = await import('./live.js');
+
+    expect(liveState).toStrictEqual({
+        status: 'idle',
+        abort: null,
+        gen: '',
+        streamPath: '',
+    });
+    expect(liveFallbackSeconds()).toBe(0);
+    expect(window.roLive.discards()).toBe(0);
+    expect(addEventListener).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+
+    const ctrl = new AbortController();
+    liveState.status = 'connecting';
+    liveState.abort = ctrl;
+    vi.spyOn(document, 'hidden', 'get').mockReturnValue(true);
+
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(ctrl.signal.aborted).toBe(true);
+    expect(liveState.abort).toBeNull();
+    expect(liveState.status).toBe('hidden');
+});

--- a/internal/assets/src/js/live.ts
+++ b/internal/assets/src/js/live.ts
@@ -70,7 +70,6 @@ export const liveState: {
     gen: '', // the minted generation every frame must echo (string compare)
     streamPath: '', // the stream URL sans ?g= -- the page/params identity
 };
-let liveGenSeq = 0;
 // liveDiscards counts ro-table frames DISCARDED at morph time (stale
 // generation, wrong page identity, in-flight `_table` request). Exposed via the
 // window.roLive debug seam so the e2e suite can await "the push arrived AND was
@@ -125,11 +124,7 @@ export function liveTeardown(): void {
     liveState.abort = null;
     liveFallbackSecs = 0;
     if (ctrl) {
-        try {
-            ctrl.abort();
-        } catch {
-            // already settled -- nothing to abort
-        }
+        ctrl.abort();
     }
 }
 
@@ -153,26 +148,25 @@ function liveEngageFallback(banner: boolean): void {
 // -- is what makes the morph-time echo check sufficient.
 function liveOpen(base: string): void {
     liveTeardown();
-    liveFallbackSecs = 0;
     liveState.streamPath = base;
     if (!base) {
         liveEngageFallback(false);
         return;
     }
     liveState.status = 'connecting';
-    liveGenSeq += 1;
-    liveState.gen = `${Date.now().toString(36)}.${liveGenSeq}`;
+    liveState.gen = window.crypto.getRandomValues(new Uint32Array(4)).toString();
     const ctrl = new AbortController();
     liveState.abort = ctrl;
-    const url = `${base + (base.indexOf('?') === -1 ? '?' : '&')}g=${encodeURIComponent(liveState.gen)}`;
+    const separator = base.includes('?') ? '&' : '?';
+    const url = `${base}${separator}g=${liveState.gen}`;
     scheduleRefreshTick(); // effective cadence is 0 now -> the poll chain disarms
     void liveConnect(url, ctrl);
 }
 
 // liveConnect is the transport core: a streaming fetch + an SSE line parser.
 // Frames are `event: <name>` + `data: <one JSON line>` + a blank line. Every
-// await resumption re-checks the supersession token; all exits funnel into the
-// taxonomy (classifyStreamClose).
+// await resumption re-checks the supersession token; equivalent read-error/EOF
+// exits share one banner-fallback path.
 async function liveConnect(url: string, ctrl: AbortController): Promise<void> {
     let res: Response;
     try {
@@ -193,48 +187,56 @@ async function liveConnect(url: string, ctrl: AbortController): Promise<void> {
     const reader = res.body.getReader();
     const decoder = new TextDecoder();
     let buffered = '';
-    let eventName = '';
-    let dataText = '';
-    try {
-        for (;;) {
-            const chunk = await reader.read();
-            if (liveState.abort !== ctrl) {
-                return; // torn down while awaiting -- go inert
-            }
-            if (chunk.done) {
-                break;
-            }
-            buffered += decoder.decode(chunk.value, { stream: true });
-            let nl = buffered.indexOf('\n');
-            while (nl !== -1) {
-                const line = buffered.slice(0, nl).replace(/\r$/, '');
-                buffered = buffered.slice(nl + 1);
-                if (line === '') {
-                    const ended = liveHandleFrame(eventName, dataText, ctrl);
-                    eventName = '';
-                    dataText = '';
-                    if (ended || liveState.abort !== ctrl) {
-                        return; // terminal handled (or superseded mid-frame)
-                    }
-                } else if (line.indexOf('event:') === 0) {
-                    eventName = line.slice(6).trim();
-                } else if (line.indexOf('data:') === 0) {
-                    const piece = line.slice(5).replace(/^ /, '');
-                    dataText = dataText === '' ? piece : `${dataText}\n${piece}`;
+    let eventName: string | null = null;
+    let dataLines: string[] = [];
+    const readAndHandleChunk = async (): Promise<Uint8Array | undefined> => {
+        const chunk = await reader.read();
+        if (liveState.abort !== ctrl) {
+            return; // torn down while awaiting -- go inert
+        }
+        // EOF has no value. Dereferencing the spec-mandated Uint8Array maps EOF
+        // (and a malformed value-less result) into the same caught close path as
+        // a reader rejection, without another unconditional read iteration.
+        const value = chunk.value as Uint8Array;
+        buffered += decoder.decode(value.subarray(), { stream: true });
+        const completeLines = buffered.split('\n');
+        buffered = completeLines.pop() as string;
+        for (const rawLine of completeLines) {
+            // Splitting CRLF on LF leaves a lone CR for the blank frame
+            // delimiter. Event names are trimmed below and JSON accepts a
+            // trailing CR, so normalizing every field line is redundant.
+            const line = rawLine === '\r' ? '' : rawLine;
+            if (line.length === 0) {
+                liveHandleFrame(eventName, dataLines.join('\n'));
+                eventName = null;
+                dataLines = [];
+                if (liveState.abort !== ctrl) {
+                    return; // terminal handled (or superseded mid-frame)
                 }
-                nl = buffered.indexOf('\n');
+            } else if (line.startsWith('event:')) {
+                eventName = line.slice(6).trim();
+            } else if (line.startsWith('data:')) {
+                // JSON accepts the SSE field's optional leading space, so
+                // keep the payload bytes and avoid a redundant normalization.
+                dataLines.push(line.slice(5));
             }
         }
+        return value;
+    };
+    try {
+        // Each condition evaluation consumes exactly one reader result. EOF,
+        // supersession, and terminal frames therefore stop the loop without an
+        // unconditional body that could spin independently of the stream.
+        while (await readAndHandleChunk()) {}
     } catch {
-        applyClose({ superseded: liveState.abort !== ctrl, cause: 'read-error' });
-        return;
+        // A reader error and a terminal-less EOF have the same user-visible
+        // outcome: the last good table stays visible and 5s fallback polling
+        // takes over. Fall through to that shared close path.
     }
     if (liveState.abort !== ctrl) {
         return;
     }
-    // The server closed without a terminal frame (its graceful paths always send
-    // one): treat it like a terminal -- banner + 5s polling.
-    applyClose({ superseded: false, cause: 'eof' });
+    liveEngageFallback(true);
 }
 
 // applyClose maps a close fact to its action via the pure taxonomy. 'ignore'
@@ -247,31 +249,31 @@ function applyClose(facts: Parameters<typeof classifyStreamClose>[0]): void {
     liveEngageFallback(action.banner);
 }
 
-// liveHandleFrame dispatches one parsed SSE frame. Returns true when the stream
-// must stop reading (a terminal was handled). THE morph-time gates live here:
+// liveHandleFrame dispatches one parsed SSE frame. THE morph-time gates live here:
 // the generation echo, the page identity, and the in-flight `_table` check all
 // run at dispatch -- which IS morph time, synchronously before htmx.swap -- so
 // a stale or racing push is dropped whole (shouldDiscardPush), never queued.
-function liveHandleFrame(name: string, text: string, ctrl: AbortController): boolean {
-    if (liveState.abort !== ctrl || text === '') {
-        return false;
-    }
-    let payload: { g?: unknown; html?: unknown } | null = null;
+function liveHandleFrame(name: string | null, text: string): void {
+    let parsed: unknown;
     try {
-        payload = JSON.parse(text);
+        parsed = JSON.parse(text);
     } catch {
-        return false; // malformed frame -> skipped (the next push is a full snapshot)
+        // Malformed frames are skipped; every later push is a full snapshot.
     }
-    if (!payload || typeof payload !== 'object') {
-        return false;
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return;
     }
+    const payload = parsed as { g?: unknown; html?: unknown };
     if (name === 'ro-terminal') {
         // idle / auth / watch-failed / shutdown: close WITHOUT reconnecting.
         applyClose({ superseded: false, cause: 'terminal-frame' });
-        return true;
+        return;
     }
     if (name !== 'ro-table') {
-        return false;
+        return;
+    }
+    if (typeof payload.g !== 'string' || typeof payload.html !== 'string') {
+        return;
     }
     pruneSettledListRequests(userListRequestsInFlight);
     pruneSettledListRequests(containerListRequestsInFlight);
@@ -285,21 +287,28 @@ function liveHandleFrame(name: string, text: string, ctrl: AbortController): boo
     // container), and the Go wrong-page-gate contract pins exactly that form in
     // the bundle (internal/web/list_redesign_test.go).
     const reason = shouldDiscardPush({
-        frameGeneration: String(payload.g),
+        frameGeneration: payload.g,
         currentGeneration: liveState.gen,
-        liveStreamBase: liveStreamBase(),
+        // The Go bundle contract pins the literal page comparison below. Feed
+        // equal page identities here so the policy supplies the first and third
+        // ordered gates (generation, then request); the literal supplies the
+        // page gate between them without evaluating it twice.
+        liveStreamBase: liveState.streamPath,
         openedStreamBase: liveState.streamPath,
         requestInFlight:
             userListRequestsInFlight.size > 0 || containerListRequestsInFlight.size > 0,
     });
-    if (reason !== 'none' || liveStreamBase() !== liveState.streamPath) {
+    if (
+        reason === 'stale-generation' ||
+        liveStreamBase() !== liveState.streamPath ||
+        reason === 'request-in-flight'
+    ) {
         // STALE GENERATION / WRONG PAGE / a _table request in flight -> dropped
         // whole at morph time, never deferred (every push is a full snapshot).
         liveDiscards += 1;
-        return false;
+        return;
     }
-    liveMorph(String(payload.html));
-    return false;
+    liveMorph(payload.html);
 }
 
 // liveMorph swaps one pushed fragment into the list container through the htmx
@@ -339,10 +348,14 @@ export function liveOnListSwap(event: Event): void {
         return;
     }
     let base = liveStreamBase();
-    const pathInfo = detail?.pathInfo;
-    const requestPath = pathInfo && (pathInfo.finalRequestPath || pathInfo.requestPath);
-    if (requestPath && requestPath.indexOf('/_table') !== -1) {
-        base = requestPath.replace('/_table', '/_stream');
+    const requestPath = detail?.pathInfo?.finalRequestPath || detail?.pathInfo?.requestPath;
+    if (typeof requestPath === 'string') {
+        const queryStart = requestPath.indexOf('?');
+        const pathname = queryStart === -1 ? requestPath : requestPath.slice(0, queryStart);
+        if (pathname.endsWith('/_table')) {
+            const query = queryStart === -1 ? '' : requestPath.slice(queryStart);
+            base = `${pathname.slice(0, -'/_table'.length)}/_stream${query}`;
+        }
     }
     liveOpen(base);
 }
@@ -353,12 +366,9 @@ export function liveOnListSwap(event: Event): void {
 // `force` (the explicit dropdown pick) always reopens.
 export function liveApply(force?: boolean): void {
     if (refreshMode() !== 'Live') {
-        if (liveState.status !== 'idle') {
-            liveTeardown();
-            liveState.status = 'idle';
-            liveState.streamPath = '';
-            liveFallbackSecs = 0;
-        }
+        liveTeardown();
+        liveState.status = 'idle';
+        liveState.streamPath = '';
         return;
     }
     const base = liveSupported() ? liveStreamBase() : '';

--- a/internal/assets/src/js/logs.dom.test.ts
+++ b/internal/assets/src/js/logs.dom.test.ts
@@ -40,6 +40,16 @@ beforeEach(() => {
 });
 
 describe('logs follow mode', () => {
+    test('exports the delegated logs event contract', () => {
+        expect(
+            logsBindings.map(({ event, selector, stop }) => ({ event, selector, stop })),
+        ).toStrictEqual([
+            { event: 'click', selector: '#logFollow', stop: true },
+            { event: 'change', selector: '#logTs', stop: true },
+            { event: 'change', selector: '#logWrap', stop: true },
+        ]);
+    });
+
     test('initializes an active stream at the tail and ignores quiet mode', () => {
         const { follow, pre } = renderLogs();
         initLogsFollow();
@@ -54,19 +64,30 @@ describe('logs follow mode', () => {
     test('toggles label and aria, snapping only when follow is re-enabled', () => {
         const { follow, pre } = renderLogs();
         const followBinding = binding('#logFollow');
+        pre.scrollTop = 17;
 
         expect(followBinding.handler(new MouseEvent('click'), follow)).toBe(true);
         expect(followBinding.stop).toBe(true);
         expect(follow).toHaveClass('quiet');
         expect(follow).toHaveAttribute('aria-pressed', 'false');
-        expect(follow.querySelector('.follow-label')).toHaveTextContent('Follow');
+        expect(follow.querySelector('.follow-label')?.textContent).toBe('Follow');
+        expect(pre.scrollTop).toBe(17);
 
         pre.scrollTop = 12;
         followBinding.handler(new MouseEvent('click'), follow);
         expect(follow).not.toHaveClass('quiet');
         expect(follow).toHaveAttribute('aria-pressed', 'true');
-        expect(follow.querySelector('.follow-label')).toHaveTextContent('Following');
+        expect(follow.querySelector('.follow-label')?.textContent).toBe('Following');
         expect(pre.scrollTop).toBe(640);
+    });
+
+    test('still toggles follow state when its optional label is absent', () => {
+        const { follow } = renderLogs();
+        follow.querySelector('.follow-label')?.remove();
+
+        expect(() => binding('#logFollow').handler(new MouseEvent('click'), follow)).not.toThrow();
+        expect(follow).toHaveClass('quiet');
+        expect(follow).toHaveAttribute('aria-pressed', 'false');
     });
 });
 
@@ -95,6 +116,17 @@ describe('logs display controls', () => {
 
         expect(pre).toHaveClass('wrap');
         expect(pre.scrollTop).toBe(25);
+    });
+
+    test('wrap repins a stream whose follow mode is active', () => {
+        const { pre, wrap } = renderLogs();
+        pre.scrollTop = 25;
+        wrap.checked = true;
+
+        expect(binding('#logWrap').handler(new Event('change'), wrap)).toBe(true);
+
+        expect(pre).toHaveClass('wrap');
+        expect(pre.scrollTop).toBe(640);
     });
 
     test('all operations degrade safely when the stream element is absent', () => {

--- a/internal/assets/src/js/misc-ui.dom.test.ts
+++ b/internal/assets/src/js/misc-ui.dom.test.ts
@@ -33,6 +33,23 @@ function setClipboard(writeText?: (text: string) => Promise<void>): void {
     });
 }
 
+test('binding descriptors preserve their dispatcher event, selector, and stop contracts', () => {
+    expect(miscBindings.map(({ event, selector, stop }) => [event, selector, stop])).toStrictEqual([
+        ['click', '[data-ro-action="toggle-sidebar"]', true],
+        ['click', '[data-ro-action="copy"]', true],
+        ['click', 'main .collapsible h4.title', true],
+        ['click', '#namespace-dropdown [data-ro-action="pick-namespace"]', true],
+        ['click', '#namespace-dropdown .context-trigger', true],
+        ['input', '#namespace-searchbox', true],
+        ['keyup', '#namespace-searchbox', true],
+        ['click', '[data-ro-more]', true],
+        ['click', '[data-ro-annolong]', true],
+        ['click', '[data-ro-action="toggle-tools"]', true],
+        ['change', 'input[data-ro-toggle-button]', true],
+        ['submit', 'form.tools-form', undefined],
+    ]);
+});
+
 function renderCopySection(): { button: HTMLElement; label: HTMLElement } {
     document.body.innerHTML = `
         <main>
@@ -137,6 +154,19 @@ describe('sidebar and copy controls', () => {
         vi.advanceTimersByTime(1500);
         expect(button.querySelector('.ro-copy-text')).toHaveTextContent('copy');
     });
+
+    test('falls back safely when YAML exists but the Clipboard API is absent', () => {
+        vi.useFakeTimers();
+        const { button, label } = renderCopySection();
+        const event = clickEvent();
+
+        expect(binding('click', '[data-ro-action="copy"]').handler(event, button)).toBe(true);
+        expect(event.defaultPrevented).toBe(true);
+        expect(label).toHaveTextContent('press ⌘C');
+
+        vi.advanceTimersByTime(1500);
+        expect(label).toHaveTextContent('copy');
+    });
 });
 
 describe('section collapse and hash state', () => {
@@ -172,8 +202,10 @@ describe('section collapse and hash state', () => {
         window.history.replaceState(null, '', '/objects?kind=pods');
         const titles = document.querySelectorAll('h4.title');
         const fold = binding('click', 'main .collapsible h4.title');
+        const foldEvent = clickEvent();
 
-        expect(fold.handler(clickEvent(), titles[0])).toBe(true);
+        expect(fold.handler(foldEvent, titles[0])).toBe(true);
+        expect(foldEvent.defaultPrevented).toBe(false);
         expect(titles[0].closest('.collapsible')).toHaveClass('is-collapsed');
         expect(window.location.hash).toBe('#collapsed=alpha,beta');
 
@@ -182,6 +214,17 @@ describe('section collapse and hash state', () => {
 
         fold.handler(clickEvent(), titles[1]);
         expect(window.location.href).toBe('https://readout.test/objects?kind=pods');
+    });
+
+    test('a detached title remains a safe stopped no-op', () => {
+        document.body.innerHTML = '<h4 class="title">Detached</h4>';
+        window.history.replaceState(null, '', '/objects#collapsed=alpha');
+        const title = document.querySelector('h4.title') as HTMLElement;
+
+        expect(binding('click', 'main .collapsible h4.title').handler(clickEvent(), title)).toBe(
+            true,
+        );
+        expect(window.location.hash).toBe('#collapsed=alpha');
     });
 });
 
@@ -192,6 +235,9 @@ describe('namespace dropdown', () => {
                 <a id="valid" data-ro-action="pick-namespace"
                     href="/clusters/prod%20east/namespaces/team%2Fblue/pods">Team</a>
                 <a id="invalid" data-ro-action="pick-namespace" href="/clusters">Invalid</a>
+                <a id="embedded" data-ro-action="pick-namespace"
+                    href="/prefix/clusters/prod/namespaces/team/pods">Embedded</a>
+                <a id="missing" data-ro-action="pick-namespace">Missing</a>
             </div>
         `;
         const pick = binding('click', '#namespace-dropdown [data-ro-action="pick-namespace"]');
@@ -203,6 +249,8 @@ describe('namespace dropdown', () => {
         expect(preferences.setNamespace).toHaveBeenCalledExactlyOnceWith('prod east', 'team/blue');
 
         pick.handler(clickEvent(), document.getElementById('invalid'));
+        pick.handler(clickEvent(), document.getElementById('embedded'));
+        pick.handler(clickEvent(), document.getElementById('missing'));
         expect(preferences.setNamespace).toHaveBeenCalledOnce();
     });
 
@@ -217,13 +265,25 @@ describe('namespace dropdown', () => {
         const trigger = dropdown.querySelector('.context-trigger') as HTMLElement;
         const search = document.getElementById('namespace-searchbox') as HTMLInputElement;
         const toggle = binding('click', '#namespace-dropdown .context-trigger');
+        const focus = vi.spyOn(search, 'focus');
 
-        toggle.handler(clickEvent(), trigger);
+        expect(toggle.handler(clickEvent(), trigger)).toBe(true);
         expect(dropdown).toHaveClass('is-active');
         expect(document.activeElement).toBe(search);
+        expect(focus).toHaveBeenCalledOnce();
 
-        toggle.handler(clickEvent(), trigger);
+        expect(toggle.handler(clickEvent(), trigger)).toBe(true);
         expect(dropdown).not.toHaveClass('is-active');
+        expect(focus).toHaveBeenCalledOnce();
+    });
+
+    test('a detached dropdown trigger remains a safe stopped no-op', () => {
+        document.body.innerHTML = '<button class="context-trigger">Namespaces</button>';
+        const trigger = document.querySelector('.context-trigger') as HTMLElement;
+
+        expect(
+            binding('click', '#namespace-dropdown .context-trigger').handler(clickEvent(), trigger),
+        ).toBe(true);
     });
 
     test('filters case-insensitively and Enter clicks the first visible namespace', () => {
@@ -243,22 +303,44 @@ describe('namespace dropdown', () => {
         links[1].innerText = 'Development';
         links[2].innerText = 'Developer Tools';
         const clicks = links.map((link) => vi.spyOn(link, 'click').mockImplementation(() => {}));
-        search.value = 'DEV';
+        const filter = binding('input', '#namespace-searchbox');
+        search.value = 'prod';
 
-        binding('input', '#namespace-searchbox').handler(new InputEvent('input'), search);
+        expect(filter.handler(new InputEvent('input'), search)).toBe(true);
+
+        expect(links[0]).not.toHaveClass('is-hidden');
+        expect(links[1]).toHaveClass('is-hidden');
+        expect(links[2]).toHaveClass('is-hidden');
+
+        search.value = 'DEV';
+        expect(filter.handler(new InputEvent('input'), search)).toBe(true);
 
         expect(links[0]).toHaveClass('is-hidden');
         expect(links[1]).not.toHaveClass('is-hidden');
         expect(links[2]).not.toHaveClass('is-hidden');
 
         const enter = binding('keyup', '#namespace-searchbox');
-        enter.handler(new KeyboardEvent('keyup', { key: 'Escape' }), search);
+        expect(enter.handler(new KeyboardEvent('keyup', { key: 'Escape' }), search)).toBe(true);
         expect(clicks.every((click) => click.mock.calls.length === 0)).toBe(true);
 
-        enter.handler(new KeyboardEvent('keyup', { key: 'Enter' }), search);
+        expect(enter.handler(new KeyboardEvent('keyup', { key: 'Enter' }), search)).toBe(true);
         expect(clicks[0]).not.toHaveBeenCalled();
         expect(clicks[1]).toHaveBeenCalledOnce();
         expect(clicks[2]).not.toHaveBeenCalled();
+
+        clicks.forEach((click) => {
+            click.mockClear();
+        });
+        links.forEach((link) => {
+            link.classList.add('is-hidden');
+        });
+        expect(enter.handler(new KeyboardEvent('keyup', { key: 'Enter' }), search)).toBe(true);
+        expect(clicks.every((click) => click.mock.calls.length === 0)).toBe(true);
+
+        links.forEach((link) => {
+            link.remove();
+        });
+        expect(enter.handler(new KeyboardEvent('keyup', { key: 'Enter' }), search)).toBe(true);
     });
 });
 
@@ -273,13 +355,15 @@ describe('transient detail controls', () => {
         const more = binding('click', '[data-ro-more]');
         const openEvent = clickEvent();
 
-        more.handler(openEvent, button);
+        expect(more.handler(openEvent, button)).toBe(true);
         expect(openEvent).toHaveProperty('defaultPrevented', true);
         expect(chips).toHaveClass('expanded');
         expect(document.getElementById('second')).not.toHaveClass('expanded');
         expect(button).toHaveAttribute('aria-expanded', 'true');
 
-        more.handler(clickEvent(), button);
+        const closeEvent = clickEvent();
+        expect(more.handler(closeEvent, button)).toBe(true);
+        expect(closeEvent.defaultPrevented).toBe(true);
         expect(chips).not.toHaveClass('expanded');
         expect(button).toHaveAttribute('aria-expanded', 'false');
     });
@@ -294,13 +378,17 @@ describe('transient detail controls', () => {
         const button = document.querySelector('[data-ro-annolong]') as HTMLElement;
         const pre = document.querySelector('.anno-pre') as HTMLElement;
         const annotation = binding('click', '[data-ro-annolong]');
+        const openEvent = clickEvent();
 
-        annotation.handler(clickEvent(), button);
+        expect(annotation.handler(openEvent, button)).toBe(true);
+        expect(openEvent.defaultPrevented).toBe(true);
         expect(pre).not.toHaveAttribute('hidden');
         expect(button).toHaveClass('open');
         expect(button).toHaveAttribute('aria-expanded', 'true');
 
-        annotation.handler(clickEvent(), button);
+        const closeEvent = clickEvent();
+        expect(annotation.handler(closeEvent, button)).toBe(true);
+        expect(closeEvent.defaultPrevented).toBe(true);
         expect(pre).toHaveAttribute('hidden');
         expect(button).not.toHaveClass('open');
         expect(button).toHaveAttribute('aria-expanded', 'false');
@@ -314,12 +402,16 @@ describe('transient detail controls', () => {
         const button = document.querySelector('[data-ro-action="toggle-tools"]') as HTMLElement;
         const panel = document.getElementById('tools-panel') as HTMLElement;
         const tools = binding('click', '[data-ro-action="toggle-tools"]');
+        const openEvent = clickEvent();
 
-        tools.handler(clickEvent(), button);
+        expect(tools.handler(openEvent, button)).toBe(true);
+        expect(openEvent.defaultPrevented).toBe(true);
         expect(button).toHaveClass('is-active');
         expect(panel).toHaveClass('is-active');
 
-        tools.handler(clickEvent(), button);
+        const closeEvent = clickEvent();
+        expect(tools.handler(closeEvent, button)).toBe(true);
+        expect(closeEvent.defaultPrevented).toBe(true);
         expect(button).not.toHaveClass('is-active');
         expect(panel).not.toHaveClass('is-active');
     });
@@ -339,17 +431,31 @@ describe('form glue', () => {
         const change = binding('change', 'input[data-ro-toggle-button]');
 
         one.checked = true;
-        change.handler(new Event('change'), one);
+        expect(change.handler(new Event('change'), one)).toBe(true);
         expect(button).toBeEnabled();
 
         two.checked = true;
         one.checked = false;
-        change.handler(new Event('change'), one);
+        expect(change.handler(new Event('change'), one)).toBe(true);
         expect(button).toBeEnabled();
 
         two.checked = false;
-        change.handler(new Event('change'), two);
+        expect(change.handler(new Event('change'), two)).toBe(true);
         expect(button).toBeDisabled();
+    });
+
+    test('a checkbox naming an absent button remains a safe stopped no-op', () => {
+        document.body.innerHTML = `
+            <input type="checkbox" data-ro-toggle-button="missing-button" checked>
+        `;
+        const checkbox = document.querySelector('input') as HTMLInputElement;
+
+        expect(
+            binding('change', 'input[data-ro-toggle-button]').handler(
+                new Event('change'),
+                checkbox,
+            ),
+        ).toBe(true);
     });
 
     test('removes names only from empty inputs and leaves the GET submit unblocked', () => {
@@ -362,8 +468,10 @@ describe('form glue', () => {
         `;
         const form = document.querySelector('form.tools-form') as HTMLFormElement;
         const submit = binding('submit', 'form.tools-form');
+        const event = new SubmitEvent('submit', { cancelable: true });
 
-        expect(submit.handler(new SubmitEvent('submit'), form)).toBeUndefined();
+        expect(submit.handler(event, form)).toBeUndefined();
+        expect(event.defaultPrevented).toBe(false);
         expect(submit.stop).toBeUndefined();
         expect(document.getElementById('empty')).toHaveAttribute('name', '');
         expect(document.getElementById('filled')).toHaveAttribute('name', 'filled');

--- a/internal/assets/src/js/misc-ui.ts
+++ b/internal/assets/src/js/misc-ui.ts
@@ -125,7 +125,7 @@ export const miscBindings: Binding[] = [
             } else {
                 window.history.replaceState(
                     null,
-                    '',
+                    document.title,
                     window.location.pathname + window.location.search,
                 );
             }
@@ -143,9 +143,10 @@ export const miscBindings: Binding[] = [
         selector: '#namespace-dropdown [data-ro-action="pick-namespace"]',
         stop: true,
         handler: (_event, matched) => {
-            const hrefMatch = /^\/clusters\/([^/]+)\/namespaces\/([^/]+)\//.exec(
-                (matched as Element).getAttribute('href') || '',
-            );
+            const href = (matched as Element).getAttribute('href');
+            const hrefMatch = href
+                ? /^\/clusters\/([^/]+)\/namespaces\/([^/]+)\//.exec(href)
+                : null;
             if (hrefMatch) {
                 roPrefsSetNamespace(
                     decodeURIComponent(hrefMatch[1]),
@@ -186,7 +187,7 @@ export const miscBindings: Binding[] = [
         handler: (_event, matched) => {
             const filterText = (matched as HTMLInputElement).value.toLowerCase();
             document.querySelectorAll('[data-ro-action="pick-namespace"]').forEach((element) => {
-                const text = ((element as HTMLElement).innerText || '').toLowerCase();
+                const text = (element as HTMLElement).innerText.toLowerCase();
                 if (text.indexOf(filterText) === -1) {
                     element.classList.add('is-hidden');
                 } else {
@@ -206,13 +207,10 @@ export const miscBindings: Binding[] = [
             if ((event as KeyboardEvent).key !== 'Enter') {
                 return true;
             }
-            const elements = document.querySelectorAll('[data-ro-action="pick-namespace"]');
-            for (let i = 0; i < elements.length; i++) {
-                if (!elements[i].classList.contains('is-hidden')) {
-                    (elements[i] as HTMLElement).click();
-                    break;
-                }
-            }
+            const firstVisible = Array.from(
+                document.querySelectorAll('[data-ro-action="pick-namespace"]'),
+            ).find((element) => !element.classList.contains('is-hidden'));
+            (firstVisible as HTMLElement | undefined)?.click();
             return true;
         },
     },

--- a/internal/assets/src/js/morph.dom.test.ts
+++ b/internal/assets/src/js/morph.dom.test.ts
@@ -29,31 +29,30 @@ interface VendorHarness {
     callbacks: MorphCallbacks;
     defineExtension: ReturnType<typeof vi.fn>;
     extension(): MorphExtension;
+    matchMedia: ReturnType<typeof vi.fn>;
     morph: ReturnType<typeof vi.fn>;
 }
 
-function stubReducedMotion(matches: boolean): void {
-    vi.stubGlobal(
-        'matchMedia',
-        vi.fn().mockImplementation((query: string) => ({
-            matches,
-            media: query,
-            onchange: null,
-            addEventListener: vi.fn(),
-            removeEventListener: vi.fn(),
-            addListener: vi.fn(),
-            removeListener: vi.fn(),
-            dispatchEvent: vi.fn(),
-        })),
-    );
+function stubReducedMotion(matches: boolean): ReturnType<typeof vi.fn> {
+    const matchMedia = vi.fn().mockImplementation((query: string) => ({
+        matches,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    }));
+    vi.stubGlobal('matchMedia', matchMedia);
+    return matchMedia;
 }
 
 function installVendors(reducedMotion = false): VendorHarness {
-    stubReducedMotion(reducedMotion);
+    const matchMedia = stubReducedMotion(reducedMotion);
 
     let registered: MorphExtension | undefined;
-    const defineExtension = vi.fn((name: string, extension: MorphExtension) => {
-        expect(name).toBe('ro-morph');
+    const defineExtension = vi.fn((_name: string, extension: MorphExtension) => {
         registered = extension;
     });
     const callbacks: MorphCallbacks = {};
@@ -72,6 +71,7 @@ function installVendors(reducedMotion = false): VendorHarness {
             expect(registered).toBeDefined();
             return registered as MorphExtension;
         },
+        matchMedia,
         morph,
     };
 }
@@ -89,7 +89,11 @@ afterEach(() => {
 });
 
 describe('ro-morph vendor guards and extension', () => {
-    test('loads without Idiomorph and does not register a half-working extension', async () => {
+    test('loads when both optional vendor globals are absent', async () => {
+        await expect(importMorph()).resolves.toBeUndefined();
+    });
+
+    test('does not register a half-working extension without Idiomorph', async () => {
         const defineExtension = vi.fn();
         vi.stubGlobal('htmx', { defineExtension });
 
@@ -98,11 +102,65 @@ describe('ro-morph vendor guards and extension', () => {
         expect(defineExtension).not.toHaveBeenCalled();
     });
 
+    test('ignores an incomplete Idiomorph global', async () => {
+        const defineExtension = vi.fn();
+        const callbacks: MorphCallbacks = {};
+        stubReducedMotion(false);
+        vi.stubGlobal('htmx', { defineExtension });
+        vi.stubGlobal('Idiomorph', { defaults: { callbacks } });
+
+        await expect(importMorph()).resolves.toBeUndefined();
+
+        expect(callbacks.beforeNodeMorphed).toBeUndefined();
+        expect(callbacks.afterNodeMorphed).toBeUndefined();
+        expect(defineExtension).not.toHaveBeenCalled();
+    });
+
+    test('installs callbacks but does not throw when htmx is absent or incomplete', async () => {
+        for (const htmxVendor of [undefined, {}]) {
+            vi.resetModules();
+            vi.unstubAllGlobals();
+            const matchMedia = stubReducedMotion(false);
+            const callbacks: MorphCallbacks = {};
+            vi.stubGlobal('Idiomorph', { defaults: { callbacks }, morph: vi.fn() });
+            if (htmxVendor !== undefined) {
+                vi.stubGlobal('htmx', htmxVendor);
+            }
+
+            await expect(importMorph()).resolves.toBeUndefined();
+
+            expect(callbacks.beforeNodeMorphed).toBeTypeOf('function');
+            expect(callbacks.afterNodeMorphed).toBeTypeOf('function');
+            expect(matchMedia).toHaveBeenCalledExactlyOnceWith('(prefers-reduced-motion: reduce)');
+        }
+    });
+
+    test.each([
+        ['no defaults', { morph: vi.fn() }],
+        ['no callbacks', { defaults: {}, morph: vi.fn() }],
+    ])('registers with partial Idiomorph defaults: %s', async (_case, idiomorphVendor) => {
+        const defineExtension = vi.fn();
+        const matchMedia = stubReducedMotion(false);
+        vi.stubGlobal('htmx', { defineExtension });
+        vi.stubGlobal('Idiomorph', idiomorphVendor);
+
+        await expect(importMorph()).resolves.toBeUndefined();
+
+        expect(defineExtension).toHaveBeenCalledOnce();
+        expect(matchMedia).not.toHaveBeenCalled();
+    });
+
     test('registers ro-morph and declines non-morph swaps', async () => {
         const vendor = installVendors();
         await importMorph();
 
-        expect(vendor.defineExtension).toHaveBeenCalledOnce();
+        expect(vendor.defineExtension).toHaveBeenCalledExactlyOnceWith('ro-morph', {
+            isInlineSwap: expect.any(Function),
+            handleSwap: expect.any(Function),
+        });
+        expect(vendor.matchMedia).toHaveBeenCalledExactlyOnceWith(
+            '(prefers-reduced-motion: reduce)',
+        );
         const extension = vendor.extension();
         expect(extension.isInlineSwap('morph')).toBe(true);
         expect(extension.isInlineSwap('innerHTML')).toBe(false);
@@ -113,6 +171,26 @@ describe('ro-morph vendor guards and extension', () => {
         expect(dependencies.captureRowModel).not.toHaveBeenCalled();
         expect(dependencies.virtualizePrepareSwap).not.toHaveBeenCalled();
         expect(vendor.morph).not.toHaveBeenCalled();
+    });
+
+    test('morphs non-list targets without list-model side effects and returns vendor result', async () => {
+        const vendor = installVendors();
+        vendor.morph.mockReturnValueOnce(false);
+        await importMorph();
+        const extension = vendor.extension();
+
+        const target = document.createElement('section');
+        target.id = 'details';
+        const fragment = document.createDocumentFragment();
+        fragment.append(document.createElement('p'));
+
+        expect(extension.handleSwap('morph', target, fragment)).toBe(false);
+        expect(dependencies.captureRowModel).not.toHaveBeenCalled();
+        expect(dependencies.virtualizePrepareSwap).not.toHaveBeenCalled();
+        expect(vendor.morph).toHaveBeenCalledExactlyOnceWith(target, fragment.children, {
+            morphStyle: 'innerHTML',
+            ignoreActiveValue: true,
+        });
     });
 
     test('captures the complete model before preparing virtualization and morphs exactly', async () => {
@@ -163,10 +241,43 @@ describe('changed-cell flash', () => {
 
         const nonCell = document.createElement('div');
         nonCell.textContent = 'before';
-        onBeforeNodeMorphed?.(nonCell);
-        nonCell.textContent = 'after';
-        onAfterNodeMorphed?.(nonCell);
+        Object.defineProperty(nonCell, 'textContent', {
+            configurable: true,
+            get: () => {
+                throw new Error('non-cell subtree was read');
+            },
+        });
+        expect(() => onBeforeNodeMorphed?.(nonCell)).not.toThrow();
+        expect(() => onAfterNodeMorphed?.(nonCell)).not.toThrow();
         expect(nonCell).not.toHaveClass('ro-cell-changed');
+    });
+
+    test('does not flash a TD without a matching before callback', async () => {
+        const vendor = installVendors();
+        await importMorph();
+
+        const cell = document.createElement('td');
+        cell.textContent = 'Already morphed';
+        vendor.callbacks.afterNodeMorphed?.(cell);
+
+        expect(cell).not.toHaveClass('ro-cell-changed');
+    });
+
+    test('consumes each before snapshot exactly once', async () => {
+        const vendor = installVendors();
+        await importMorph();
+
+        const cell = document.createElement('td');
+        cell.textContent = 'Queued';
+        vendor.callbacks.beforeNodeMorphed?.(cell);
+        cell.textContent = 'Running';
+        vendor.callbacks.afterNodeMorphed?.(cell);
+        expect(cell).toHaveClass('ro-cell-changed');
+
+        cell.classList.remove('ro-cell-changed');
+        cell.textContent = 'Done';
+        vendor.callbacks.afterNodeMorphed?.(cell);
+        expect(cell).not.toHaveClass('ro-cell-changed');
     });
 
     test('does not install flash callbacks for reduced-motion users', async () => {
@@ -177,5 +288,8 @@ describe('changed-cell flash', () => {
         expect(vendor.callbacks.beforeNodeMorphed).toBeUndefined();
         expect(vendor.callbacks.afterNodeMorphed).toBeUndefined();
         expect(vendor.defineExtension).toHaveBeenCalledOnce();
+        expect(vendor.matchMedia).toHaveBeenCalledExactlyOnceWith(
+            '(prefers-reduced-motion: reduce)',
+        );
     });
 });

--- a/internal/assets/src/js/morph.ts
+++ b/internal/assets/src/js/morph.ts
@@ -51,7 +51,10 @@ declare const Idiomorph:
 // Reading an undeclared classic-script global directly throws before optional
 // chaining can help. Resolve it through typeof once so the bundle also loads on
 // pages where the optional vendor script is absent.
-const idiomorph = typeof Idiomorph === 'undefined' ? undefined : Idiomorph;
+const idiomorph =
+    typeof Idiomorph !== 'undefined' && typeof Idiomorph.morph === 'function'
+        ? Idiomorph
+        : undefined;
 
 // ---------------------------------------------------------------------------
 // Auto-refresh CHANGED-CELL flash -- honest + reduced-motion-safe.
@@ -70,28 +73,30 @@ const idiomorph = typeof Idiomorph === 'undefined' ? undefined : Idiomorph;
 // Disabled entirely under prefers-reduced-motion: we never register the callbacks,
 // so those users get a silent in-place morph (the progress bar handles that case
 // too, and refresh-spin is dropped in CSS). beforeNodeMorphed returns undefined
-// (NOT false) so it never cancels a morph; we read text only on element nodes.
+// (NOT false) so it never cancels a morph. Only TD text is read: this callback
+// runs for every morphed node, so walking every ancestor subtree would put avoidable
+// work on each polling/Live refresh.
 if (
     idiomorph?.defaults?.callbacks &&
     !window.matchMedia('(prefers-reduced-motion: reduce)').matches
 ) {
-    const PRIOR = new WeakMap<Element, string | null>();
+    const PRIOR = new WeakMap<Node, string | null>();
     idiomorph.defaults.callbacks.beforeNodeMorphed = (oldNode: Node) => {
-        if (oldNode && oldNode.nodeType === 1 && (oldNode as Element).tagName === 'TD') {
-            PRIOR.set(oldNode as Element, oldNode.textContent);
+        if (oldNode.nodeName !== 'TD') {
+            return;
         }
+        PRIOR.set(oldNode, oldNode.textContent);
         // return undefined -> idiomorph proceeds with the morph (false would skip it)
     };
     idiomorph.defaults.callbacks.afterNodeMorphed = (oldNode: Node) => {
-        if (oldNode?.nodeType !== 1 || (oldNode as Element).tagName !== 'TD') {
+        // Only TD nodes enter PRIOR in the before hook, so map membership is the
+        // complete eligibility gate here; repeating the tag check is equivalent.
+        if (!PRIOR.has(oldNode)) {
             return;
         }
         const el = oldNode as HTMLElement;
-        if (!PRIOR.has(el)) {
-            return;
-        }
-        const before = PRIOR.get(el);
-        PRIOR.delete(el);
+        const before = PRIOR.get(oldNode);
+        PRIOR.delete(oldNode);
         if (before !== el.textContent) {
             el.classList.remove('ro-cell-changed');
             // force a reflow so re-adding the class restarts the animation if the
@@ -121,7 +126,7 @@ if (
 // re-sorted fragment MOVES the existing <tr> nodes instead of rewriting them
 // positionally. defaults.callbacks (the cell-flash hooks above) still merge in:
 // an explicit config object without `callbacks` inherits Idiomorph.defaults.
-if (typeof htmx !== 'undefined' && idiomorph) {
+if (typeof htmx !== 'undefined' && typeof htmx.defineExtension === 'function' && idiomorph) {
     htmx.defineExtension('ro-morph', {
         isInlineSwap: (swapStyle: string) => swapStyle === 'morph',
         handleSwap: (swapStyle: string, target: Element, fragment: DocumentFragment) => {
@@ -134,7 +139,7 @@ if (typeof htmx !== 'undefined' && idiomorph) {
             // even when a client-side windowing layer keeps only a
             // window of rows in the live DOM -- the free-text matcher and the
             // value-frequency autocomplete must never read the windowed DOM.
-            if (target && target.id === 'resource-list-content') {
+            if (target.id === 'resource-list-content') {
                 captureRowModel(fragment);
                 // Virtualization, AFTER the model capture: a
                 // >threshold fragment's rows are detached for adoption so

--- a/internal/assets/src/js/palette-rank.test.ts
+++ b/internal/assets/src/js/palette-rank.test.ts
@@ -5,11 +5,12 @@
 //
 // Run: `npm test`.
 
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import {
     buildPaletteGroups,
     dedupeRecents,
+    feedEntryLabel,
     type PaletteFeed,
     paletteRecentTarget,
     type RecentEntry,
@@ -27,6 +28,7 @@ test('empty query is rank-neutral (matches everything at score 0)', () => {
 });
 
 test('a non-subsequence returns -1', () => {
+    expect(roFuzzyScore('z', 'pods')).toBe(-1);
     expect(roFuzzyScore('sys', 'pods')).toBe(-1);
     expect(roFuzzyScore('xyz', 'Deployments')).toBe(-1);
 });
@@ -42,11 +44,46 @@ test('prefix beats word-start beats scattered (the tier law)', () => {
     expect(wordStart, `wordStart ${wordStart} < scattered ${scattered}`).toBeLessThan(scattered);
 });
 
+test('tier, gap, and first-position weights produce exact comparable scores', () => {
+    expect(roFuzzyScore('abc', 'abc')).toBe(0);
+    expect(roFuzzyScore('abc', 'x abc')).toBe(100002);
+    expect(roFuzzyScore('abc', 'xabc')).toBe(200001);
+    expect(roFuzzyScore('abc', 'aXbYc')).toBe(200200);
+
+    // Very late matches stay inside their tier instead of bleeding into the
+    // gap component: only the first-position contribution is capped at 99.
+    expect(roFuzzyScore('abc', `${'x'.repeat(120)}abc`)).toBe(200099);
+});
+
+test('every documented separator creates a word-start boundary', () => {
+    for (const separator of [' ', '-', '_', '.', '/', ':']) {
+        expect(roFuzzyScore('abc', `x${separator}abc`), `separator ${separator}`).toBe(100002);
+    }
+});
+
 test('a camelCase hump counts as a word-start boundary', () => {
     const camel = roFuzzyScore('vol', 'PersistentVolumes'); // hump at "Volumes"
     const scattered = roFuzzyScore('sys', 'misty-sales');
     expect(camel).toBeGreaterThanOrEqual(0);
     expect(camel, `camelHump ${camel} < scattered ${scattered}`).toBeLessThan(scattered);
+});
+
+test('camel humps use exact ASCII uppercase boundaries', () => {
+    // A and Z pin both inclusive ends of the uppercase range.
+    expect(roFuzzyScore('apple', 'xApple')).toBe(100001);
+    expect(roFuzzyScore('zoo', 'xZoo')).toBe(100001);
+
+    // A lowercase start is not a hump, and an uppercase predecessor means the
+    // match is inside an acronym rather than at a camelCase word start.
+    expect(roFuzzyScore('apple', 'xapple')).toBe(200001);
+    expect(roFuzzyScore('@app', 'x@app')).toBe(200001);
+    expect(roFuzzyScore('beta', 'ABeta')).toBe(200001);
+    expect(roFuzzyScore('beta', 'ZBeta')).toBe(200001);
+});
+
+test('one source character cannot satisfy repeated query characters', () => {
+    expect(roFuzzyScore('aa', 'a')).toBe(-1);
+    expect(roFuzzyScore('aaa', 'aa')).toBe(-1);
 });
 
 test('subsequence works where a substring test would fail; tighter wins', () => {
@@ -78,7 +115,11 @@ test('matching is case-insensitive and respects diacritics as literal chars', ()
 
 test('rankPaletteEntries keeps feed order on an empty query', () => {
     const list = [{ n: 'b' }, { n: 'a' }, { n: 'c' }];
-    expect(rankPaletteEntries(list, '', (e) => e.n)).toStrictEqual(list);
+    const labelOf = vi.fn((entry: { n: string }) => entry.n);
+    const ranked = rankPaletteEntries(list, '', labelOf);
+    expect(ranked).toStrictEqual(list);
+    expect(ranked).not.toBe(list);
+    expect(labelOf).not.toHaveBeenCalled();
 });
 
 test('rankPaletteEntries drops non-matches and orders best-first', () => {
@@ -86,6 +127,27 @@ test('rankPaletteEntries drops non-matches and orders best-first', () => {
     const out = rankPaletteEntries(list, 'sys', (e) => e.n).map((e) => e.n);
     // prefix (system-pods) first, then word-start (kube-system), then scattered.
     expect(out).toStrictEqual(['system-pods', 'kube-system', 'misty-sales']);
+});
+
+test('rankPaletteEntries preserves feed order when non-empty-query scores tie', () => {
+    const list = [
+        { id: 1, n: 'x-alpha' },
+        { id: 2, n: 'y-alpha' },
+        { id: 3, n: 'z-alpha' },
+    ];
+    expect(rankPaletteEntries(list, 'alpha', (entry) => entry.n).map((entry) => entry.id)).toEqual([
+        1, 2, 3,
+    ]);
+});
+
+test('feed labels use their group-specific primary, fallback, and empty shapes', () => {
+    expect(feedEntryLabel({ kind: 'Pod', plural: 'pods' }, 'kinds')).toBe('Pod');
+    expect(feedEntryLabel({ kind: '', plural: 'pods' }, 'kinds')).toBe('pods');
+    expect(feedEntryLabel({}, 'kinds')).toBe('');
+
+    expect(feedEntryLabel({ name: 'prod', label: 'Production' }, 'clusters')).toBe('prod');
+    expect(feedEntryLabel({ name: '', label: 'Toggle theme' }, 'actions')).toBe('Toggle theme');
+    expect(feedEntryLabel({}, 'actions')).toBe('');
 });
 
 // --- recents dedupe ---------------------------------------------------------
@@ -137,6 +199,12 @@ test('empty query: Recents first (when present), then On this page, then feed', 
     const pageObjects = [{ name: 'nginx', href: '/p/nginx' }];
     const groups = buildPaletteGroups('', feed, recents, pageObjects);
     expect(groups.map((g) => g.title)).toStrictEqual(['Recents', 'On this page', 'Resource types']);
+    expect(groups[0]).toStrictEqual({
+        title: 'Recents',
+        key: 'recents',
+        entries: recents,
+    });
+    expect(groups[0].entries).not.toBe(recents);
     // Everywhere is ABSENT on the empty query.
     expect(groups.map((group) => group.title)).not.toContain('Everywhere');
 });
@@ -162,6 +230,13 @@ test('typing: Everywhere is pinned FIRST, then On this page, then ranked feed', 
     expect(groups[0].entries).toStrictEqual([{ query: 'ng' }]);
     // On this page is ranked: nginx matches "ng", my-app does not.
     expect((groups[1].entries as { name: string }[]).map((e) => e.name)).toStrictEqual(['nginx']);
+});
+
+test('typing trims the query before both Everywhere output and ranking', () => {
+    expect(buildPaletteGroups('  ng  ', EMPTY_FEED, [], [{ name: 'nginx' }])).toStrictEqual([
+        { title: 'Everywhere', key: 'everywhere', entries: [{ query: 'ng' }] },
+        { title: 'On this page', key: 'objects', entries: [{ name: 'nginx' }] },
+    ]);
 });
 
 test('empty groups are skipped entirely', () => {

--- a/internal/assets/src/js/palette-rank.ts
+++ b/internal/assets/src/js/palette-rank.ts
@@ -25,38 +25,50 @@
 // Greedy leftmost matching keeps it linear in the text. PURE (no DOM, no module
 // state) and re-exported as window.roFuzzy by palette.ts -- the e2e suite
 // unit-tests the ranking in isolation through that seam.
+const WORD_SEPARATORS = ' -_./:';
+
+function isAsciiUppercase(character: string): boolean {
+    return character >= 'A' && character <= 'Z';
+}
+
 export function roFuzzyScore(query: string, text: string): number {
-    const source = String(text || '');
-    const q = String(query || '').toLowerCase();
+    const source = text;
+    const q = query.toLowerCase();
     const t = source.toLowerCase();
     if (!q) {
         return 0; // empty query matches everything, rank-neutral
     }
-    let from = 0;
-    let first = -1;
-    let last = -1;
-    for (let i = 0; i < q.length; i++) {
+
+    const first = t.indexOf(q[0]);
+    if (first === -1) {
+        return -1;
+    }
+
+    let from = first + 1;
+    for (let i = 1; i < q.length; i++) {
         const at = t.indexOf(q[i], from);
         if (at === -1) {
             return -1; // not a subsequence
         }
-        if (first === -1) {
-            first = at;
-        }
-        last = at;
         from = at + 1;
     }
-    const gaps = last - first + 1 - q.length;
-    const camelHump =
-        source[first] >= 'A' &&
-        source[first] <= 'Z' &&
-        !(source[first - 1] >= 'A' && source[first - 1] <= 'Z');
-    const wordStart = first === 0 || ' -_./:'.indexOf(t[first - 1]) !== -1 || camelHump;
+
+    // `from` is one past the final matched character, so this is the matched
+    // span minus the query length without a separate, sentinel-initialized
+    // `last` index.
+    const gaps = from - first - q.length;
     let tier = 2;
-    if (gaps === 0 && first === 0) {
-        tier = 0;
-    } else if (gaps === 0 && wordStart) {
-        tier = 1;
+    if (gaps === 0) {
+        if (first === 0) {
+            tier = 0;
+        } else {
+            const separatorBoundary = WORD_SEPARATORS.includes(t[first - 1]);
+            const camelHump =
+                isAsciiUppercase(source[first]) && !isAsciiUppercase(source[first - 1]);
+            if (separatorBoundary || camelHump) {
+                tier = 1;
+            }
+        }
     }
     return tier * 100000 + gaps * 100 + Math.min(first, 99);
 }
@@ -176,7 +188,7 @@ export function buildPaletteGroups(
     recents: RecentEntry[],
     pageObjects: PageObject[],
 ): PaletteGroup[] {
-    const q = (query || '').trim();
+    const q = query.trim();
     const groups: PaletteGroup[] = [];
 
     // First slot: Everywhere while typing (pinned, so ⏎ on a fresh query

--- a/internal/assets/src/js/palette.dom.test.ts
+++ b/internal/assets/src/js/palette.dom.test.ts
@@ -22,7 +22,7 @@ vi.mock('./virtualizer.js', () => ({
     virtualizerActive: dependencies.virtualizerActive,
 }));
 
-import { closePalette, openPalette, paletteBindings } from './palette.js';
+import { closePalette, openPalette, paletteBindings, paletteHrefSafe } from './palette.js';
 
 interface PaletteFeed {
     currentCluster: string | null;
@@ -83,6 +83,30 @@ function activeLabel(): string | undefined {
     return document.querySelector<HTMLElement>('.ro-pal-item.active')?.dataset.label;
 }
 
+function expectPaletteRowContract(row: HTMLElement): void {
+    expect(row.classList.contains('ro-pal-item')).toBe(true);
+    expect(row.dataset.roAction).toBe('pick-palette-row');
+    expect(row.getAttribute('role')).toBe('option');
+    expect(row.querySelector(':scope > .pal-label')).not.toBeNull();
+}
+
+function expectPaletteBindingContract(bindings: Binding[]): void {
+    expect(bindings.map(({ event, selector, stop }) => ({ event, selector, stop }))).toStrictEqual([
+        {
+            event: 'click',
+            selector: '[data-ro-action="pick-palette-row"]',
+            stop: true,
+        },
+        { event: 'click', selector: '[data-ro-palette-open]', stop: true },
+        { event: 'click', selector: '[data-ro-search-refine]', stop: true },
+        { event: 'click', selector: '#ro-palette', stop: true },
+        { event: 'input', selector: '#ro-palette-input', stop: true },
+        { event: 'keydown', selector: undefined, stop: undefined },
+        { event: 'keydown', selector: undefined, stop: undefined },
+        { event: 'focusin', selector: '[data-ro-palette-open]', stop: undefined },
+    ]);
+}
+
 function targetedKeyboardEvent(
     key: string,
     target: Element,
@@ -93,7 +117,7 @@ function targetedKeyboardEvent(
     return event;
 }
 
-function targetedMouseEvent(target: Element): MouseEvent {
+function targetedMouseEvent(target: EventTarget): MouseEvent {
     const event = new MouseEvent('click', { bubbles: true, cancelable: true });
     Object.defineProperty(event, 'target', { configurable: true, value: target });
     return event;
@@ -119,6 +143,53 @@ beforeEach(() => {
     });
 });
 
+describe('binding contract', () => {
+    test('exports the complete delegated palette contract in order', () => {
+        expectPaletteBindingContract(paletteBindings);
+        expect((window as unknown as { roOpenPalette: unknown }).roOpenPalette).toBe(openPalette);
+    });
+
+    test('re-evaluates module-owned static contracts under an isolated import', async () => {
+        const seams = window as unknown as {
+            roFuzzy: (query: string, text: string) => number;
+            roOpenPalette: typeof openPalette;
+        };
+        const priorFuzzy = seams.roFuzzy;
+        const priorOpen = seams.roOpenPalette;
+        vi.resetModules();
+
+        try {
+            const freshRank = await import('./palette-rank.js');
+            const freshPalette = await import('./palette.js');
+            const feed = emptyFeed();
+            feed.clusters = [{ name: 'Fresh cluster', href: '#fresh-cluster' }];
+            const data = document.getElementById('ro-palette-data') as HTMLElement;
+            data.textContent = JSON.stringify({
+                ...feed,
+                clusters: [null, ...feed.clusters],
+            });
+            window.localStorage.setItem(
+                'ro-pref-recents',
+                JSON.stringify([null, { label: 'Fresh recent', href: '#fresh-recent' }]),
+            );
+
+            expectPaletteBindingContract(freshPalette.paletteBindings);
+            expect(seams.roFuzzy).toBe(freshRank.roFuzzyScore);
+            expect(seams.roFuzzy('dpl', 'Deployments')).toBeGreaterThanOrEqual(0);
+            expect(seams.roOpenPalette).toBe(freshPalette.openPalette);
+
+            freshPalette.openPalette();
+
+            expect(document.getElementById('ro-palette')?.classList.contains('open')).toBe(true);
+            expect(rowByLabel('Fresh recent').dataset.href).toBe('#fresh-recent');
+            expect(rowByLabel('Fresh cluster').dataset.href).toBe('#fresh-cluster');
+        } finally {
+            seams.roFuzzy = priorFuzzy;
+            seams.roOpenPalette = priorOpen;
+        }
+    });
+});
+
 describe('feed and recent-storage validation', () => {
     test('malformed feed and localStorage degrade to an open empty palette', () => {
         renderPaletteHarness('{not-json');
@@ -131,6 +202,9 @@ describe('feed and recent-storage validation', () => {
             'No matching targets.',
         );
         expect(document.querySelectorAll('.ro-pal-item')).toHaveLength(0);
+        const empty = document.querySelector('.ro-pal-empty') as HTMLElement;
+        expect(empty.className).toBe('ro-pal-empty');
+        expect(empty.textContent).toBe('No matching targets.');
     });
 
     test.each([
@@ -146,12 +220,19 @@ describe('feed and recent-storage validation', () => {
             },
         },
         {
-            name: 'non-object JSON',
+            name: 'null JSON',
             prepare: () => {
                 const data = document.getElementById('ro-palette-data');
                 if (data) data.textContent = 'null';
             },
         },
+        ...['false', '42', '"scalar"'].map((json) => ({
+            name: `${json} JSON primitive`,
+            prepare: () => {
+                const data = document.getElementById('ro-palette-data');
+                if (data) data.textContent = json;
+            },
+        })),
         {
             name: 'array JSON',
             prepare: () => {
@@ -179,19 +260,39 @@ describe('feed and recent-storage validation', () => {
     test('drops null, scalar, and array feed entries while keeping valid records', () => {
         renderPaletteHarness(
             JSON.stringify({
-                currentCluster: null,
-                currentNamespace: null,
+                currentCluster: 42,
+                currentNamespace: [],
                 clusters: [
                     null,
                     42,
                     'invalid',
                     false,
                     [],
+                    {},
+                    { name: '', href: '#empty-name' },
+                    { name: '   ', href: '#blank-name' },
+                    { name: 42, href: '#numeric-name' },
+                    { label: 'Cluster alias', href: '#cluster-alias' },
                     { name: 'Safe cluster', href: '#safe-cluster' },
                 ],
-                namespaces: [null, { name: 'Safe namespace', href: '#safe-namespace' }],
-                kinds: [null, { kind: 'Pod', namespaced: true, href: '#pods' }],
-                actions: [null, { label: 'Switch theme', action: 'theme' }],
+                namespaces: [
+                    null,
+                    { label: '', href: '#empty-namespace' },
+                    { name: 'Safe namespace', href: '#safe-namespace' },
+                ],
+                kinds: [
+                    null,
+                    { plural: '', href: '#empty-kind' },
+                    { kind: 42, href: '#numeric-kind' },
+                    { kind: 'Pod', namespaced: true, href: '#pods' },
+                ],
+                actions: [
+                    null,
+                    { label: '   ', action: 'theme' },
+                    { label: 'No target' },
+                    { label: 'Numeric action', action: 42 },
+                    { label: 'Switch theme', action: 'theme' },
+                ],
             }),
         );
 
@@ -201,29 +302,118 @@ describe('feed and recent-storage validation', () => {
             Array.from(document.querySelectorAll<HTMLElement>('.ro-pal-item')).map(
                 (row) => row.dataset.label,
             ),
-        ).toStrictEqual(['Pod', 'Safe namespace', 'Safe cluster', 'Switch theme']);
+        ).toStrictEqual(['Pod', 'Safe namespace', 'Cluster alias', 'Safe cluster', 'Switch theme']);
+        const scope = document.getElementById('ro-palette-scope') as HTMLElement;
+        expect(scope.hidden).toBe(true);
+        expect(scope.textContent).toBe('');
+        expect(document.querySelector('[data-label="No target"]')).toBeNull();
+        expect(document.querySelector('[data-label="Numeric action"]')).toBeNull();
     });
 
     test('unsafe recent hrefs and malformed entries are re-validated before rendering', () => {
         window.localStorage.setItem(
             'ro-pref-recents',
             JSON.stringify([
+                null,
+                42,
+                'scalar',
+                [],
                 { label: 'unsafe js', href: 'javascript:alert(1)' },
                 { label: 'unsafe data', href: 'data:text/html,pwned' },
                 { label: 'safe recent', href: '#safe-recent' },
                 { label: 'theme recent', action: 'theme' },
+                { label: ' padded recent ', action: ' future-action ' },
                 { label: '', href: '#blank-label' },
+                { label: '   ', href: '#whitespace-label' },
+                { label: 42, href: '#numeric-label' },
+                { label: 'numeric action', action: 42 },
+                { label: 'whitespace action', action: '   ' },
+                { label: 'numeric href', href: 42 },
+                { label: 'whitespace href', href: '   ' },
+                { label: 'invalid URL', href: 'http://[' },
                 { label: 'no target' },
             ]),
         );
 
         openPalette();
 
-        expect(rowByLabel('safe recent')).toHaveAttribute('data-href', '#safe-recent');
-        expect(rowByLabel('theme recent')).toHaveAttribute('data-action', 'theme');
+        const safeRecent = rowByLabel('safe recent');
+        expect(safeRecent.dataset.href).toBe('#safe-recent');
+        expect(safeRecent.dataset.action).toBeUndefined();
+        const themeRecent = rowByLabel('theme recent');
+        expect(themeRecent.dataset.action).toBe('theme');
+        expect(themeRecent.dataset.href).toBeUndefined();
+        expect(rowByLabel('padded recent').dataset.action).toBe('future-action');
         expect(document.querySelector('[data-label="unsafe js"]')).not.toBeInTheDocument();
         expect(document.querySelector('[data-label="unsafe data"]')).not.toBeInTheDocument();
+        expect(document.querySelector('[data-label="numeric action"]')).not.toBeInTheDocument();
+        expect(document.querySelector('[data-label="whitespace action"]')).not.toBeInTheDocument();
+        expect(document.querySelector('[data-label="numeric href"]')).not.toBeInTheDocument();
+        expect(document.querySelector('[data-label="whitespace href"]')).not.toBeInTheDocument();
+        expect(document.querySelector('[data-label="invalid URL"]')).not.toBeInTheDocument();
         expect(document.querySelector('[data-label="no target"]')).not.toBeInTheDocument();
+    });
+
+    test.each(['', '{}', '42', '"scalar"', 'null'])(
+        'treats unusable recent payload %s as empty',
+        (stored) => {
+            window.localStorage.setItem('ro-pref-recents', stored);
+
+            expect(() => openPalette()).not.toThrow();
+
+            expect(document.querySelectorAll('.ro-pal-item')).toHaveLength(0);
+            expect(document.querySelector('.ro-pal-empty')?.textContent).toBe(
+                'No matching targets.',
+            );
+        },
+    );
+
+    test('accepts only same-origin HTTP destinations after trimming', () => {
+        const feed = emptyFeed();
+        const origin = window.location.origin;
+        feed.clusters = [
+            { name: 'relative', href: '  /clusters/prod  ' },
+            { name: 'same origin', href: `${origin}/clusters/stage` },
+            { name: 'external http', href: 'http://example.test/clusters' },
+            { name: 'external https', href: 'https://example.test/clusters' },
+            { name: 'protocol relative', href: '//example.test/clusters' },
+            { name: 'same-origin blob', href: `blob:${origin}/opaque-id` },
+            { name: 'invalid URL', href: 'http://[' },
+            { name: 'blank href', href: '   ' },
+            { name: 'numeric href', href: 42 },
+        ];
+        renderPaletteHarness(feed);
+
+        openPalette();
+
+        expect(rowByLabel('relative').dataset.href).toBe('/clusters/prod');
+        expect(rowByLabel('same origin').dataset.href).toBe(`${origin}/clusters/stage`);
+        for (const label of [
+            'external http',
+            'external https',
+            'protocol relative',
+            'same-origin blob',
+            'invalid URL',
+            'blank href',
+            'numeric href',
+        ]) {
+            expect(document.querySelector(`[data-label="${label}"]`)).toBeNull();
+        }
+    });
+
+    test('the href policy explicitly accepts both same-origin HTTP and HTTPS', () => {
+        expect(paletteHrefSafe('/clusters/prod', 'http://readout.test/current')).toBe(
+            '/clusters/prod',
+        );
+        expect(
+            paletteHrefSafe('https://readout.test/clusters/prod', 'https://readout.test/current'),
+        ).toBe('https://readout.test/clusters/prod');
+        expect(paletteHrefSafe('blob:http://readout.test/id', 'http://readout.test/current')).toBe(
+            '',
+        );
+        expect(
+            paletteHrefSafe('blob:https://readout.test/id', 'https://readout.test/current'),
+        ).toBe('');
     });
 
     test('dedupes recents by normalized destination, keeps the newest, and caps distinct rows', () => {
@@ -262,6 +452,7 @@ describe('feed and recent-storage validation', () => {
             JSON.stringify([
                 { label: 'Old pods label', href: '#pods' },
                 { label: 'Other', href: '#other' },
+                { label: 'Theme', href: '   ', action: 'theme' },
                 { label: 'Unsafe', href: 'vbscript:msgbox(1)' },
             ]),
         );
@@ -276,6 +467,7 @@ describe('feed and recent-storage validation', () => {
         expect(JSON.parse(window.localStorage.getItem('ro-pref-recents') || 'null')).toStrictEqual([
             { label: 'Pods', href: '#pods' },
             { label: 'Other', href: '#other' },
+            { label: 'Theme', action: 'theme' },
         ]);
         expect(window.location.hash).toBe('#pods');
     });
@@ -284,10 +476,10 @@ describe('feed and recent-storage validation', () => {
         const feed = emptyFeed();
         feed.clusters = [{ name: 'Pods', href: '#pods' }];
         renderPaletteHarness(feed);
-        vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+        const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
             throw new DOMException('blocked', 'SecurityError');
         });
-        vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
             throw new DOMException('blocked', 'SecurityError');
         });
 
@@ -301,58 +493,217 @@ describe('feed and recent-storage validation', () => {
 
         expect(window.location.hash).toBe('#pods');
         expect(document.getElementById('ro-palette')).not.toHaveClass('open');
+        expect(getItem).toHaveBeenCalledWith('ro-pref-recents');
+        expect(setItem).toHaveBeenCalledWith(
+            'ro-pref-recents',
+            JSON.stringify([{ label: 'Pods', href: '#pods' }]),
+        );
+    });
+
+    test('re-reads a swapped feed and replaces the active row model on every open', () => {
+        const first = emptyFeed();
+        first.clusters = [{ name: 'Alpha', href: '#alpha' }];
+        renderPaletteHarness(first);
+        openPalette();
+        expect(activeLabel()).toBe('Alpha');
+
+        const second = emptyFeed();
+        second.clusters = [{ name: 'Beta', href: '#beta' }];
+        const data = document.getElementById('ro-palette-data') as HTMLElement;
+        data.textContent = JSON.stringify(second);
+        openPalette();
+
+        expect(document.querySelector('[data-label="Alpha"]')).toBeNull();
+        expect(activeLabel()).toBe('Beta');
+        const enter = targetedKeyboardEvent(
+            'Enter',
+            document.getElementById('ro-palette-input') as HTMLInputElement,
+        );
+        binding('keydown', undefined, 1).handler(enter, null);
+        expect(enter.defaultPrevented).toBe(true);
+        expect(window.location.hash).toBe('#beta');
     });
 });
 
 describe('safe DOM rendering and actions', () => {
+    test('all row types expose one exact delegated option contract', () => {
+        const feed = emptyFeed();
+        feed.clusters = [{ name: 'Production', href: '#production' }];
+        feed.kinds = [{ kind: 'Pod', href: '#pods' }];
+        renderPaletteHarness(feed);
+        window.localStorage.setItem(
+            'ro-pref-recents',
+            JSON.stringify([{ label: 'Recent', href: '#recent' }]),
+        );
+        document.body.insertAdjacentHTML(
+            'beforeend',
+            `<div id="resource-list-content"><table class="ro-table"><tbody><tr>
+                <td class="cell-name"><a href="#api">api-0</a></td>
+            </tr></tbody></table></div>`,
+        );
+
+        openPalette();
+
+        const rows = Array.from(document.querySelectorAll<HTMLElement>('.ro-pal-item'));
+        expect(rows.map((row) => row.dataset.label)).toStrictEqual([
+            'Recent',
+            'api-0',
+            'Pod',
+            'Production',
+        ]);
+        rows.forEach(expectPaletteRowContract);
+        expect(rows[0].getAttribute('aria-selected')).toBe('true');
+        rows.slice(1).forEach((row) => {
+            expect(row.getAttribute('aria-selected')).toBe('false');
+        });
+        expect(document.querySelector('.ro-pal-empty')).toBeNull();
+        expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' });
+
+        const input = document.getElementById('ro-palette-input') as HTMLInputElement;
+        input.value = 'api';
+        binding('input', '#ro-palette-input').handler(new Event('input'), input);
+        const everywhere = document.querySelector<HTMLElement>('.ro-pal-item');
+        expect(everywhere).not.toBeNull();
+        expectPaletteRowContract(everywhere as HTMLElement);
+        expect(everywhere?.querySelector(':scope > .pal-label')?.textContent).toBe(
+            'Search all clusters for “api”',
+        );
+        expect(everywhere?.dataset.href).toBe('/search?q=api');
+        expect(document.querySelector('[data-label="Recent"]')).toBeNull();
+    });
+
+    test('the everywhere row clones the optional glyph and URL-encodes the trimmed query', () => {
+        const original = document.querySelector('#ro-palette .ro-pal-search .ico') as HTMLElement;
+
+        openPalette('  api/v1 ? ready  ');
+
+        const everywhere = document.querySelector('.ro-pal-item') as HTMLElement;
+        const clone = everywhere.querySelector('.ico');
+        expect(document.querySelector('.ro-pal-group')?.textContent).toBe('Everywhere');
+        expect(everywhere.dataset.label).toBe('Search all clusters for “api/v1 ? ready”');
+        expect(everywhere.querySelector('.pal-label')?.textContent).toBe(
+            'Search all clusters for “api/v1 ? ready”',
+        );
+        expect(everywhere.dataset.href).toBe('/search?q=api%2Fv1%20%3F%20ready');
+        expect(clone).not.toBe(original);
+        expect(clone?.textContent).toBe('search');
+
+        original.remove();
+        const input = document.getElementById('ro-palette-input') as HTMLInputElement;
+        input.value = 'pods';
+        binding('input', '#ro-palette-input').handler(new Event('input'), input);
+        expect(document.querySelector('.ro-pal-item .ico')).toBeNull();
+        expect(document.querySelector('.ro-pal-item')?.getAttribute('data-label')).toBe(
+            'Search all clusters for “pods”',
+        );
+    });
+
     test('renders feed context, kind metadata, display names, and safe icon markup', () => {
         const feed = emptyFeed();
-        feed.currentCluster = 'prod';
-        feed.currentNamespace = 'team-a';
-        feed.clusters = [{ name: 'prod', display: 'Production', href: '#prod' }];
-        feed.namespaces = [{ name: 'team-a', href: '#team-a' }];
+        feed.currentCluster = ' prod ';
+        feed.currentNamespace = ' team-a ';
+        feed.clusters = [
+            { name: ' prod ', display: ' Production ', href: '#prod' },
+            { name: 'staging', display: '', icon: '<b>not a kind</b>', href: '#staging' },
+            { name: 'Primary cluster', label: 'Secondary cluster', href: '#primary' },
+        ];
+        feed.namespaces = [
+            { name: 'team-a', href: '#team-a' },
+            { name: 'team-b', href: '#team-b' },
+        ];
         feed.kinds = [
             {
                 kind: 'Deployment',
                 display: 'Deploy',
-                group: 'apps',
+                group: ' apps ',
                 namespaced: true,
                 icon: '<span class="kind-icon" aria-hidden="true">D</span>',
+                name: 'team-a',
                 href: '#deployments',
             },
-            { plural: 'nodes', namespaced: false, href: '#nodes' },
+            { plural: 'nodes', namespaced: false, icon: 42, href: '#nodes' },
+            { kind: 'Service', plural: 'services', href: '#services' },
         ];
-        feed.actions = [{ label: 'Switch theme', action: 'theme' }];
+        feed.actions = [{ label: 'Switch theme', action: ' theme ', icon: '<b>not a kind</b>' }];
         renderPaletteHarness(feed);
 
         openPalette();
 
         const scope = document.getElementById('ro-palette-scope');
-        expect(scope).toHaveTextContent('team-a');
-        expect(scope).not.toHaveAttribute('hidden');
+        expect(scope?.textContent).toBe('team-a');
+        expect((scope as HTMLElement).hidden).toBe(false);
+
+        expect(
+            Array.from(document.querySelectorAll<HTMLElement>('.ro-pal-group')).map(
+                (heading) => heading.textContent,
+            ),
+        ).toStrictEqual(['Resource types', 'Namespaces', 'Clusters', 'Actions']);
 
         const cluster = rowByLabel('prod');
-        expect(cluster).toHaveAttribute('title', 'prod');
-        expect(cluster.querySelector('.pal-label')).toHaveTextContent('Productioncurrent');
-        expect(cluster.querySelector('.pal-ctx')).toHaveTextContent('current');
-        expect(rowByLabel('team-a').querySelector('.pal-ctx')).toHaveTextContent('current');
+        expect(cluster.getAttribute('title')).toBe('prod');
+        expect(cluster.querySelector('.pal-label')?.firstChild?.textContent).toBe('Production');
+        expect(cluster.querySelector('.pal-ctx')?.className).toBe('pal-ctx');
+        expect(cluster.querySelector('.pal-ctx')?.textContent).toBe('current');
+        expect(rowByLabel('team-a').querySelector('.pal-ctx')?.textContent).toBe('current');
+        const staging = rowByLabel('staging');
+        expect(staging.getAttribute('title')).toBeNull();
+        expect(staging.querySelector('.pal-label')?.textContent).toBe('staging');
+        expect(staging.querySelector('.pal-ctx')).toBeNull();
+        expect(staging.querySelector('b')).toBeNull();
+        expect(staging.dataset.action).toBeUndefined();
+        expect(rowByLabel('Primary cluster').querySelector('.pal-label')?.textContent).toBe(
+            'Primary cluster',
+        );
+        expect(document.querySelector('[data-label="Secondary cluster"]')).toBeNull();
+        expect(rowByLabel('team-b').querySelector('.pal-ctx')).toBeNull();
 
         const deployment = rowByLabel('Deployment');
-        expect(deployment).toHaveAttribute('title', 'Deployment');
-        expect(deployment.querySelector('.kind-icon')).toHaveTextContent('D');
-        expect(deployment.querySelector('.pal-meta')).toHaveTextContent('apps');
-        expect(deployment.querySelector('.pal-scope')).toHaveClass('ns');
-        expect(deployment.querySelector('.pal-scope')).toHaveTextContent('namespaced');
+        expect(deployment.getAttribute('title')).toBe('Deployment');
+        expect(deployment.querySelector('.kind-icon')?.textContent).toBe('D');
+        expect(deployment.querySelector('.pal-meta')?.textContent).toBe('apps');
+        expect(deployment.querySelector('.pal-scope')?.className).toBe('pal-scope ns');
+        expect(deployment.querySelector('.pal-scope')?.textContent).toBe('namespaced');
+        expect(deployment.querySelector('.pal-ctx')).toBeNull();
 
         const nodes = rowByLabel('nodes');
-        expect(nodes.querySelector('.pal-meta')).toHaveTextContent('core');
-        expect(nodes.querySelector('.pal-scope')).toHaveClass('cluster');
-        expect(nodes.querySelector('.pal-scope')).toHaveTextContent('cluster');
-        expect(rowByLabel('Switch theme')).toHaveAttribute('data-action', 'theme');
+        expect(nodes.getAttribute('title')).toBeNull();
+        expect(nodes.querySelector('.pal-meta')?.textContent).toBe('core');
+        expect(nodes.querySelector('.pal-scope')?.className).toBe('pal-scope cluster');
+        expect(nodes.querySelector('.pal-scope')?.textContent).toBe('cluster');
+        expect(nodes.querySelector('.kind-icon')).toBeNull();
+        expect(rowByLabel('Service').querySelector('.pal-label')?.textContent).toBe('Service');
+        expect(document.querySelector('[data-label="services"]')).toBeNull();
+        const action = rowByLabel('Switch theme');
+        expect(action.dataset.action).toBe('theme');
+        expect(action.dataset.href).toBeUndefined();
+        expect(action.querySelector('.pal-meta')).toBeNull();
+        expect(action.querySelector('.pal-scope')).toBeNull();
+        expect(action.querySelector('b')).toBeNull();
 
+        const nodeScroll = vi.spyOn(nodes, 'scrollIntoView');
+        nodeScroll.mockClear();
         nodes.dispatchEvent(new MouseEvent('mousemove'));
         expect(activeLabel()).toBe('nodes');
-        expect(nodes).toHaveAttribute('aria-selected', 'true');
+        expect(nodes.getAttribute('aria-selected')).toBe('true');
+        expect(deployment.getAttribute('aria-selected')).toBe('false');
+        expect(nodeScroll).toHaveBeenCalledOnce();
+        expect(nodeScroll).toHaveBeenCalledWith({ block: 'nearest' });
+    });
+
+    test.each([
+        { cluster: 'prod', namespace: null, text: 'prod', hidden: false },
+        { cluster: null, namespace: null, text: '', hidden: true },
+    ])('renders the exact scope fallback for $text', ({ cluster, namespace, text, hidden }) => {
+        const feed = emptyFeed();
+        feed.currentCluster = cluster;
+        feed.currentNamespace = namespace;
+        renderPaletteHarness(feed);
+
+        openPalette();
+
+        const scope = document.getElementById('ro-palette-scope') as HTMLElement;
+        expect(scope.textContent).toBe(text);
+        expect(scope.hidden).toBe(hidden);
     });
 
     test('harvests usable table rows with status tone and skips incomplete rows', () => {
@@ -377,10 +728,53 @@ describe('safe DOM rendering and actions', () => {
         expect(document.querySelector('[data-label="No link"]')).not.toBeInTheDocument();
         expect(document.querySelector('[data-label=""]')).not.toBeInTheDocument();
         const api = rowByLabel('api-0');
-        expect(api).toHaveAttribute('data-href', '#api');
-        expect(api.querySelector('.pal-status')).toHaveTextContent('CrashLoop');
-        expect(api.querySelector('.pal-status')).toHaveClass('err');
-        expect(rowByLabel('backend').querySelector('.pal-status')).not.toBeInTheDocument();
+        expect(api.dataset.href).toBe('#api');
+        expect(api.querySelector('.pal-status')?.textContent).toBe('CrashLoop');
+        expect(api.querySelector('.pal-status')?.className).toBe('pal-status err');
+        expect(rowByLabel('backend').querySelector('.pal-status')).toBeNull();
+    });
+
+    test('preserves every supported status tone with deterministic precedence', () => {
+        const rows = [
+            ['healthy', ' ok ', 'ok'],
+            ['warning', ' warn ', 'warn'],
+            ['failed', ' err ', 'err'],
+            ['working', ' info ', 'info'],
+            ['quiet', ' mute ', 'mute'],
+            ['plain', ' custom ', 'other'],
+            ['priority', ' first ', 'err warn info'],
+            ['empty', '   ', 'ok'],
+        ]
+            .map(
+                ([name, status, classes]) => `<tr>
+                    <td class="cell-name"><a href="#${name}"> ${name} </a></td>
+                    <td class="cell-status ${classes}">${status}</td>
+                </tr>`,
+            )
+            .join('');
+        document.body.insertAdjacentHTML(
+            'beforeend',
+            `<div id="resource-list-content"><table class="ro-table"><tbody>${rows}</tbody></table></div>`,
+        );
+
+        openPalette();
+
+        for (const tone of ['ok', 'warn', 'err', 'info', 'mute']) {
+            const status = rowByLabel(
+                { ok: 'healthy', warn: 'warning', err: 'failed', info: 'working', mute: 'quiet' }[
+                    tone
+                ] as string,
+            ).querySelector('.pal-status') as HTMLElement;
+            expect(status.textContent).toBe(tone);
+            expect(status.className).toBe(`pal-status ${tone}`);
+        }
+        const plain = rowByLabel('plain').querySelector('.pal-status') as HTMLElement;
+        expect(plain.textContent).toBe('custom');
+        expect(plain.className).toBe('pal-status');
+        const priority = rowByLabel('priority').querySelector('.pal-status') as HTMLElement;
+        expect(priority.textContent).toBe('first');
+        expect(priority.className).toBe('pal-status warn');
+        expect(rowByLabel('empty').querySelector('.pal-status')).toBeNull();
     });
 
     test('rejects unsafe href schemes harvested from rendered table rows', () => {
@@ -445,14 +839,8 @@ describe('safe DOM rendering and actions', () => {
         expect(document.querySelector('#ro-palette-list img')).not.toBeInTheDocument();
         expect(document.querySelector('#ro-palette-list script')).not.toBeInTheDocument();
         for (const label of ['javascript target', 'data target', 'vbscript target']) {
-            expect(rowByLabel(label)).not.toHaveAttribute('data-href');
+            expect(document.querySelector(`[data-label="${label}"]`)).toBeNull();
         }
-
-        const unsafe = rowByLabel('javascript target');
-        binding('click', '[data-ro-action="pick-palette-row"]').handler(
-            new MouseEvent('click', { cancelable: true }),
-            unsafe,
-        );
         expect(window.location.hash).toBe('');
     });
 
@@ -525,6 +913,62 @@ describe('safe DOM rendering and actions', () => {
             { label: 'Switch theme', action: 'theme' },
         ]);
     });
+
+    test('theme wins over a mixed href target and remains safe without a toggle', () => {
+        const feed = emptyFeed();
+        feed.actions = [{ label: 'Theme with href', action: 'theme', href: '#must-not-navigate' }];
+        renderPaletteHarness(feed);
+        window.location.hash = '#before';
+        document.getElementById('btn-theme-toggle')?.remove();
+        openPalette();
+
+        expect(() =>
+            binding('click', '[data-ro-action="pick-palette-row"]').handler(
+                new MouseEvent('click', { cancelable: true }),
+                rowByLabel('Theme with href'),
+            ),
+        ).not.toThrow();
+
+        expect(window.location.hash).toBe('#before');
+        expect(document.getElementById('ro-palette')).not.toHaveClass('open');
+        expect(JSON.parse(window.localStorage.getItem('ro-pref-recents') || 'null')).toStrictEqual([
+            { label: 'Theme with href', href: '#must-not-navigate', action: 'theme' },
+        ]);
+    });
+
+    test('an unknown action may still carry its explicit navigation destination', () => {
+        const feed = emptyFeed();
+        feed.actions = [{ label: 'Navigate action', action: 'future-action', href: '#future' }];
+        renderPaletteHarness(feed);
+        openPalette();
+
+        binding('click', '[data-ro-action="pick-palette-row"]').handler(
+            new MouseEvent('click', { cancelable: true }),
+            rowByLabel('Navigate action'),
+        );
+
+        expect(window.location.hash).toBe('#future');
+        expect(JSON.parse(window.localStorage.getItem('ro-pref-recents') || 'null')).toStrictEqual([
+            { label: 'Navigate action', href: '#future', action: 'future-action' },
+        ]);
+    });
+
+    test('delegated malformed rows can act, but are never persisted as recents', () => {
+        const choose = binding('click', '[data-ro-action="pick-palette-row"]');
+        const missingLabel = document.createElement('div');
+        missingLabel.dataset.href = '#raw-target';
+
+        choose.handler(new MouseEvent('click', { cancelable: true }), missingLabel);
+
+        expect(window.location.hash).toBe('#raw-target');
+        expect(window.localStorage.getItem('ro-pref-recents')).toBeNull();
+
+        const missingTarget = document.createElement('div');
+        missingTarget.dataset.label = 'Dead row';
+        choose.handler(new MouseEvent('click', { cancelable: true }), missingTarget);
+
+        expect(window.localStorage.getItem('ro-pref-recents')).toBeNull();
+    });
 });
 
 describe('delegated entry points and dismissal', () => {
@@ -544,7 +988,9 @@ describe('delegated entry points and dismissal', () => {
         expect(input).toHaveFocus();
 
         input.value = 'deploy';
-        expect(binding('input', '#ro-palette-input').handler(new Event('input'), input)).toBe(true);
+        const inputEvent = new Event('input', { cancelable: true });
+        expect(binding('input', '#ro-palette-input').handler(inputEvent, input)).toBe(true);
+        expect(inputEvent.defaultPrevented).toBe(false);
         expect(rowByLabel('Deployments')).toBeInTheDocument();
         expect(document.querySelector('.ro-pal-item .ico')).toHaveTextContent('search');
         expect(document.querySelector('.ro-pal-item')).toHaveAttribute(
@@ -569,6 +1015,30 @@ describe('delegated entry points and dismissal', () => {
         expect(rowByLabel('Services')).toBeInTheDocument();
     });
 
+    test('missing or non-string programmatic prefills reset to the empty query', () => {
+        const feed = emptyFeed();
+        feed.clusters = [{ name: 'Pods', href: '#pods' }];
+        renderPaletteHarness(feed);
+        const input = document.getElementById('ro-palette-input') as HTMLInputElement;
+        const refine = document.createElement('button');
+        const refineEvent = targetedMouseEvent(refine);
+
+        input.value = 'stale';
+        expect(binding('click', '[data-ro-search-refine]').handler(refineEvent, refine)).toBe(true);
+        expect(refineEvent.defaultPrevented).toBe(true);
+        expect(input.value).toBe('');
+        expect(document.querySelector('.ro-pal-group')?.textContent).toBe('Clusters');
+
+        input.value = 'stale again';
+        (
+            window as unknown as {
+                roOpenPalette: (prefill: unknown) => void;
+            }
+        ).roOpenPalette(42);
+        expect(input.value).toBe('');
+        expect(rowByLabel('Pods')).toBeInTheDocument();
+    });
+
     test('only a click on the backdrop itself dismisses the palette', () => {
         openPalette('pods');
         const palette = document.getElementById('ro-palette') as HTMLElement;
@@ -578,12 +1048,19 @@ describe('delegated entry points and dismissal', () => {
         expect(backdrop.handler(targetedMouseEvent(panel), palette)).toBe(false);
         expect(palette).toHaveClass('open');
 
+        const text = document.createTextNode('not an element');
+        panel.appendChild(text);
+        expect(() => backdrop.handler(targetedMouseEvent(text), palette)).not.toThrow();
+        expect(backdrop.handler(targetedMouseEvent(text), palette)).toBe(false);
+        expect(palette).toHaveClass('open');
+
         expect(backdrop.handler(targetedMouseEvent(palette), palette)).toBe(true);
         expect(palette).not.toHaveClass('open');
     });
 
     test('focus-opening restores the opener without immediately reopening the palette', () => {
         const opener = document.getElementById('palette-opener') as HTMLButtonElement;
+        const blur = vi.spyOn(opener, 'blur');
         const focusBinding = binding('focusin', '[data-ro-palette-open]');
         const listener = (event: FocusEvent): void => {
             if (event.target === opener) {
@@ -596,11 +1073,13 @@ describe('delegated entry points and dismissal', () => {
             opener.focus();
             expect(document.getElementById('ro-palette')).toHaveClass('open');
             expect(document.getElementById('ro-palette-input')).toHaveFocus();
+            expect(blur).toHaveBeenCalledOnce();
 
             closePalette();
 
             expect(opener).toHaveFocus();
             expect(document.getElementById('ro-palette')).not.toHaveClass('open');
+            expect(blur).toHaveBeenCalledOnce();
         } finally {
             document.removeEventListener('focusin', listener);
         }
@@ -622,6 +1101,10 @@ describe('delegated entry points and dismissal', () => {
         expect(filterEscape.defaultPrevented).toBe(false);
         expect(document.getElementById('ro-palette')).toHaveClass('open');
 
+        const filterArrow = targetedKeyboardEvent('ArrowDown', filter);
+        openKeys.handler(filterArrow, null);
+        expect(filterArrow.defaultPrevented).toBe(false);
+
         const unrelated = targetedKeyboardEvent('x', document.body);
         openKeys.handler(unrelated, null);
         expect(unrelated.defaultPrevented).toBe(false);
@@ -631,6 +1114,15 @@ describe('delegated entry points and dismissal', () => {
         openKeys.handler(escapeKey, null);
         expect(escapeKey.defaultPrevented).toBe(true);
         expect(document.getElementById('ro-palette')).not.toHaveClass('open');
+
+        openPalette();
+        const targetlessEscape = new KeyboardEvent('keydown', {
+            key: 'Escape',
+            cancelable: true,
+        });
+        openKeys.handler(targetlessEscape, null);
+        expect(targetlessEscape.defaultPrevented).toBe(true);
+        expect(document.getElementById('ro-palette')).not.toHaveClass('open');
     });
 
     test('does not hijack modified or unrelated keyboard shortcuts', () => {
@@ -638,6 +1130,8 @@ describe('delegated entry points and dismissal', () => {
         const events = [
             targetedKeyboardEvent('k', document.body),
             targetedKeyboardEvent('k', document.body, { metaKey: true, altKey: true }),
+            targetedKeyboardEvent('k', document.body, { ctrlKey: true, altKey: true }),
+            targetedKeyboardEvent('k', document.body, { metaKey: true, shiftKey: true }),
             targetedKeyboardEvent('k', document.body, { ctrlKey: true, shiftKey: true }),
             targetedKeyboardEvent('x', document.body, { metaKey: true }),
         ];
@@ -654,9 +1148,19 @@ describe('delegated entry points and dismissal', () => {
     test('defensive DOM gaps are no-ops instead of breaking the page', () => {
         document.getElementById('ro-palette-input')?.remove();
         expect(() => openPalette()).not.toThrow();
+        expect(document.getElementById('ro-palette')).not.toHaveClass('open');
+
+        renderPaletteHarness();
+        document.getElementById('ro-palette')?.remove();
+        expect(() => openPalette()).not.toThrow();
 
         renderPaletteHarness();
         document.getElementById('ro-palette-list')?.remove();
+        expect(() => openPalette()).not.toThrow();
+        expect(document.getElementById('ro-palette')).toHaveClass('open');
+
+        renderPaletteHarness();
+        document.getElementById('ro-palette-scope')?.remove();
         expect(() => openPalette()).not.toThrow();
         expect(document.getElementById('ro-palette')).toHaveClass('open');
 
@@ -670,6 +1174,7 @@ describe('focus and keyboard model', () => {
         const prior = document.getElementById('prior-focus') as HTMLButtonElement;
         const input = document.getElementById('ro-palette-input') as HTMLInputElement;
         prior.focus();
+        const restore = vi.spyOn(prior, 'focus');
 
         openPalette('pods');
         openPalette('services');
@@ -684,6 +1189,78 @@ describe('focus and keyboard model', () => {
         expect(document.getElementById('ro-palette')).not.toHaveClass('open');
         expect(document.getElementById('ro-palette')).toHaveAttribute('aria-hidden', 'true');
         expect(prior).toHaveFocus();
+        expect(restore).toHaveBeenCalledOnce();
+
+        closePalette();
+        expect(restore).toHaveBeenCalledOnce();
+    });
+
+    test('close refuses stale and inside-palette restore targets', () => {
+        const palette = document.getElementById('ro-palette') as HTMLElement;
+        const inside = document.createElement('button');
+        palette.appendChild(inside);
+        inside.focus();
+        const insideRestore = vi.spyOn(inside, 'focus');
+
+        openPalette();
+        closePalette();
+
+        expect(insideRestore).not.toHaveBeenCalled();
+
+        const detached = document.getElementById('prior-focus') as HTMLButtonElement;
+        detached.focus();
+        const detachedRestore = vi.spyOn(detached, 'focus');
+        openPalette();
+        detached.remove();
+        closePalette();
+        expect(detachedRestore).not.toHaveBeenCalled();
+    });
+
+    test('close restores a connected focusable SVG target', () => {
+        const palette = document.getElementById('ro-palette') as HTMLElement;
+
+        const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        svg.setAttribute('tabindex', '0');
+        document.body.appendChild(svg);
+        svg.focus();
+        expect(document.activeElement).toBe(svg);
+        const svgRestore = vi.spyOn(svg, 'focus');
+        openPalette();
+        closePalette();
+        expect(svgRestore).toHaveBeenCalledOnce();
+        expect(document.activeElement).toBe(svg);
+        expect(palette).not.toHaveClass('open');
+    });
+
+    test('close safely skips a connected prior Element without a focus method', () => {
+        const inert = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        document.body.appendChild(inert);
+        Object.defineProperty(inert, 'focus', { configurable: true, value: undefined });
+        const activeElement = vi.spyOn(document, 'activeElement', 'get').mockReturnValue(inert);
+        openPalette();
+        activeElement.mockRestore();
+
+        expect(() => closePalette()).not.toThrow();
+        expect(document.getElementById('ro-palette')).not.toHaveClass('open');
+    });
+
+    test('a throwing focus restore always releases the reopen gate', () => {
+        const prior = document.getElementById('prior-focus') as HTMLButtonElement;
+        const opener = document.getElementById('palette-opener') as HTMLButtonElement;
+        prior.focus();
+        openPalette();
+        vi.spyOn(prior, 'focus').mockImplementation(() => {
+            throw new Error('focus failed');
+        });
+
+        expect(() => closePalette()).toThrow('focus failed');
+
+        const blur = vi.spyOn(opener, 'blur');
+        const event = new FocusEvent('focusin');
+        Object.defineProperty(event, 'target', { configurable: true, value: opener });
+        binding('focusin', '[data-ro-palette-open]').handler(event, opener);
+        expect(document.getElementById('ro-palette')).toHaveClass('open');
+        expect(blur).toHaveBeenCalledOnce();
     });
 
     test('Arrow and Tab keys wrap the active row, and Enter activates it', () => {
@@ -691,35 +1268,56 @@ describe('focus and keyboard model', () => {
         feed.clusters = [
             { name: 'Alpha', href: '#alpha' },
             { name: 'Beta', href: '#beta' },
+            { name: 'Gamma', href: '#gamma' },
         ];
         renderPaletteHarness(feed);
         openPalette();
         const input = document.getElementById('ro-palette-input') as HTMLInputElement;
         const openKeys = binding('keydown', undefined, 1);
+        const alpha = rowByLabel('Alpha');
+        const beta = rowByLabel('Beta');
+        const gamma = rowByLabel('Gamma');
+        const alphaScroll = vi.spyOn(alpha, 'scrollIntoView');
+        const betaScroll = vi.spyOn(beta, 'scrollIntoView');
+        const gammaScroll = vi.spyOn(gamma, 'scrollIntoView');
 
         expect(activeLabel()).toBe('Alpha');
 
         const up = targetedKeyboardEvent('ArrowUp', input);
         openKeys.handler(up, null);
         expect(up.defaultPrevented).toBe(true);
-        expect(activeLabel()).toBe('Beta');
+        expect(activeLabel()).toBe('Gamma');
+        expect(alpha.getAttribute('aria-selected')).toBe('false');
+        expect(gamma.getAttribute('aria-selected')).toBe('true');
+        expect(gammaScroll).toHaveBeenLastCalledWith({ block: 'nearest' });
 
-        openKeys.handler(targetedKeyboardEvent('ArrowDown', input), null);
+        const down = targetedKeyboardEvent('ArrowDown', input);
+        openKeys.handler(down, null);
+        expect(down.defaultPrevented).toBe(true);
         expect(activeLabel()).toBe('Alpha');
+        expect(alphaScroll).toHaveBeenLastCalledWith({ block: 'nearest' });
 
-        openKeys.handler(targetedKeyboardEvent('Tab', input), null);
+        const tab = targetedKeyboardEvent('Tab', input);
+        openKeys.handler(tab, null);
+        expect(tab.defaultPrevented).toBe(true);
         expect(activeLabel()).toBe('Beta');
+        expect(betaScroll).toHaveBeenLastCalledWith({ block: 'nearest' });
 
-        openKeys.handler(targetedKeyboardEvent('Tab', input, { shiftKey: true }), null);
+        const shiftTab = targetedKeyboardEvent('Tab', input, { shiftKey: true });
+        openKeys.handler(shiftTab, null);
+        expect(shiftTab.defaultPrevented).toBe(true);
         expect(activeLabel()).toBe('Alpha');
-        openKeys.handler(targetedKeyboardEvent('ArrowUp', input), null);
-        expect(activeLabel()).toBe('Beta');
-        expect(rowByLabel('Beta')).toHaveAttribute('aria-selected', 'true');
+        expect(alphaScroll).toHaveBeenLastCalledWith({ block: 'nearest' });
+        const secondUp = targetedKeyboardEvent('ArrowUp', input);
+        openKeys.handler(secondUp, null);
+        expect(secondUp.defaultPrevented).toBe(true);
+        expect(activeLabel()).toBe('Gamma');
+        expect(gamma.getAttribute('aria-selected')).toBe('true');
 
         const enter = targetedKeyboardEvent('Enter', input);
         openKeys.handler(enter, null);
         expect(enter.defaultPrevented).toBe(true);
-        expect(window.location.hash).toBe('#beta');
+        expect(window.location.hash).toBe('#gamma');
     });
 
     test('keyboard navigation is a safe no-op for an empty open palette', () => {
@@ -728,20 +1326,38 @@ describe('focus and keyboard model', () => {
         const input = document.getElementById('ro-palette-input') as HTMLInputElement;
         const openKeys = binding('keydown', undefined, 1);
 
-        expect(() => {
-            openKeys.handler(targetedKeyboardEvent('ArrowDown', input), null);
-            openKeys.handler(targetedKeyboardEvent('ArrowUp', input), null);
-            openKeys.handler(targetedKeyboardEvent('Enter', input), null);
-        }).not.toThrow();
+        const events = [
+            targetedKeyboardEvent('ArrowDown', input),
+            targetedKeyboardEvent('ArrowUp', input),
+            targetedKeyboardEvent('Enter', input),
+            targetedKeyboardEvent('Tab', input),
+            targetedKeyboardEvent('Tab', input, { shiftKey: true }),
+        ];
+        expect(() =>
+            events.forEach((event) => {
+                openKeys.handler(event, null);
+            }),
+        ).not.toThrow();
 
+        events.forEach((event) => {
+            expect(event.defaultPrevented).toBe(true);
+        });
         expect(window.location.hash).toBe('');
+        expect(window.localStorage.getItem('ro-pref-recents')).toBeNull();
         expect(document.getElementById('ro-palette')).toHaveClass('open');
+        expect(HTMLElement.prototype.scrollIntoView).not.toHaveBeenCalled();
     });
 
-    test('the command chord closes competing surfaces before opening the palette', () => {
+    test.each([
+        { key: 'k', modifiers: { metaKey: true } },
+        { key: 'K', modifiers: { metaKey: true } },
+        { key: 'k', modifiers: { ctrlKey: true } },
+        { key: 'K', modifiers: { ctrlKey: true } },
+        { key: 'k', modifiers: { metaKey: true, ctrlKey: true } },
+    ])('the $key command chord closes competing surfaces for $modifiers', ({ key, modifiers }) => {
         const chord = binding('keydown', undefined, 0);
         const target = document.body;
-        const event = targetedKeyboardEvent('k', target, { metaKey: true });
+        const event = targetedKeyboardEvent(key, target, modifiers);
 
         chord.handler(event, null);
 

--- a/internal/assets/src/js/palette.ts
+++ b/internal/assets/src/js/palette.ts
@@ -52,6 +52,27 @@ interface PaletteData extends PaletteFeed {
     currentNamespace: string | null;
 }
 
+// JSON primitives, null, and arrays cannot carry any of the named palette
+// fields. Box every parsed value, then validate the fields we actually consume;
+// this avoids a redundant broad "is object" gate before the real schema checks.
+function asPropertyRecord(value: unknown): Record<string, unknown> {
+    return Object(value) as Record<string, unknown>;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function feedEntryLabel(entry: Record<string, unknown>, kindEntry: boolean): string | undefined {
+    return kindEntry
+        ? (nonEmptyString(entry.kind) ?? nonEmptyString(entry.plural))
+        : (nonEmptyString(entry.name) ?? nonEmptyString(entry.label));
+}
+
 // Parse the #ro-palette-data JSON blob into the grouped feed. Guarded end to
 // end: a missing/empty/malformed blob yields an all-empty feed (the palette
 // still opens with a "no targets" state) and NEVER throws. Re-read on every
@@ -71,28 +92,30 @@ function readPaletteData(): PaletteData {
     if (!el) {
         return empty;
     }
-    const raw = (el.textContent || '').trim();
-    if (!raw) {
-        return empty;
-    }
     try {
-        const data = JSON.parse(raw);
-        if (!data || typeof data !== 'object' || Array.isArray(data)) {
-            return empty;
-        }
-        // Normalise: every group is an array of records even if the blob
-        // omitted/nulled it or contains malformed scalar/null entries.
-        (['clusters', 'namespaces', 'kinds', 'actions'] as const).forEach((k) => {
-            if (!Array.isArray(data[k])) {
-                data[k] = [];
-                return;
-            }
-            data[k] = data[k].filter(
-                (entry: unknown) =>
-                    entry !== null && typeof entry === 'object' && !Array.isArray(entry),
-            );
-        });
-        return data as PaletteData;
+        const data = asPropertyRecord(JSON.parse(el.textContent as string));
+        // Normalise into a fresh, fully-validated shape: every group is an
+        // array of labelled, navigable records and malformed scope fields
+        // become absent. Dead/unsafe rows never reach the ranker or the DOM.
+        const records = (value: unknown, kindEntries = false): Record<string, unknown>[] =>
+            Array.isArray(value)
+                ? value
+                      .map(asPropertyRecord)
+                      .filter((entry) => feedEntryLabel(entry, kindEntries) !== undefined)
+                      .filter(
+                          (entry) =>
+                              paletteHrefSafe(entry.href) !== '' ||
+                              nonEmptyString(entry.action) !== undefined,
+                      )
+                : [];
+        return {
+            currentCluster: nonEmptyString(data.currentCluster) ?? null,
+            currentNamespace: nonEmptyString(data.currentNamespace) ?? null,
+            clusters: records(data.clusters),
+            namespaces: records(data.namespaces),
+            kinds: records(data.kinds, true),
+            actions: records(data.actions),
+        };
     } catch {
         return empty; // malformed blob -> empty palette, no throw
     }
@@ -102,15 +125,19 @@ function readPaletteData(): PaletteData {
 // (never user-typed), but as defence in depth we still refuse anything that is
 // not a same-origin path / http(s) URL before navigating -- a javascript:,
 // data:, or vbscript: scheme is never navigated.
-function paletteHrefSafe(href: unknown): string {
-    if (!href || typeof href !== 'string') {
+export function paletteHrefSafe(href: unknown, pageHref: string = window.location.href): string {
+    if (typeof href !== 'string') {
         return '';
     }
     const trimmed = href.trim();
-    if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed) && !/^https?:/i.test(trimmed)) {
+    try {
+        const page = new URL(pageHref);
+        const parsed = new URL(trimmed, page);
+        const networkProtocol = parsed.protocol === 'http:' || parsed.protocol === 'https:';
+        return networkProtocol && parsed.origin === page.origin ? trimmed : '';
+    } catch {
         return '';
     }
-    return trimmed;
 }
 
 // --- Palette Recents: the last 5 CHOSEN entries, in
@@ -122,48 +149,29 @@ const PALETTE_RECENTS_KEY = 'ro-pref-recents';
 const PALETTE_RECENTS_MAX = 5;
 
 function readPaletteRecents(): RecentEntry[] {
-    let raw: string | null = null;
     try {
-        raw = window.localStorage.getItem(PALETTE_RECENTS_KEY);
-    } catch {
-        return []; // localStorage unavailable (privacy mode) -> no recents
-    }
-    if (!raw) {
-        return [];
-    }
-    try {
-        const list = JSON.parse(raw);
-        if (!Array.isArray(list)) {
+        const raw = window.localStorage.getItem(PALETTE_RECENTS_KEY);
+        if (!raw) {
             return [];
         }
+        const list: unknown = JSON.parse(raw);
         // Shape-check, normalise and dedupe every entry. The store is newest
         // first, so the first occurrence of a destination wins. Apply the cap
         // after dedupe so corrupt/legacy duplicates do not crowd out valid rows.
         const recents: RecentEntry[] = [];
         const seen = new Set<string>();
-        for (const value of list) {
-            if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        for (const value of list as unknown[]) {
+            const record = asPropertyRecord(value);
+            const label = nonEmptyString(record.label);
+            if (!label) {
                 continue;
             }
-            const candidate = value as Record<string, unknown>;
-            if (typeof candidate.label !== 'string' || candidate.label === '') {
-                continue;
-            }
-            const href = paletteHrefSafe(candidate.href);
-            const action =
-                typeof candidate.action === 'string' && candidate.action !== ''
-                    ? candidate.action
-                    : '';
+            const href = paletteHrefSafe(record.href);
+            const action = nonEmptyString(record.action);
             if (!href && !action) {
                 continue;
             }
-            const recent: RecentEntry = { label: candidate.label };
-            if (href) {
-                recent.href = href;
-            }
-            if (action) {
-                recent.action = action;
-            }
+            const recent: RecentEntry = { label, href: href || undefined, action };
             const target = paletteRecentTarget(recent);
             if (seen.has(target)) {
                 continue;
@@ -176,21 +184,19 @@ function readPaletteRecents(): RecentEntry[] {
         }
         return recents;
     } catch {
-        return []; // corrupt store -> ignored (next record starts fresh)
+        return []; // corrupt/unavailable store -> ignored (next record starts fresh)
     }
 }
 
-function recordPaletteRecent(label: string, href: string, action: string): void {
+function recordPaletteRecent(
+    label: string | undefined,
+    href: string | undefined,
+    action: string | undefined,
+): void {
     if (!label || (!href && !action)) {
         return; // not a navigable choice -> never recorded
     }
-    const entry: RecentEntry = { label: label };
-    if (href) {
-        entry.href = href;
-    }
-    if (action) {
-        entry.action = action;
-    }
+    const entry: RecentEntry = { label, href, action };
     const kept = dedupeRecents(readPaletteRecents(), entry, PALETTE_RECENTS_MAX);
     try {
         window.localStorage.setItem(PALETTE_RECENTS_KEY, JSON.stringify(kept));
@@ -199,12 +205,10 @@ function recordPaletteRecent(label: string, href: string, action: string): void 
     }
 }
 
-// The flat list of currently-rendered rows ({ el, item }) in visual order, and
+// The flat list of currently-rendered row elements in visual order, and
 // the index of the active one -- the model the arrows + Enter drive.
 interface PaletteRow {
     el: HTMLElement;
-    item: unknown;
-    key: string;
 }
 let paletteRows: PaletteRow[] = [];
 let paletteActive = 0;
@@ -216,53 +220,66 @@ const paletteScope: { cluster: string | null; namespace: string | null } = {
     namespace: null,
 };
 
-// Build one row element for a blob entry in group `key`. Names go in via
-// textContent; the kind `icon` (server-escaped markup) is the ONLY innerHTML.
-function buildPaletteRow(entry: Record<string, unknown>, key: string): HTMLElement {
+function createPaletteRow(): HTMLElement {
     const row = document.createElement('div');
     row.className = 'ro-pal-item';
     row.dataset.roAction = 'pick-palette-row';
     row.setAttribute('role', 'option');
-    row.setAttribute('aria-selected', 'false');
+    return row;
+}
 
-    if (key === 'kinds' && entry.icon) {
+function appendPaletteLabel(row: HTMLElement, text: string): HTMLSpanElement {
+    const label = document.createElement('span');
+    label.className = 'pal-label';
+    label.textContent = text;
+    row.appendChild(label);
+    return label;
+}
+
+// Build one row element for a blob entry in group `key`. Names go in via
+// textContent; the kind `icon` (server-escaped markup) is the ONLY innerHTML.
+function buildPaletteRow(entry: Record<string, unknown>, key: string): HTMLElement {
+    const row = createPaletteRow();
+    const kindRow = key === 'kinds';
+
+    const icon = nonEmptyString(entry.icon);
+    if (kindRow && icon) {
         const holder = document.createElement('template');
-        holder.innerHTML = String(entry.icon); // server-escaped markup -- the only innerHTML
+        holder.innerHTML = icon; // server-escaped markup -- the only innerHTML
         row.appendChild(holder.content);
     }
 
-    const labelText =
-        key === 'kinds'
-            ? String(entry.kind || entry.plural || '')
-            : String(entry.name || entry.label || '');
-    const display =
-        typeof entry.display === 'string' && entry.display !== '' ? entry.display : labelText;
-    const label = document.createElement('span');
-    label.className = 'pal-label';
-    label.textContent = display;
+    // readPaletteData admits only entries with this label invariant.
+    const labelText = feedEntryLabel(entry, kindRow) as string;
+    const display = nonEmptyString(entry.display) ?? labelText;
+    const label = appendPaletteLabel(row, display);
     if (display !== labelText) {
         row.title = labelText; // truncated -> full name in the tooltip
     }
 
-    const isCurrent =
-        (key === 'clusters' && entry.name && entry.name === paletteScope.cluster) ||
-        (key === 'namespaces' && entry.name && entry.name === paletteScope.namespace);
-    if (isCurrent) {
+    const entryName = nonEmptyString(entry.name);
+    const currentScope =
+        key === 'clusters'
+            ? paletteScope.cluster
+            : key === 'namespaces'
+              ? paletteScope.namespace
+              : null;
+    if (entryName && entryName === currentScope) {
         const ctx = document.createElement('span');
         ctx.className = 'pal-ctx';
         ctx.textContent = 'current';
         label.appendChild(ctx);
     }
-    row.appendChild(label);
 
-    if (key === 'kinds') {
+    if (kindRow) {
         const meta = document.createElement('span');
         meta.className = 'pal-meta';
-        meta.textContent = String(entry.group || 'core');
+        meta.textContent = nonEmptyString(entry.group) ?? 'core';
         row.appendChild(meta);
         const scope = document.createElement('span');
-        scope.className = `pal-scope ${entry.namespaced ? 'ns' : 'cluster'}`;
-        scope.textContent = entry.namespaced ? 'namespaced' : 'cluster';
+        const namespaced = entry.namespaced === true;
+        scope.className = `pal-scope ${namespaced ? 'ns' : 'cluster'}`;
+        scope.textContent = namespaced ? 'namespaced' : 'cluster';
         row.appendChild(scope);
     }
 
@@ -270,8 +287,9 @@ function buildPaletteRow(entry: Record<string, unknown>, key: string): HTMLEleme
     if (href) {
         row.dataset.href = href;
     }
-    if (entry.action) {
-        row.dataset.action = String(entry.action);
+    const action = nonEmptyString(entry.action);
+    if (action) {
+        row.dataset.action = action;
     }
     row.dataset.label = labelText;
     return row;
@@ -281,53 +299,32 @@ function buildPaletteRow(entry: Record<string, unknown>, key: string): HTMLEleme
 // query exists: `Search all clusters for "q"` -> a plain GET /search?q=. The
 // leading glyph is a CLONE of the palette's own server-rendered search icon.
 function buildEverywhereRow(query: string): HTMLElement {
-    const row = document.createElement('div');
-    row.className = 'ro-pal-item';
-    row.dataset.roAction = 'pick-palette-row';
-    row.setAttribute('role', 'option');
-    row.setAttribute('aria-selected', 'false');
+    const row = createPaletteRow();
     const glyph = document.querySelector(`#${PALETTE_ID} .ro-pal-search .ico`);
     if (glyph) {
         row.appendChild(glyph.cloneNode(true));
     }
-    const label = document.createElement('span');
-    label.className = 'pal-label';
-    label.textContent = `Search all clusters for “${query}”`;
-    row.appendChild(label);
+    const labelText = `Search all clusters for “${query}”`;
+    appendPaletteLabel(row, labelText);
     row.dataset.href = `/search?q=${encodeURIComponent(query)}`;
-    row.dataset.label = label.textContent;
+    row.dataset.label = labelText;
     return row;
 }
 
-// buildRecentRow renders one persisted recent: label-led (textContent), with the
-// destination re-vetted through paletteHrefSafe before it lands in the dataset.
-function buildRecentRow(entry: RecentEntry): HTMLElement {
-    const row = document.createElement('div');
-    row.className = 'ro-pal-item';
-    row.dataset.roAction = 'pick-palette-row';
-    row.setAttribute('role', 'option');
-    row.setAttribute('aria-selected', 'false');
-    const label = document.createElement('span');
-    label.className = 'pal-label';
-    label.textContent = entry.label;
-    row.appendChild(label);
-    const href = paletteHrefSafe(entry.href);
-    if (href) {
-        row.dataset.href = href;
-    }
-    if (entry.action) {
-        row.dataset.action = entry.action;
-    }
-    row.dataset.label = entry.label;
-    return row;
+const PALETTE_STATUS_TONES = ['ok', 'warn', 'err', 'info', 'mute'] as const;
+
+interface PalettePageObject extends PageObject {
+    href: string;
+    status?: string;
+    tone?: string;
 }
 
 // harvestPageObjects reads the rows of the rendered list table into
 // {name, href, status, tone}. While the Unit-24 virtualizer is engaged the DOM
 // holds only a window of the rows -- harvest from the full row set (the
 // virtualizer module, imported directly) so ⌘K filters every object on the page.
-function harvestPageObjects(): PageObject[] {
-    const out: PageObject[] = [];
+function harvestPageObjects(): PalettePageObject[] {
+    const out: PalettePageObject[] = [];
     const rows: ArrayLike<Element> = virtualizerActive()
         ? virtRows()
         : document.querySelectorAll('#resource-list-content table.ro-table tbody tr');
@@ -337,45 +334,35 @@ function harvestPageObjects(): PageObject[] {
             return;
         }
         const href = paletteHrefSafe(a.getAttribute('href'));
-        const name = (a.textContent || '').trim();
+        const name = (a.textContent as string).trim();
         if (!href || !name) {
             return;
         }
-        let status = '';
-        let tone = '';
+        const object: PalettePageObject = { name, href };
         const st = tr.querySelector('.cell-status');
         if (st) {
-            status = (st.textContent || '').trim();
-            ['ok', 'warn', 'err', 'info', 'mute'].forEach((t) => {
-                if (!tone && st.classList.contains(t)) {
-                    tone = t;
-                }
-            });
+            object.status = (st.textContent as string).trim();
+            object.tone = PALETTE_STATUS_TONES.find((candidate) =>
+                st.classList.contains(candidate),
+            );
         }
-        out.push({ name: name, href: href, status: status, tone: tone });
+        out.push(object);
     });
     return out;
 }
 
 // buildObjectRow renders one harvested page object: its name (textContent) + a
 // tone-coloured short status. The detail href rides in the dataset.
-function buildObjectRow(o: PageObject): HTMLElement {
-    const row = document.createElement('div');
-    row.className = 'ro-pal-item';
-    row.dataset.roAction = 'pick-palette-row';
-    row.setAttribute('role', 'option');
-    row.setAttribute('aria-selected', 'false');
-    const label = document.createElement('span');
-    label.className = 'pal-label';
-    label.textContent = o.name;
-    row.appendChild(label);
+function buildObjectRow(o: PalettePageObject): HTMLElement {
+    const row = createPaletteRow();
+    appendPaletteLabel(row, o.name);
     if (o.status) {
         const st = document.createElement('span');
-        st.className = `pal-status${o.tone ? ` ${String(o.tone)}` : ''}`;
-        st.textContent = String(o.status);
+        st.className = `pal-status${o.tone ? ` ${o.tone}` : ''}`;
+        st.textContent = o.status;
         row.appendChild(st);
     }
-    row.dataset.href = String(o.href);
+    row.dataset.href = o.href;
     row.dataset.label = o.name;
     return row;
 }
@@ -389,28 +376,26 @@ function renderPalette(query: string): void {
         return;
     }
     const data = readPaletteData();
-    paletteScope.cluster = data.currentCluster || null;
-    paletteScope.namespace = data.currentNamespace || null;
+    paletteScope.cluster = data.currentCluster;
+    paletteScope.namespace = data.currentNamespace;
 
     const scope = document.getElementById('ro-palette-scope');
     if (scope) {
-        const scopeText = paletteScope.namespace || paletteScope.cluster || '';
-        scope.textContent = scopeText;
-        (scope as HTMLElement).hidden = scopeText === '';
+        const scopeText = paletteScope.namespace ?? paletteScope.cluster;
+        scope.textContent = scopeText ?? '';
+        (scope as HTMLElement).hidden = scopeText === null;
     }
 
-    const q = (query || '').trim();
-    list.textContent = '';
+    const q = query;
+    list.replaceChildren();
     paletteRows = [];
 
     const rowFor = (item: unknown, key: string): HTMLElement => {
         switch (key) {
             case 'everywhere':
                 return buildEverywhereRow((item as { query: string }).query);
-            case 'recents':
-                return buildRecentRow(item as RecentEntry);
             case 'objects':
-                return buildObjectRow(item as PageObject);
+                return buildObjectRow(item as PalettePageObject);
             default:
                 return buildPaletteRow(item as Record<string, unknown>, key);
         }
@@ -438,7 +423,7 @@ function renderPalette(query: string): void {
             const idx = paletteRows.length;
             row.addEventListener('mousemove', () => setPaletteActive(idx));
             list.appendChild(row);
-            paletteRows.push({ el: row, item: item, key: group.key });
+            paletteRows.push({ el: row });
         });
     });
 
@@ -465,47 +450,30 @@ function paintPaletteActive(): void {
     }
 }
 
-// Seat the active row at a clamped index (guards empty + out-of-range).
+// Seat the active row selected by one of the currently-rendered row listeners.
 function setPaletteActive(index: number): void {
-    if (paletteRows.length === 0) {
-        return;
-    }
-    let i = index;
-    if (i < 0) {
-        i = 0;
-    }
-    if (i > paletteRows.length - 1) {
-        i = paletteRows.length - 1;
-    }
-    paletteActive = i;
+    paletteActive = index;
     paintPaletteActive();
 }
 
-// Move the active row by delta, wrapping at the ends. Guards empty.
+// Move the active row by delta, wrapping at the ends. With no rows there is no
+// addressable active element, so paintPaletteActive remains a no-op.
 function movePaletteActive(delta: number): void {
-    if (paletteRows.length === 0) {
-        return;
-    }
-    paletteActive = (paletteActive + delta + paletteRows.length) % paletteRows.length;
+    const length = paletteRows.length;
+    paletteActive = (paletteActive + delta + length) % length;
     paintPaletteActive();
 }
 
 // Act on a chosen row: run its named client action and/or navigate to its
 // server-built href, then close. EVERY choice is first recorded into Recents
 // -- click and ⏎ both land here.
-function choosePaletteRow(rowEl: HTMLElement | null): void {
-    if (!rowEl) {
-        return;
-    }
+function choosePaletteRow(rowEl: HTMLElement): void {
     const action = rowEl.dataset.action;
     const href = rowEl.dataset.href;
-    recordPaletteRecent(rowEl.dataset.label || '', href || '', action || '');
+    recordPaletteRecent(rowEl.dataset.label, href, action);
     closePalette();
     if (action === 'theme') {
-        const toggle = document.getElementById('btn-theme-toggle');
-        if (toggle) {
-            (toggle as HTMLElement).click(); // the server POST /preferences toggle
-        }
+        document.getElementById('btn-theme-toggle')?.click(); // the server POST /preferences toggle
         return;
     }
     if (href) {
@@ -527,7 +495,7 @@ let palettePriorFocus: Element | null = null;
 // True only while closePalette is handing focus back to the prior element: when
 // that element is the topbar [data-ro-palette-open] box, the focus restore itself
 // fires focusin, which would re-open the palette the user just closed.
-let paletteRestoringFocus = false;
+let paletteRestoringFocus: true | undefined;
 
 // Open the palette: reveal the overlay (the `open` class), build the grouped
 // rows from the blob, seed + focus the query box, and seat the first row active.
@@ -561,17 +529,21 @@ export function closePalette(): void {
     }
     palette.classList.remove('open');
     palette.setAttribute('aria-hidden', 'true');
-    if (
-        palettePriorFocus &&
-        document.contains(palettePriorFocus) &&
-        !palette.contains(palettePriorFocus) &&
-        typeof (palettePriorFocus as HTMLElement).focus === 'function'
-    ) {
-        paletteRestoringFocus = true;
-        (palettePriorFocus as HTMLElement).focus();
-        paletteRestoringFocus = false;
-    }
+    const prior = palettePriorFocus;
     palettePriorFocus = null;
+    if (!prior || !document.contains(prior) || palette.contains(prior)) {
+        return;
+    }
+    const focus = (prior as Element & { focus?: unknown }).focus;
+    if (typeof focus !== 'function') {
+        return;
+    }
+    paletteRestoringFocus = true;
+    try {
+        focus.call(prior);
+    } finally {
+        paletteRestoringFocus = undefined;
+    }
 }
 
 // --- dispatcher bindings ----------------------------------------------------
@@ -615,21 +587,20 @@ export const paletteBindings: Binding[] = [
         stop: true,
         handler: (event, matched) => {
             event.preventDefault();
-            openPalette((matched as HTMLElement).dataset.query || '');
+            openPalette((matched as HTMLElement).dataset.query);
             return true;
         },
     },
     // A click on the palette backdrop ITSELF (the dimmed area outside the panel)
     // closes it, like Esc. A click inside the panel does not match. The selector
-    // is the backdrop root id; the handler still verifies target.id === PALETTE_ID
-    // so a click that bubbles from a descendant (closest matched the root) does
-    // NOT close it -- the monolith's exact `target.id === PALETTE_ID` test.
+    // is the backdrop root id; the handler still verifies that the original
+    // target is that matched root, so a descendant click does NOT close it.
     {
         event: 'click',
         selector: `#${PALETTE_ID}`,
         stop: true,
-        handler: (event) => {
-            if ((event.target as Element).id === PALETTE_ID) {
+        handler: (event, matched) => {
+            if (event.target === matched) {
                 closePalette();
                 return true;
             }
@@ -727,9 +698,7 @@ export const paletteBindings: Binding[] = [
             }
             openPalette();
             const t = event.target as HTMLElement;
-            if (typeof t.blur === 'function') {
-                t.blur();
-            }
+            t.blur();
         },
     },
 ];

--- a/internal/assets/src/js/prefs.dom.test.ts
+++ b/internal/assets/src/js/prefs.dom.test.ts
@@ -6,6 +6,7 @@ import {
     PREFS_COOKIE,
     PREFS_COOKIE_MAX_AGE,
     type Prefs,
+    REFRESH_KEY,
     readPrefs,
     roPrefsSetHiddenColumns,
     roPrefsSetNamespace,
@@ -23,6 +24,12 @@ function clearPrefsCookie(): void {
 beforeEach(() => {
     clearPrefsCookie();
     document.cookie = 'unrelated=; Path=/; Max-Age=0';
+});
+
+test('the legacy refresh key remains stable for localStorage migration', () => {
+    window.localStorage.setItem(REFRESH_KEY, '30');
+    expect(REFRESH_KEY).toBe('roRefresh');
+    expect(window.localStorage.getItem('roRefresh')).toBe('30');
 });
 
 test('readPrefs returns empty prefs for an absent or corrupt cookie', () => {
@@ -64,6 +71,19 @@ test('writePrefs assigns the persistent cookie attributes for the current protoc
     expect(readPrefs().refresh).toBe('Live');
 });
 
+test('writePrefs omits Secure on an HTTP page', () => {
+    const cookieSetter = vi.spyOn(document, 'cookie', 'set');
+    vi.stubGlobal('window', { location: { protocol: 'http:' } });
+    try {
+        writePrefs({ kinds: [], refresh: 'Live', ns: {} });
+
+        expect(cookieSetter).toHaveBeenCalledOnce();
+        expect(cookieSetter.mock.calls[0][0]).not.toContain('; Secure');
+    } finally {
+        vi.unstubAllGlobals();
+    }
+});
+
 test('roPrefsSetSort preserves other fields and moves the touched kind to the front', () => {
     writePrefs({
         kinds: [
@@ -85,6 +105,29 @@ test('roPrefsSetSort preserves other fields and moves the touched kind to the fr
         ],
         refresh: '10',
         ns: { test: 'kube-system' },
+    });
+});
+
+test('roPrefsSetSort creates a missing kind at the front', () => {
+    writePrefs({
+        kinds: [
+            { k: 'deployments', sort: 'Age' },
+            { k: 'services', hide: ['Cluster IP'] },
+        ],
+        refresh: '10',
+        ns: {},
+    });
+
+    roPrefsSetSort('pods', 'Status:desc');
+
+    expect(readPrefs()).toStrictEqual({
+        kinds: [
+            { k: 'pods', sort: 'Status:desc' },
+            { k: 'deployments', sort: 'Age' },
+            { k: 'services', hide: ['Cluster IP'] },
+        ],
+        refresh: '10',
+        ns: {},
     });
 });
 
@@ -131,6 +174,26 @@ test('roPrefsSetNamespace records a namespace while preserving existing preferen
         refresh: '30',
         ns: { other: 'default', test: '_all' },
     });
+});
+
+test('roPrefsSetNamespace safely persists special own-property cluster names', () => {
+    const entries = [
+        ['__proto__', 'proto-ns'],
+        ['constructor', 'constructor-ns'],
+        ['toString', 'string-ns'],
+    ] as const;
+
+    for (const [cluster, namespace] of entries) {
+        roPrefsSetNamespace(cluster, namespace);
+    }
+
+    const ns = readPrefs().ns;
+    expect(Object.entries(ns)).toStrictEqual(entries);
+    expect(Object.getPrototypeOf(ns)).toBe(Object.prototype);
+    for (const [cluster, namespace] of entries) {
+        expect(Object.hasOwn(ns, cluster), cluster).toBe(true);
+        expect(ns[cluster], cluster).toBe(namespace);
+    }
 });
 
 test('roPrefsSetNamespace ignores an empty cluster or namespace without writing', () => {

--- a/internal/assets/src/js/prefs.test.ts
+++ b/internal/assets/src/js/prefs.test.ts
@@ -6,12 +6,13 @@
 //
 // Run: `npm test`.
 
+import { Buffer } from 'node:buffer';
 import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
-import { decodePrefsValue, encodePrefsValue, type Prefs } from './prefs.js';
+import { decodePrefsValue, encodePrefsValue, PREFS_MAX_ENCODED, type Prefs } from './prefs.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 // js -> src -> assets -> internal -> repo root, then into the Go testdata dir.
@@ -40,6 +41,10 @@ function loadFixture<T>(name: string): T {
     return JSON.parse(readFileSync(join(goldenDir, name), 'utf8')) as T;
 }
 
+function wireValue(payload: unknown): string {
+    return `v1.${Buffer.from(JSON.stringify(payload)).toString('base64url')}`;
+}
+
 // Enumerate the golden fixtures off disk so a NEW fixture is picked up without
 // touching this file -- exactly like the Go golden test globs the directory.
 const fixtureFiles = readdirSync(goldenDir)
@@ -53,6 +58,236 @@ test('golden fixtures discovered', () => {
         `expected >=7 golden fixtures, found ${fixtureFiles.length}`,
     ).toBeGreaterThanOrEqual(7);
     expect(fixtureFiles, 'corrupt-decode fixture missing').toContain('07_corrupt_decode.json');
+});
+
+test('empty preferences have the canonical minimal wire representation', () => {
+    expect(encodePrefsValue({ kinds: [], refresh: '', ns: {} })).toBe('v1.e30');
+});
+
+test('base64url is unpadded, URL-safe, and round-trips both replacement characters', () => {
+    const prefs: Prefs = { kinds: [], refresh: '࠾࠿', ns: {} };
+    const encoded = encodePrefsValue(prefs);
+
+    expect(encoded).toMatch(/^v1\.[A-Za-z0-9_-]+$/);
+    expect(encoded).toContain('-');
+    expect(encoded).toContain('_');
+    expect(decodePrefsValue(encoded)).toStrictEqual({ prefs, ok: true });
+
+    const doublePadding: Prefs = { kinds: [{ k: '¿' }], refresh: '', ns: {} };
+    expect(decodePrefsValue(encodePrefsValue(doublePadding))).toStrictEqual({
+        prefs: doublePadding,
+        ok: true,
+    });
+});
+
+test('decoder accepts canonical unpadded payloads requiring one or two padding bytes', () => {
+    expect(decodePrefsValue('v1.eyJyZWZyZXNoIjoieHgifQ')).toStrictEqual({
+        prefs: { kinds: [], refresh: 'xx', ns: {} },
+        ok: true,
+    });
+    expect(decodePrefsValue('v1.eyJyZWZyZXNoIjoieHh4In0')).toStrictEqual({
+        prefs: { kinds: [], refresh: 'xxx', ns: {} },
+        ok: true,
+    });
+});
+
+test('decoder ignores CR/LF inside RawURLEncoding input exactly like Go', () => {
+    for (const value of ['v1.\r\ne30', 'v1.e\r\n30', 'v1.e\n3\r0\n']) {
+        expect(decodePrefsValue(value), JSON.stringify(value)).toStrictEqual({
+            prefs: { kinds: [], refresh: '', ns: {} },
+            ok: true,
+        });
+    }
+    expect(decodePrefsValue('v1.e\t30')).toStrictEqual({
+        prefs: { kinds: [], refresh: '', ns: {} },
+        ok: false,
+    });
+});
+
+test('sparse preferences without kinds encode only their present fields', () => {
+    expect(encodePrefsValue({ refresh: 'Live' })).toBe(wireValue({ refresh: 'Live' }));
+    expect(decodePrefsValue(encodePrefsValue({ refresh: 'Live' }))).toStrictEqual({
+        prefs: { kinds: [], refresh: 'Live', ns: {} },
+        ok: true,
+    });
+});
+
+test('an under-cap payload needs at most one wire encoding', () => {
+    const encodeBinary = vi.spyOn(globalThis, 'btoa');
+    const prefs: Prefs = {
+        kinds: [
+            { k: 'pods', sort: 'Name' },
+            { k: 'deployments', hide: ['Ready'] },
+            { k: 'services' },
+        ],
+        refresh: '30',
+        ns: { prod: 'default' },
+    };
+
+    expect(encodePrefsValue(prefs)).toBe(wireValue(prefs));
+    expect(encodeBinary.mock.calls.length).toBeLessThanOrEqual(1);
+});
+
+test('oversized eviction encodes candidates lazily and stops at the first fitting prefix', () => {
+    const encodeBinary = vi.spyOn(globalThis, 'btoa');
+    const prefs: Prefs = {
+        kinds: [
+            { k: 'pods', sort: 'Name' },
+            { k: 'oversized-tail', hide: ['x'.repeat(5000)] },
+        ],
+        refresh: '30',
+        ns: {},
+    };
+
+    const encoded = encodePrefsValue(prefs);
+
+    expect(decodePrefsValue(encoded).prefs.kinds).toStrictEqual([{ k: 'pods', sort: 'Name' }]);
+    expect(encodeBinary.mock.calls.length).toBeLessThanOrEqual(2);
+});
+
+test('eviction rejects a candidate one byte boundary above the cap before stopping', () => {
+    const encodeBinary = vi.spyOn(globalThis, 'btoa');
+    const boundary = structuredClone(loadFixture<EncodeFixture>('04_at_cap_boundary.json').payload);
+    const hide = boundary.kinds[0]?.hide;
+    expect(hide).toBeDefined();
+    if (!hide) {
+        throw new Error('boundary fixture has no hidden column');
+    }
+    hide[0] += 'x';
+    const boundaryWire = wireValue({ kinds: boundary.kinds, refresh: boundary.refresh });
+    expect(boundaryWire).toHaveLength(PREFS_MAX_ENCODED + 1);
+
+    const encoded = encodePrefsValue({
+        kinds: [...boundary.kinds, { k: 'oversized-tail', hide: ['y'.repeat(5000)] }],
+        refresh: boundary.refresh,
+        ns: boundary.ns ?? {},
+    });
+
+    expect(encoded.length).toBeLessThanOrEqual(PREFS_MAX_ENCODED);
+    expect(decodePrefsValue(encoded).prefs.kinds).toStrictEqual([]);
+    expect(encodeBinary.mock.calls.length).toBeLessThanOrEqual(3);
+});
+
+test('non-object top-level JSON is structural corruption', () => {
+    for (const payload of [null, [], 42, 'prefs']) {
+        expect(decodePrefsValue(wireValue(payload)), JSON.stringify(payload)).toStrictEqual({
+            prefs: { kinds: [], refresh: '', ns: {} },
+            ok: false,
+        });
+    }
+});
+
+test('invalid kind records and fields are dropped without losing valid siblings', () => {
+    const encoded = wireValue({
+        kinds: [
+            null,
+            42,
+            [],
+            { k: 7 },
+            { k: 'pods', sort: 9, hide: ['Node', 3] },
+            { k: 'services', sort: 'Name', hide: ['Cluster IP'] },
+        ],
+    });
+
+    expect(decodePrefsValue(encoded)).toStrictEqual({
+        prefs: {
+            kinds: [{ k: 'pods' }, { k: 'services', sort: 'Name', hide: ['Cluster IP'] }],
+            refresh: '',
+            ns: {},
+        },
+        ok: true,
+    });
+});
+
+test('namespace maps keep only string values and reject scalar or array containers', () => {
+    expect(
+        decodePrefsValue(wireValue({ ns: { good: 'default', numeric: 7, missing: null } })),
+    ).toStrictEqual({
+        prefs: { kinds: [], refresh: '', ns: { good: 'default' } },
+        ok: true,
+    });
+    for (const ns of ['default', ['default'], 7]) {
+        expect(decodePrefsValue(wireValue({ ns }))).toStrictEqual({
+            prefs: { kinds: [], refresh: '', ns: {} },
+            ok: true,
+        });
+    }
+});
+
+test('special namespace keys round-trip as own properties without changing prototypes', () => {
+    const namespaces = Object.fromEntries([
+        ['__proto__', 'proto-ns'],
+        ['constructor', 'constructor-ns'],
+        ['prototype', 'prototype-ns'],
+        ['toString', 'string-ns'],
+        ['hasOwnProperty', 'own-ns'],
+    ]);
+
+    const encoded = encodePrefsValue({ kinds: [], refresh: '', ns: namespaces });
+    const { prefs, ok } = decodePrefsValue(encoded);
+
+    expect(ok).toBe(true);
+    expect(Object.keys(prefs.ns)).toHaveLength(Object.keys(namespaces).length);
+    expect(Object.getPrototypeOf(prefs.ns)).toBe(Object.prototype);
+    for (const [cluster, namespace] of Object.entries(namespaces)) {
+        expect(Object.hasOwn(prefs.ns, cluster), cluster).toBe(true);
+        expect(prefs.ns[cluster], cluster).toBe(namespace);
+    }
+    expect(Object.getOwnPropertyDescriptor(prefs.ns, '__proto__')).toStrictEqual({
+        value: 'proto-ns',
+        enumerable: true,
+        configurable: true,
+        writable: true,
+    });
+});
+
+test('a single oversized kind is fully evicted without mutating the caller', () => {
+    const prefs: Prefs = {
+        kinds: [{ k: 'pods', sort: 'Name', hide: ['x'.repeat(5000)] }],
+        refresh: '30',
+        ns: {},
+    };
+    const before = structuredClone(prefs);
+    const encoded = encodePrefsValue(prefs);
+
+    expect(encoded.length).toBeLessThanOrEqual(PREFS_MAX_ENCODED);
+    expect(decodePrefsValue(encoded)).toStrictEqual({
+        prefs: { kinds: [], refresh: '30', ns: {} },
+        ok: true,
+    });
+    expect(prefs).toStrictEqual(before);
+});
+
+test('oversized non-kind data returns the final no-kinds candidate', () => {
+    const refresh = 'x'.repeat(5000);
+    const encoded = encodePrefsValue({
+        kinds: [{ k: 'pods', sort: 'Name' }],
+        refresh,
+        ns: {},
+    });
+
+    expect(encoded).toBe(wireValue({ refresh }));
+    expect(encoded.length).toBeGreaterThan(PREFS_MAX_ENCODED);
+    expect(decodePrefsValue(encoded)).toStrictEqual({
+        prefs: { kinds: [], refresh, ns: {} },
+        ok: true,
+    });
+});
+
+test('the first reachable value above the cap is evicted', () => {
+    const boundary = structuredClone(loadFixture<EncodeFixture>('04_at_cap_boundary.json').payload);
+    const hide = boundary.kinds[0]?.hide;
+    expect(hide).toBeDefined();
+    if (!hide) {
+        throw new Error('boundary fixture has no hidden column');
+    }
+    hide[0] += 'x';
+    const fullWire = wireValue({ kinds: boundary.kinds, refresh: boundary.refresh });
+    expect(fullWire).toHaveLength(PREFS_MAX_ENCODED + 1);
+
+    const encoded = encodePrefsValue(boundary);
+    expect(encoded.length).toBeLessThanOrEqual(PREFS_MAX_ENCODED);
+    expect(decodePrefsValue(encoded).prefs.kinds).toStrictEqual([]);
 });
 
 for (const file of fixtureFiles) {
@@ -123,3 +358,18 @@ for (const file of fixtureFiles) {
         });
     }
 }
+
+test('publishes the exact cookie protocol and legacy migration constants at module load', async () => {
+    vi.resetModules();
+    const fresh = await import('./prefs.js');
+
+    expect({
+        cookie: fresh.PREFS_COOKIE,
+        versionPrefix: fresh.PREFS_VERSION_PREFIX,
+        legacyRefreshKey: fresh.REFRESH_KEY,
+    }).toStrictEqual({
+        cookie: 'ro_prefs',
+        versionPrefix: 'v1.',
+        legacyRefreshKey: 'roRefresh',
+    });
+});

--- a/internal/assets/src/js/prefs.ts
+++ b/internal/assets/src/js/prefs.ts
@@ -57,21 +57,94 @@ export const REFRESH_KEY = 'roRefresh';
 // are global in both the browser and Node 24 (no polyfill); btoa/atob are too.
 function b64urlEncodeUTF8(text: string): string {
     const bytes = new TextEncoder().encode(text);
-    let bin = '';
-    for (let i = 0; i < bytes.length; i++) {
-        bin += String.fromCharCode(bytes[i]);
-    }
-    return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const bin = Array.from(bytes, (byte) => String.fromCharCode(byte)).join('');
+    return btoa(bin).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
 }
 
 function b64urlDecodeUTF8(encoded: string): string {
-    const b64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
-    const bin = atob(b64 + '===='.slice(b64.length % 4 || 4));
-    const bytes = new Uint8Array(bin.length);
-    for (let i = 0; i < bin.length; i++) {
-        bytes[i] = bin.charCodeAt(i);
+    // Go's RawURLEncoding accepts only the URL-safe alphabet without `=`
+    // padding (while ignoring CR/LF). Browser atob is deliberately more
+    // forgiving: it also accepts padded and standard `+/` base64, so validate
+    // the wire alphabet before translating it for atob.
+    const compact = encoded.replaceAll('\r', '').replaceAll('\n', '');
+    if (!/^[A-Za-z0-9_-]*$/.test(compact)) {
+        // The public decoder intentionally collapses every wire failure to
+        // ok=false, so there is no observable error message to preserve here.
+        throw new TypeError();
     }
-    return new TextDecoder().decode(bytes);
+    const b64 = compact.replaceAll('-', '+').replaceAll('_', '/');
+    // atob uses the platform's forgiving base64 decoder: valid unpadded input
+    // with a remainder of 2 or 3 is accepted directly. Base64url emitted from
+    // real bytes can never have the invalid remainder of 1, so manufacturing
+    // padding here added mutation-prone arithmetic without changing behavior.
+    const bin = atob(b64);
+    const bytes = Uint8Array.from(bin, (char) => char.charCodeAt(0));
+    // Preserve a leading UTF-8 BOM as U+FEFF. TextDecoder's default strips it,
+    // while Go passes those bytes to json.Unmarshal, which rejects a BOM before
+    // the JSON value. JSON.parse likewise rejects the preserved U+FEFF.
+    return new TextDecoder('utf-8', { ignoreBOM: true }).decode(bytes);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+// Assignment to an ordinary object's `__proto__` key invokes the legacy
+// prototype setter instead of creating a cluster entry. Define every decoded
+// or newly-written namespace key as an own data property so special names
+// (`__proto__`, `constructor`, `toString`, ...) round-trip without changing the
+// record's prototype.
+function setOwnNamespace(ns: Record<string, string>, cluster: string, namespace: string): void {
+    Object.defineProperty(ns, cluster, {
+        value: namespace,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+    });
+}
+
+// encoding/json orders string map keys with strings.Compare: lexicographically
+// over their UTF-8 bytes. JavaScript's default sort compares UTF-16 code units,
+// and ordinary-object enumeration imposes a separate numeric-index order, so
+// neither can define the canonical `ns` wire order. Sort encoded key bytes and
+// render the small map directly to preserve Go's byte-exact map ordering for
+// valid Unicode keys, including `__proto__` and numeric-looking cluster names.
+function compareUTF8(left: Uint8Array, right: Uint8Array): number {
+    // subarray clamps its end to left.length, giving the shared prefix without
+    // a mutable min/max choice.
+    const mismatch = left
+        .subarray(0, right.length)
+        .findIndex((byte, index) => byte !== right[index]);
+    if (mismatch !== -1) {
+        return left[mismatch] - right[mismatch];
+    }
+    return left.length - right.length;
+}
+
+// encoding/json escapes the JSONP-unsafe U+2028/U+2029 code points even when
+// Encoder.SetEscapeHTML(false); JSON.stringify leaves them literal. Apply that
+// final wire-level difference to every serialized prefs string/container while
+// retaining JSON.stringify's desired literal <, >, and & behavior.
+function stringifyPrefsJSON(value: string | KindPrefs[]): string {
+    // Both members of the closed input union always have a JSON representation.
+    const encoded = JSON.stringify(value) as string;
+    return encoded.replaceAll('\u2028', '\\u2028').replaceAll('\u2029', '\\u2029');
+}
+
+function canonicalNamespaceJSON(ns: Record<string, string>): string {
+    const encoder = new TextEncoder();
+    const entries = Object.entries(ns).map(([cluster, namespace]) => ({
+        cluster,
+        namespace,
+        encodedCluster: encoder.encode(cluster),
+    }));
+    entries.sort((left, right) => compareUTF8(left.encodedCluster, right.encodedCluster));
+    return `{${entries
+        .map(
+            ({ cluster, namespace }) =>
+                `${stringifyPrefsJSON(cluster)}:${stringifyPrefsJSON(namespace)}`,
+        )
+        .join(',')}}`;
 }
 
 // decodePrefsValue is the PURE decode half: it parses a raw cookie VALUE
@@ -87,24 +160,21 @@ function b64urlDecodeUTF8(encoded: string): string {
 // so a passthrough here would keep perpetuating a cookie SSR can never apply.
 // Dropping just the mistyped field means the very next JS write re-encodes a
 // clean cookie and the two readers converge again (self-heal).
-export function decodePrefsValue(value: string): { prefs: Prefs; ok: boolean } {
+export function decodePrefsValue(value?: string): { prefs: Prefs; ok: boolean } {
     const empty: Prefs = { kinds: [], refresh: '', ns: {} };
-    if (value?.indexOf(PREFS_VERSION_PREFIX) !== 0) {
+    if (!value?.startsWith(PREFS_VERSION_PREFIX)) {
         return { prefs: empty, ok: false };
     }
     const payload = value.slice(PREFS_VERSION_PREFIX.length);
-    if (!payload) {
-        return { prefs: empty, ok: false };
-    }
     try {
-        const decoded = JSON.parse(b64urlDecodeUTF8(payload));
-        if (!decoded || typeof decoded !== 'object') {
+        const decoded: unknown = JSON.parse(b64urlDecodeUTF8(payload));
+        if (!isRecord(decoded)) {
             return { prefs: empty, ok: false };
         }
         const kinds: KindPrefs[] = [];
         if (Array.isArray(decoded.kinds)) {
             decoded.kinds.forEach((raw: unknown) => {
-                if (!raw || typeof raw !== 'object') {
+                if (!isRecord(raw)) {
                     return;
                 }
                 // raw is an untyped JSON object; narrow each field on read (Go's
@@ -130,10 +200,10 @@ export function decodePrefsValue(value: string): { prefs: Prefs; ok: boolean } {
             });
         }
         const ns: Record<string, string> = {};
-        if (decoded.ns && typeof decoded.ns === 'object' && !Array.isArray(decoded.ns)) {
-            Object.keys(decoded.ns).forEach((cluster) => {
-                if (typeof decoded.ns[cluster] === 'string') {
-                    ns[cluster] = decoded.ns[cluster];
+        if (isRecord(decoded.ns)) {
+            Object.entries(decoded.ns).forEach(([cluster, namespace]) => {
+                if (typeof namespace === 'string') {
+                    setOwnNamespace(ns, cluster, namespace);
                 }
             });
         }
@@ -155,38 +225,57 @@ export function decodePrefsValue(value: string): { prefs: Prefs; ok: boolean } {
 // 3KB cap (the entries are most-recent-first, so the least recently used kinds
 // drop first). Never mutates the caller's arrays. The output is pure ASCII, so
 // value.length (UTF-16 code units) equals the byte length the Go cap measures.
-export function encodePrefsValue(prefs: Prefs): string {
-    const out: { kinds?: KindPrefs[]; refresh?: string; ns?: Record<string, string> } = {};
-    if (prefs.kinds && prefs.kinds.length > 0) {
-        out.kinds = prefs.kinds;
+function encodePrefsCandidate(
+    kinds: KindPrefs[],
+    refresh: string,
+    ns: Record<string, string>,
+): string {
+    const fields: string[] = [];
+    if (kinds.length > 0) {
+        fields.push(`"kinds":${stringifyPrefsJSON(kinds)}`);
     }
-    if (prefs.refresh) {
-        out.refresh = prefs.refresh;
+    if (refresh) {
+        fields.push(`"refresh":${stringifyPrefsJSON(refresh)}`);
     }
-    if (prefs.ns && Object.keys(prefs.ns).length > 0) {
-        out.ns = prefs.ns;
+    if (Object.keys(ns).length > 0) {
+        fields.push(`"ns":${canonicalNamespaceJSON(ns)}`);
     }
-    let value = PREFS_VERSION_PREFIX + b64urlEncodeUTF8(JSON.stringify(out));
-    while (value.length > PREFS_MAX_ENCODED && out.kinds && out.kinds.length > 0) {
-        out.kinds = out.kinds.slice(0, -1); // tail eviction: drop the least-recently-used kind
-        if (out.kinds.length === 0) {
-            delete out.kinds;
-        }
-        value = PREFS_VERSION_PREFIX + b64urlEncodeUTF8(JSON.stringify(out));
+    return PREFS_VERSION_PREFIX + b64urlEncodeUTF8(`{${fields.join(',')}}`);
+}
+
+export function encodePrefsValue(prefs: Partial<Prefs>): string {
+    // Golden/wire payloads may omit empty fields even though normalized callers
+    // always carry them. Normalize that sparse input before encoding.
+    const kinds = prefs.kinds ?? [];
+    const refresh = prefs.refresh ?? '';
+    const ns = prefs.ns ?? {};
+    // Base64url payload lengths jump over 3072 (3071 -> 3073). Express the
+    // inclusive 3072 cap as the reachable exclusive boundary 3073, so the
+    // boundary remains both precise and behaviorally testable.
+    const evictionBoundary = PREFS_MAX_ENCODED + 1;
+    let value = encodePrefsCandidate(kinds, refresh, ns);
+    if (value.length < evictionBoundary) {
+        return value;
     }
+    // Only an oversized full payload pays for eviction candidates. `some` is a
+    // bounded, lazy walk: it stops at the first fitting head prefix, while an
+    // oversized non-kind payload naturally reaches the final no-kinds value.
+    Array.from({ length: kinds.length }).some((_, evicted) => {
+        const kept = kinds.length - evicted - 1;
+        value = encodePrefsCandidate(kinds.slice(0, kept), refresh, ns);
+        return value.length < evictionBoundary;
+    });
     return value;
 }
 
 // --- thin document.cookie wrappers (DOM) ----------------------------------
 
-function prefsCookieValue(): string {
-    const parts = document.cookie ? document.cookie.split('; ') : [];
-    for (let i = 0; i < parts.length; i++) {
-        if (parts[i].indexOf(`${PREFS_COOKIE}=`) === 0) {
-            return parts[i].slice(PREFS_COOKIE.length + 1);
-        }
-    }
-    return '';
+function prefsCookieValue(): string | undefined {
+    const prefix = `${PREFS_COOKIE}=`;
+    return document.cookie
+        .split('; ')
+        .find((part) => part.startsWith(prefix))
+        ?.slice(prefix.length);
 }
 
 // readPrefs reads the cookie and decodes it (always returns a usable prefs
@@ -216,16 +305,10 @@ export function writePrefs(prefs: Prefs): void {
 // prefsTouchKind finds-or-creates the entry for a plural and moves it to the
 // FRONT (most-recent-first -- the order tail eviction relies on).
 function prefsTouchKind(prefs: Prefs, plural: string): KindPrefs {
-    for (let i = 0; i < prefs.kinds.length; i++) {
-        if (prefs.kinds[i].k === plural) {
-            const entry = prefs.kinds.splice(i, 1)[0];
-            prefs.kinds.unshift(entry);
-            return entry;
-        }
-    }
-    const fresh: KindPrefs = { k: plural };
-    prefs.kinds.unshift(fresh);
-    return fresh;
+    const index = prefs.kinds.findIndex((entry) => entry.k === plural);
+    const entry = index < 0 ? { k: plural } : prefs.kinds.splice(index, 1)[0];
+    prefs.kinds.unshift(entry);
+    return entry;
 }
 
 // roPrefsSetSort persists a sort param ("Name", "Status:desc", ...) for a
@@ -243,7 +326,7 @@ export function roPrefsSetSort(plural: string, sort: string): void {
 // preference" (it suppresses the DefaultHiddenColumns config default).
 export function roPrefsSetHiddenColumns(plural: string, names: string[]): void {
     const prefs = readPrefs();
-    prefsTouchKind(prefs, plural).hide = Array.isArray(names) ? names : [];
+    prefsTouchKind(prefs, plural).hide = names;
     writePrefs(prefs);
 }
 
@@ -264,6 +347,6 @@ export function roPrefsSetNamespace(cluster: string, namespace: string): void {
         return;
     }
     const prefs = readPrefs();
-    prefs.ns[cluster] = namespace;
+    setOwnNamespace(prefs.ns, cluster, namespace);
     writePrefs(prefs);
 }

--- a/internal/assets/src/js/refresh.dom.test.ts
+++ b/internal/assets/src/js/refresh.dom.test.ts
@@ -26,11 +26,18 @@ vi.mock('./stale.js', () => ({
 import {
     applyRefresh,
     containerListRequestsInFlight,
+    effectivePollSeconds,
     fireRefresh,
+    handleRefreshAfterRequest,
+    handleRefreshBeforeRequest,
+    handleRefreshConfigRequest,
+    handleRefreshVisibilityChange,
+    isPreloadRequest,
     noteRefreshFailure,
     noteRefreshRecovery,
     pruneSettledListRequests,
     refreshBindings,
+    refreshInterval,
     refreshMode,
     refreshNextAtMs,
     requestListRefresh,
@@ -64,8 +71,63 @@ function xhrAt(readyState: number): XMLHttpRequest {
     return { readyState } as unknown as XMLHttpRequest;
 }
 
-function dispatchHtmx(type: string, detail: Record<string, unknown>): void {
-    document.dispatchEvent(new CustomEvent(type, { bubbles: true, detail }));
+function dispatchHtmx(
+    type: 'htmx:afterRequest' | 'htmx:beforeRequest' | 'htmx:configRequest',
+    detail: unknown,
+): void {
+    const event = new CustomEvent(type, { bubbles: true, detail });
+    const handler = {
+        'htmx:afterRequest': handleRefreshAfterRequest,
+        'htmx:beforeRequest': handleRefreshBeforeRequest,
+        'htmx:configRequest': handleRefreshConfigRequest,
+    }[type];
+    handler(event);
+}
+
+function refreshBinding(selector: string) {
+    const binding = refreshBindings.find((candidate) => candidate.selector === selector);
+    expect(binding).toBeDefined();
+    return binding as (typeof refreshBindings)[number];
+}
+
+function renderRefreshControls(): {
+    dropdown: HTMLElement;
+    label: HTMLElement;
+    live: HTMLElement;
+    missing: HTMLElement;
+    off: HTMLElement;
+    thirty: HTMLElement;
+} {
+    document.body.innerHTML = `
+        <div id="refresh-dropdown">
+            <span id="refresh-label"></span>
+            <button data-ro-action="set-refresh" data-ro-interval="0">Off</button>
+            <button data-ro-action="set-refresh" data-ro-interval="30">30s</button>
+            <button data-ro-action="set-refresh" data-ro-interval="Live">Live</button>
+            <button data-ro-action="set-refresh" class="is-active">Missing</button>
+        </div>
+    `;
+    return {
+        dropdown: document.getElementById('refresh-dropdown') as HTMLElement,
+        label: document.getElementById('refresh-label') as HTMLElement,
+        live: document.querySelector('[data-ro-interval="Live"]') as HTMLElement,
+        missing: document.querySelector(
+            '[data-ro-action="set-refresh"]:not([data-ro-interval])',
+        ) as HTMLElement,
+        off: document.querySelector('[data-ro-interval="0"]') as HTMLElement,
+        thirty: document.querySelector('[data-ro-interval="30"]') as HTMLElement,
+    };
+}
+
+function captureTimeouts() {
+    const callbacks: Array<() => void> = [];
+    const setTimeout = vi.spyOn(window, 'setTimeout').mockImplementation((handler) => {
+        expect(handler).toBeTypeOf('function');
+        callbacks.push(handler as () => void);
+        return callbacks.length as unknown as ReturnType<typeof window.setTimeout>;
+    });
+    const clearTimeout = vi.spyOn(window, 'clearTimeout').mockImplementation(() => {});
+    return { callbacks, clearTimeout, setTimeout };
 }
 
 beforeEach(() => {
@@ -99,17 +161,60 @@ test('prunes only DONE and aborted XHRs from an in-flight set', () => {
 });
 
 describe('htmx request lifecycle', () => {
-    test('marks container requests RO-No-Push and tracks each request class', () => {
+    test('recognizes only the exact preload header and tolerates missing request metadata', () => {
+        expect(isPreloadRequest(new Event('plain'))).toBe(false);
+        expect(isPreloadRequest(new CustomEvent('request', { detail: null }))).toBe(false);
+        expect(isPreloadRequest(new CustomEvent('request', { detail: {} }))).toBe(false);
+        expect(
+            isPreloadRequest(new CustomEvent('request', { detail: { requestConfig: null } })),
+        ).toBe(false);
+        expect(
+            isPreloadRequest(new CustomEvent('request', { detail: { requestConfig: {} } })),
+        ).toBe(false);
+        expect(
+            isPreloadRequest(
+                new CustomEvent('request', { detail: { requestConfig: { headers: {} } } }),
+            ),
+        ).toBe(false);
+        expect(
+            isPreloadRequest(
+                new CustomEvent('request', {
+                    detail: { requestConfig: { headers: { 'HX-Preloaded': 'false' } } },
+                }),
+            ),
+        ).toBe(false);
+        expect(
+            isPreloadRequest(
+                new CustomEvent('request', {
+                    detail: { requestConfig: { headers: { 'HX-Preloaded': 'true' } } },
+                }),
+            ),
+        ).toBe(true);
+    });
+
+    test('marks only a container config request RO-No-Push', () => {
+        const content = renderContent();
+        const other = document.createElement('button');
+        const untouched: Record<string, string> = {};
+
+        dispatchHtmx('htmx:configRequest', null);
+        dispatchHtmx('htmx:configRequest', {});
+        dispatchHtmx('htmx:configRequest', { elt: content });
+        dispatchHtmx('htmx:configRequest', { elt: other, headers: untouched });
+        expect(untouched).toStrictEqual({});
+
+        const headers: Record<string, string> = {};
+        dispatchHtmx('htmx:configRequest', { elt: content, headers });
+        expect(headers).toStrictEqual({ 'RO-No-Push': 'true' });
+    });
+
+    test('tracks each request class, lets a user request win, and settles both sets', () => {
         const content = renderContent();
         const userSource = document.createElement('button');
         document.body.appendChild(userSource);
         const htmx = installHtmx();
-        const headers: Record<string, string> = {};
         const containerXHR = xhrAt(1);
         const userXHR = xhrAt(1);
-
-        dispatchHtmx('htmx:configRequest', { elt: content, headers });
-        expect(headers).toStrictEqual({ 'RO-No-Push': 'true' });
 
         dispatchHtmx('htmx:beforeRequest', {
             elt: content,
@@ -130,10 +235,62 @@ describe('htmx request lifecycle', () => {
         expect(userListRequestsInFlight).toContain(userXHR);
         expect(htmx.trigger).toHaveBeenCalledExactlyOnceWith(content, 'htmx:abort');
 
+        dispatchHtmx('htmx:afterRequest', null);
+        dispatchHtmx('htmx:afterRequest', {});
+        dispatchHtmx('htmx:afterRequest', { unrelated: true });
+        expect(containerListRequestsInFlight).toContain(containerXHR);
+        expect(userListRequestsInFlight).toContain(userXHR);
+
         dispatchHtmx('htmx:afterRequest', { xhr: containerXHR });
         dispatchHtmx('htmx:afterRequest', { xhr: userXHR });
         expect(containerListRequestsInFlight).toHaveLength(0);
         expect(userListRequestsInFlight).toHaveLength(0);
+    });
+
+    test('treats a container request without an XHR as container-owned and inert', () => {
+        const content = renderContent();
+        const htmx = installHtmx();
+
+        dispatchHtmx('htmx:beforeRequest', { elt: content, target: content });
+
+        expect(containerListRequestsInFlight).toHaveLength(0);
+        expect(userListRequestsInFlight).toHaveLength(0);
+        expect(htmx.trigger).not.toHaveBeenCalled();
+    });
+
+    test('aborts for a genuine user request even when htmx did not expose an XHR', () => {
+        const content = renderContent();
+        const userSource = document.createElement('button');
+        const htmx = installHtmx();
+
+        dispatchHtmx('htmx:beforeRequest', { elt: userSource, target: content });
+
+        expect(userListRequestsInFlight).toHaveLength(0);
+        expect(htmx.trigger).toHaveBeenCalledExactlyOnceWith(content, 'htmx:abort');
+    });
+
+    test('ignores incomplete, wrong-target, and non-Element user-request shapes', () => {
+        const content = renderContent();
+        const otherTarget = document.createElement('div');
+        const userSource = document.createElement('button');
+        const htmx = installHtmx();
+        const cases: unknown[] = [
+            null,
+            {},
+            { elt: userSource },
+            { target: content },
+            { elt: 'not-an-element', target: content },
+            { elt: userSource, target: 'not-an-element' },
+            { elt: userSource, target: otherTarget },
+        ];
+
+        cases.forEach((detail) => {
+            dispatchHtmx('htmx:beforeRequest', detail);
+        });
+
+        expect(userListRequestsInFlight).toHaveLength(0);
+        expect(containerListRequestsInFlight).toHaveLength(0);
+        expect(htmx.trigger).not.toHaveBeenCalled();
     });
 
     test('does not track or abort a preloaded user request', () => {
@@ -151,14 +308,41 @@ describe('htmx request lifecycle', () => {
         expect(userListRequestsInFlight).toHaveLength(0);
         expect(htmx.trigger).not.toHaveBeenCalled();
     });
+
+    test('tracks a user XHR without aborting when the live content or htmx seam is absent', () => {
+        const detachedTarget = document.createElement('div');
+        detachedTarget.id = 'resource-list-content';
+        const source = document.createElement('button');
+        const firstXHR = xhrAt(1);
+        const htmx = installHtmx();
+
+        dispatchHtmx('htmx:beforeRequest', {
+            elt: source,
+            target: detachedTarget,
+            xhr: firstXHR,
+        });
+        expect(userListRequestsInFlight).toContain(firstXHR);
+        expect(htmx.trigger).not.toHaveBeenCalled();
+
+        userListRequestsInFlight.clear();
+        delete (window as unknown as { htmx?: HtmxHarness }).htmx;
+        renderContent();
+        const secondXHR = xhrAt(1);
+        dispatchHtmx('htmx:beforeRequest', {
+            elt: source,
+            target: document.getElementById('resource-list-content'),
+            xhr: secondXHR,
+        });
+        expect(userListRequestsInFlight).toContain(secondXHR);
+    });
 });
 
 describe('refresh requests', () => {
-    test('uses the live location path and exact current query for v2 lists', () => {
+    test('uses the live location path, trims every trailing slash, and keeps the exact query', () => {
         window.history.replaceState(
             null,
             '',
-            '/clusters/prod/namespaces/default/pods/?sort=Age%3Adesc&f=status%3ARunning',
+            '/clusters/prod/namespaces/default/pods///?sort=Age%3Adesc&f=status%3ARunning',
         );
         const content = renderContent('location');
         const htmx = installHtmx();
@@ -173,6 +357,9 @@ describe('refresh requests', () => {
             { source: content },
         );
         expect(catchRequest).toHaveBeenCalledWith(expect.any(Function));
+        const rejectionHandler = catchRequest.mock.calls[0]?.[0] as (() => void) | undefined;
+        expect(rejectionHandler).toBeTypeOf('function');
+        expect(() => rejectionHandler?.()).not.toThrow();
         expect(htmx.trigger).not.toHaveBeenCalled();
     });
 
@@ -186,16 +373,38 @@ describe('refresh requests', () => {
         expect(htmx.trigger).toHaveBeenCalledExactlyOnceWith(content, 'ro:refresh');
     });
 
+    test('loads safely without the content or htmx and exposes the production window seam', () => {
+        const seam = (window as unknown as { requestListRefresh?: unknown }).requestListRefresh;
+        expect(seam).toBe(requestListRefresh);
+
+        expect(() => requestListRefresh()).not.toThrow();
+        const content = renderContent('location');
+        expect(() => requestListRefresh()).not.toThrow();
+
+        content.remove();
+        installHtmx();
+        expect(() => requestListRefresh()).not.toThrow();
+    });
+
+    test.each([undefined, {}, { catch: 'not-a-function' }])(
+        'accepts an htmx ajax result without a callable catch: %j',
+        (request) => {
+            renderContent('location');
+            const htmx = installHtmx();
+            htmx.ajax.mockReturnValue(request);
+
+            expect(() => requestListRefresh()).not.toThrow();
+            expect(htmx.ajax).toHaveBeenCalledOnce();
+        },
+    );
+
     test('retry aborts the old container request before issuing the replacement', () => {
         const content = renderContent('location');
         const htmx = installHtmx();
-        const retry = refreshBindings.find(
-            (binding) => binding.selector === '[data-ro-action="retry"]',
-        );
-        expect(retry).toBeDefined();
+        const retry = refreshBinding('[data-ro-action="retry"]');
         const event = new Event('click', { cancelable: true });
 
-        expect(retry?.handler(event, null)).toBe(true);
+        expect(retry.handler(event, null)).toBe(true);
 
         expect(event.defaultPrevented).toBe(true);
         expect(htmx.trigger).toHaveBeenCalledExactlyOnceWith(content, 'htmx:abort');
@@ -203,6 +412,23 @@ describe('refresh requests', () => {
         expect(htmx.trigger.mock.invocationCallOrder[0]).toBeLessThan(
             htmx.ajax.mock.invocationCallOrder[0] as number,
         );
+    });
+
+    test('retry remains a handled, prevented no-op when no refresh surface exists', () => {
+        const retry = refreshBinding('[data-ro-action="retry"]');
+        const htmx = installHtmx();
+        const withoutContent = new Event('click', { cancelable: true });
+
+        expect(retry.handler(withoutContent, null)).toBe(true);
+        expect(withoutContent.defaultPrevented).toBe(true);
+        expect(htmx.trigger).not.toHaveBeenCalled();
+        expect(htmx.ajax).not.toHaveBeenCalled();
+
+        delete (window as unknown as { htmx?: HtmxHarness }).htmx;
+        renderContent('location');
+        const withoutHtmx = new Event('click', { cancelable: true });
+        expect(retry.handler(withoutHtmx, null)).toBe(true);
+        expect(withoutHtmx.defaultPrevented).toBe(true);
     });
 });
 
@@ -233,91 +459,434 @@ test('fireRefresh is suppressed while hidden or while either request class is in
     expect(htmx.ajax).toHaveBeenCalledOnce();
 });
 
-test('migrates legacy localStorage once and then prefers the canonical preference', () => {
-    let persisted = '';
-    dependencies.readPrefs.mockImplementation(() => ({
-        kinds: [],
-        refresh: persisted,
-        ns: {},
-    }));
-    dependencies.roPrefsSetRefresh.mockImplementation((mode: string) => {
-        persisted = mode;
+describe('persisted refresh mode', () => {
+    test('migrates legacy localStorage once and then prefers the canonical preference', () => {
+        let persisted = '';
+        dependencies.readPrefs.mockImplementation(() => ({
+            kinds: [],
+            refresh: persisted,
+            ns: {},
+        }));
+        dependencies.roPrefsSetRefresh.mockImplementation((mode: string) => {
+            persisted = mode;
+        });
+        window.localStorage.setItem('roRefresh', '30');
+
+        expect(refreshMode()).toBe('30');
+        expect(dependencies.roPrefsSetRefresh).toHaveBeenCalledExactlyOnceWith('30');
+
+        window.localStorage.setItem('roRefresh', '5');
+        expect(refreshMode()).toBe('30');
+        expect(dependencies.roPrefsSetRefresh).toHaveBeenCalledOnce();
     });
-    window.localStorage.setItem('roRefresh', '30');
 
-    expect(refreshMode()).toBe('30');
-    expect(dependencies.roPrefsSetRefresh).toHaveBeenCalledExactlyOnceWith('30');
+    test('does not consult legacy storage when any canonical mode is present', () => {
+        dependencies.readPrefs.mockReturnValue({ kinds: [], refresh: 'Live', ns: {} });
+        const getItem = vi.spyOn(Storage.prototype, 'getItem');
 
-    window.localStorage.setItem('roRefresh', '5');
-    expect(refreshMode()).toBe('30');
-    expect(dependencies.roPrefsSetRefresh).toHaveBeenCalledOnce();
+        expect(refreshMode()).toBe('Live');
+        expect(getItem).not.toHaveBeenCalled();
+        expect(dependencies.roPrefsSetRefresh).not.toHaveBeenCalled();
+    });
+
+    test.each([null, ''])('treats an absent legacy value %j as no preference', (legacy) => {
+        if (legacy !== null) {
+            window.localStorage.setItem('roRefresh', legacy);
+        }
+
+        expect(refreshMode()).toBe('');
+        expect(dependencies.roPrefsSetRefresh).not.toHaveBeenCalled();
+    });
+
+    test('degrades safely when localStorage cannot be read', () => {
+        vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+            throw new DOMException('blocked', 'SecurityError');
+        });
+
+        expect(refreshMode()).toBe('');
+        expect(dependencies.roPrefsSetRefresh).not.toHaveBeenCalled();
+    });
+
+    test.each([
+        { legacy: '0', mode: 'Off' },
+        { legacy: '-5', mode: 'Off' },
+        { legacy: 'junk', mode: 'Off' },
+        { legacy: '5junk', mode: 'Off' },
+        { legacy: 'junk5', mode: 'Off' },
+        { legacy: '+005', mode: '5' },
+    ])('normalizes legacy $legacy to $mode before writing the cookie', ({ legacy, mode }) => {
+        window.localStorage.setItem('roRefresh', legacy);
+
+        expect(refreshMode()).toBe(mode);
+        expect(dependencies.roPrefsSetRefresh).toHaveBeenCalledExactlyOnceWith(mode);
+    });
+
+    test.each([
+        { mode: '', seconds: 0 },
+        { mode: 'Off', seconds: 0 },
+        { mode: 'Live', seconds: 0 },
+        { mode: '0', seconds: 0 },
+        { mode: '-5', seconds: 0 },
+        { mode: ' 5', seconds: 0 },
+        { mode: '5 ', seconds: 0 },
+        { mode: '5.5', seconds: 0 },
+        { mode: '5junk', seconds: 0 },
+        { mode: 'junk5', seconds: 0 },
+        { mode: '9007199254740992', seconds: 0 },
+        { mode: '5', seconds: 5 },
+        { mode: '9', seconds: 9 },
+        { mode: '10', seconds: 10 },
+        { mode: '005', seconds: 5 },
+        { mode: '+5', seconds: 5 },
+    ])('parses canonical mode $mode as $seconds polling seconds', ({ mode, seconds }) => {
+        dependencies.readPrefs.mockReturnValue({ kinds: [], refresh: mode, ns: {} });
+        expect(refreshInterval()).toBe(seconds);
+    });
+
+    test('folds the parsed mode and Live fallback from one preference snapshot', () => {
+        dependencies.readPrefs.mockReturnValue({ kinds: [], refresh: '30', ns: {} });
+        dependencies.liveFallbackSeconds.mockReturnValue(5);
+        expect(effectivePollSeconds()).toBe(30);
+        expect(dependencies.readPrefs).toHaveBeenCalledOnce();
+
+        dependencies.readPrefs.mockClear();
+        dependencies.readPrefs.mockReturnValue({ kinds: [], refresh: 'Live', ns: {} });
+        expect(effectivePollSeconds()).toBe(5);
+        expect(dependencies.readPrefs).toHaveBeenCalledOnce();
+
+        dependencies.readPrefs.mockClear();
+        dependencies.readPrefs.mockReturnValue({ kinds: [], refresh: 'Off', ns: {} });
+        expect(effectivePollSeconds()).toBe(0);
+        expect(dependencies.readPrefs).toHaveBeenCalledOnce();
+    });
 });
 
-test('maintains one timer chain across scheduling, backoff, recovery, and a fired tick', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-08-25T10:00:00Z'));
+test('maintains one timer chain across scheduling, backoff, recovery, and one fired tick', () => {
+    const now = new Date('2026-08-25T10:00:00Z').getTime();
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(now);
+    const timers = captureTimeouts();
     dependencies.readPrefs.mockReturnValue({ kinds: [], refresh: '5', ns: {} });
     const content = renderContent('location');
     const htmx = installHtmx();
     htmx.ajax.mockReturnValue({ catch: vi.fn() });
     const toast = vi.fn();
     window.roToast = toast;
-    const now = Date.now();
 
     applyRefresh();
     expect(refreshNextAtMs()).toBe(now + 5_000);
-    expect(vi.getTimerCount()).toBe(1);
+    expect(timers.setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 5_000);
 
     scheduleRefreshTick();
-    expect(vi.getTimerCount()).toBe(1);
+    expect(timers.clearTimeout).toHaveBeenLastCalledWith(1);
+    expect(timers.setTimeout).toHaveBeenCalledTimes(2);
 
     noteRefreshFailure();
     expect(refreshNextAtMs()).toBe(now + 5_000);
-    expect(vi.getTimerCount()).toBe(1);
+    expect(timers.clearTimeout).toHaveBeenLastCalledWith(2);
+    expect(timers.setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 5_000);
 
     noteRefreshFailure();
     expect(refreshNextAtMs()).toBe(now + 10_000);
-    expect(vi.getTimerCount()).toBe(1);
+    expect(timers.clearTimeout).toHaveBeenLastCalledWith(3);
+    expect(timers.setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 10_000);
 
     noteRefreshRecovery();
     expect(refreshNextAtMs()).toBe(now + 5_000);
-    expect(vi.getTimerCount()).toBe(1);
+    expect(timers.clearTimeout).toHaveBeenLastCalledWith(4);
+    expect(timers.setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 5_000);
     expect(toast).toHaveBeenCalledExactlyOnceWith('Refresh resumed');
 
-    vi.advanceTimersByTime(5_000);
+    const firedTick = timers.callbacks.at(-1);
+    expect(firedTick).toBeTypeOf('function');
+    dateNow.mockReturnValue(now + 5_000);
+    firedTick?.();
+
     expect(htmx.ajax).toHaveBeenCalledExactlyOnceWith('GET', '/_table', { source: content });
     expect(refreshNextAtMs()).toBe(now + 10_000);
-    expect(vi.getTimerCount()).toBe(1);
+    expect(timers.setTimeout).toHaveBeenCalledTimes(6);
+    expect(timers.setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 5_000);
+    expect(timers.setTimeout.mock.invocationCallOrder.at(-1)).toBeLessThan(
+        htmx.ajax.mock.invocationCallOrder[0] as number,
+    );
     expect(dependencies.updateStaleCountdown).toHaveBeenCalled();
 });
 
-test('syncRefreshUI renders Live and numeric modes without cross-activating options', () => {
-    document.body.innerHTML = `
-        <div id="refresh-dropdown">
-            <span id="refresh-label"></span>
+test('disarms a pending timer at zero cadence and repaints the stale countdown', () => {
+    const timers = captureTimeouts();
+    dependencies.readPrefs.mockReturnValue({ kinds: [], refresh: '5', ns: {} });
+    applyRefresh();
+    expect(timers.setTimeout).toHaveBeenCalledOnce();
+
+    timers.setTimeout.mockClear();
+    timers.clearTimeout.mockClear();
+    dependencies.updateStaleCountdown.mockClear();
+    dependencies.readPrefs.mockReturnValue({ kinds: [], refresh: 'Off', ns: {} });
+
+    scheduleRefreshTick();
+
+    expect(timers.clearTimeout).toHaveBeenCalledExactlyOnceWith(1);
+    expect(timers.setTimeout).not.toHaveBeenCalled();
+    expect(refreshNextAtMs()).toBe(0);
+    expect(dependencies.updateStaleCountdown).toHaveBeenCalledOnce();
+});
+
+test('keeps an ordinary stage-zero recovery silent and does not re-arm', () => {
+    const timers = captureTimeouts();
+    const toast = vi.fn();
+    window.roToast = toast;
+
+    noteRefreshRecovery();
+
+    expect(toast).not.toHaveBeenCalled();
+    expect(timers.setTimeout).not.toHaveBeenCalled();
+    expect(dependencies.updateStaleCountdown).not.toHaveBeenCalled();
+});
+
+test('recovers and re-arms safely when the optional toast seam is absent', () => {
+    const timers = captureTimeouts();
+    dependencies.readPrefs.mockReturnValue({ kinds: [], refresh: '5', ns: {} });
+    noteRefreshFailure();
+    timers.setTimeout.mockClear();
+    timers.clearTimeout.mockClear();
+
+    expect(() => noteRefreshRecovery()).not.toThrow();
+
+    expect(timers.clearTimeout).toHaveBeenCalledOnce();
+    expect(timers.setTimeout).toHaveBeenCalledExactlyOnceWith(expect.any(Function), 5_000);
+});
+
+describe('refresh UI', () => {
+    test.each([
+        {
+            mode: 'Live',
+            label: 'Live',
+            active: 'live',
+            refreshOn: true,
+        },
+        {
+            mode: '30',
+            label: '30s',
+            active: 'thirty',
+            refreshOn: true,
+        },
+        {
+            mode: 'Off',
+            label: 'Off',
+            active: 'off',
+            refreshOn: false,
+        },
+        {
+            mode: '30junk',
+            label: 'Off',
+            active: 'off',
+            refreshOn: false,
+        },
+    ] as const)(
+        'renders $mode without cross-activating another option',
+        ({ mode, label, active, refreshOn }) => {
+            const controls = renderRefreshControls();
+            dependencies.readPrefs.mockReturnValue({ kinds: [], refresh: mode, ns: {} });
+
+            syncRefreshUI();
+
+            expect(controls.label).toHaveTextContent(label);
+            expect(controls.live.classList.contains('is-active')).toBe(active === 'live');
+            expect(controls.thirty.classList.contains('is-active')).toBe(active === 'thirty');
+            expect(controls.off.classList.contains('is-active')).toBe(active === 'off');
+            expect(controls.missing).not.toHaveClass('is-active');
+            expect(controls.dropdown.classList.contains('refresh-on')).toBe(refreshOn);
+        },
+    );
+
+    test('updates valid options without requiring a label or dropdown', () => {
+        document.body.innerHTML = `
             <button data-ro-action="set-refresh" data-ro-interval="0"></button>
-            <button data-ro-action="set-refresh" data-ro-interval="30"></button>
-            <button data-ro-action="set-refresh" data-ro-interval="Live"></button>
-        </div>
-    `;
-    const dropdown = document.getElementById('refresh-dropdown');
-    const off = document.querySelector('[data-ro-interval="0"]');
-    const thirty = document.querySelector('[data-ro-interval="30"]');
-    const live = document.querySelector('[data-ro-interval="Live"]');
+            <button data-ro-action="set-refresh" data-ro-interval="Live" class="is-active"></button>
+        `;
+        dependencies.readPrefs.mockReturnValue({ kinds: [], refresh: 'Off', ns: {} });
 
-    dependencies.readPrefs.mockReturnValue({ kinds: [], refresh: 'Live', ns: {} });
-    syncRefreshUI();
-    expect(document.getElementById('refresh-label')).toHaveTextContent('Live');
-    expect(live).toHaveClass('is-active');
-    expect(thirty).not.toHaveClass('is-active');
-    expect(off).not.toHaveClass('is-active');
-    expect(dropdown).toHaveClass('refresh-on');
+        expect(() => syncRefreshUI()).not.toThrow();
 
-    dependencies.readPrefs.mockReturnValue({ kinds: [], refresh: '30', ns: {} });
-    syncRefreshUI();
-    expect(document.getElementById('refresh-label')).toHaveTextContent('30s');
-    expect(thirty).toHaveClass('is-active');
-    expect(live).not.toHaveClass('is-active');
-    expect(off).not.toHaveClass('is-active');
-    expect(dropdown).toHaveClass('refresh-on');
+        expect(document.querySelector('[data-ro-interval="0"]')).toHaveClass('is-active');
+        expect(document.querySelector('[data-ro-interval="Live"]')).not.toHaveClass('is-active');
+    });
+});
+
+describe('visibility catch-up', () => {
+    test('fires only when the document becomes visible with an effective cadence', () => {
+        renderContent('location');
+        const htmx = installHtmx();
+        const hidden = vi.spyOn(document, 'hidden', 'get');
+
+        dependencies.readPrefs.mockReturnValue({ kinds: [], refresh: '30', ns: {} });
+        hidden.mockReturnValue(true);
+        handleRefreshVisibilityChange();
+        expect(htmx.ajax).not.toHaveBeenCalled();
+
+        hidden.mockReturnValue(false);
+        dependencies.readPrefs.mockReturnValue({ kinds: [], refresh: 'Off', ns: {} });
+        handleRefreshVisibilityChange();
+        expect(htmx.ajax).not.toHaveBeenCalled();
+
+        dependencies.readPrefs.mockReturnValue({ kinds: [], refresh: 'Live', ns: {} });
+        dependencies.liveFallbackSeconds.mockReturnValue(0);
+        handleRefreshVisibilityChange();
+        expect(htmx.ajax).not.toHaveBeenCalled();
+
+        dependencies.liveFallbackSeconds.mockReturnValue(5);
+        handleRefreshVisibilityChange();
+        expect(htmx.ajax).toHaveBeenCalledOnce();
+
+        dependencies.readPrefs.mockReturnValue({ kinds: [], refresh: '30', ns: {} });
+        dependencies.liveFallbackSeconds.mockReturnValue(0);
+        handleRefreshVisibilityChange();
+        expect(htmx.ajax).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('refresh dispatcher bindings', () => {
+    test('publish the exact handled click contracts in retry-then-picker order', () => {
+        expect(
+            refreshBindings.map(({ event, selector, stop }) => ({ event, selector, stop })),
+        ).toStrictEqual([
+            { event: 'click', selector: '[data-ro-action="retry"]', stop: true },
+            { event: 'click', selector: '[data-ro-action="set-refresh"]', stop: true },
+        ]);
+    });
+
+    test('a Live pick persists, reconciles Live, paints, disarms polling, blurs, and prevents', () => {
+        const controls = renderRefreshControls();
+        const option = controls.live;
+        let persisted = 'Off';
+        dependencies.readPrefs.mockImplementation(() => ({
+            kinds: [],
+            refresh: persisted,
+            ns: {},
+        }));
+        dependencies.roPrefsSetRefresh.mockImplementation((mode: string) => {
+            persisted = mode;
+        });
+        option.focus();
+        const event = new Event('click', { cancelable: true });
+        const picker = refreshBinding('[data-ro-action="set-refresh"]');
+
+        expect(picker.handler(event, option)).toBe(true);
+
+        expect(dependencies.roPrefsSetRefresh).toHaveBeenCalledExactlyOnceWith('Live');
+        expect(dependencies.liveApply).toHaveBeenCalledExactlyOnceWith(true);
+        expect(controls.label).toHaveTextContent('Live');
+        expect(controls.live).toHaveClass('is-active');
+        expect(controls.off).not.toHaveClass('is-active');
+        expect(controls.dropdown).toHaveClass('refresh-on');
+        expect(dependencies.updateStaleCountdown).toHaveBeenCalledOnce();
+        expect(document.activeElement).not.toBe(option);
+        expect(event.defaultPrevented).toBe(true);
+        expect(dependencies.roPrefsSetRefresh.mock.invocationCallOrder[0]).toBeLessThan(
+            dependencies.liveApply.mock.invocationCallOrder[0] as number,
+        );
+    });
+
+    test('a numeric pick canonicalizes the interval, paints it, and arms that exact delay', () => {
+        const controls = renderRefreshControls();
+        const timers = captureTimeouts();
+        let persisted = 'Off';
+        dependencies.readPrefs.mockImplementation(() => ({
+            kinds: [],
+            refresh: persisted,
+            ns: {},
+        }));
+        dependencies.roPrefsSetRefresh.mockImplementation((mode: string) => {
+            persisted = mode;
+        });
+        controls.thirty.dataset.roInterval = '030';
+        controls.thirty.focus();
+        const event = new Event('click', { cancelable: true });
+        const picker = refreshBinding('[data-ro-action="set-refresh"]');
+
+        expect(picker.handler(event, controls.thirty)).toBe(true);
+
+        expect(dependencies.roPrefsSetRefresh).toHaveBeenCalledExactlyOnceWith('30');
+        expect(dependencies.liveApply).toHaveBeenCalledExactlyOnceWith(true);
+        expect(controls.label).toHaveTextContent('30s');
+        expect(controls.thirty).toHaveClass('is-active');
+        expect(timers.setTimeout.mock.calls.filter(([, delay]) => delay === 30_000)).toHaveLength(
+            1,
+        );
+        expect(document.activeElement).not.toBe(controls.thirty);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    test.each([undefined, '0', '-5', '30junk'])(
+        'an invalid pick %j canonicalizes to Off',
+        (value) => {
+            const controls = renderRefreshControls();
+            let persisted = '30';
+            dependencies.readPrefs.mockImplementation(() => ({
+                kinds: [],
+                refresh: persisted,
+                ns: {},
+            }));
+            dependencies.roPrefsSetRefresh.mockImplementation((mode: string) => {
+                persisted = mode;
+            });
+            if (value === undefined) {
+                delete controls.thirty.dataset.roInterval;
+            } else {
+                controls.thirty.dataset.roInterval = value;
+            }
+            const event = new Event('click', { cancelable: true });
+            const picker = refreshBinding('[data-ro-action="set-refresh"]');
+
+            expect(picker.handler(event, controls.thirty)).toBe(true);
+
+            expect(dependencies.roPrefsSetRefresh).toHaveBeenCalledExactlyOnceWith('Off');
+            expect(controls.label).toHaveTextContent('Off');
+            expect(controls.off).toHaveClass('is-active');
+            expect(controls.dropdown).not.toHaveClass('refresh-on');
+            expect(event.defaultPrevented).toBe(true);
+        },
+    );
+});
+
+test('registers every required resident listener and binding at module load', async () => {
+    // The first import happens while Vitest collects this file, outside an
+    // individual test's coverage window. Re-evaluate the side-effect module so
+    // listener registrations and descriptor literals are mutation-covered.
+    vi.resetModules();
+    const documentAdd = vi.spyOn(document, 'addEventListener');
+    const registrationStart = documentAdd.mock.calls.length;
+
+    const fresh = await import('./refresh.js');
+
+    expect(documentAdd.mock.calls.slice(registrationStart)).toEqual(
+        expect.arrayContaining([
+            ['htmx:configRequest', fresh.handleRefreshConfigRequest],
+            ['htmx:beforeRequest', fresh.handleRefreshBeforeRequest],
+            ['htmx:afterRequest', fresh.handleRefreshAfterRequest],
+            ['visibilitychange', fresh.handleRefreshVisibilityChange],
+        ]),
+    );
+    expect(
+        fresh.refreshBindings.map(({ event, handler, selector, stop }) => ({
+            event,
+            handler: typeof handler,
+            selector,
+            stop,
+        })),
+    ).toEqual(
+        expect.arrayContaining([
+            {
+                event: 'click',
+                handler: 'function',
+                selector: '[data-ro-action="retry"]',
+                stop: true,
+            },
+            {
+                event: 'click',
+                handler: 'function',
+                selector: '[data-ro-action="set-refresh"]',
+                stop: true,
+            },
+        ]),
+    );
 });

--- a/internal/assets/src/js/refresh.ts
+++ b/internal/assets/src/js/refresh.ts
@@ -77,6 +77,21 @@ export const userListRequestsInFlight = new Set<XMLHttpRequest>();
 // QUEUE inside htmx and replay on the next htmx:abort with its stale URL.
 export const containerListRequestsInFlight = new Set<XMLHttpRequest>();
 
+interface HtmxRequestDetail {
+    elt?: unknown;
+    headers?: unknown;
+    requestConfig?: unknown;
+    target?: unknown;
+    xhr?: unknown;
+}
+
+function requestDetail(event: Event): HtmxRequestDetail {
+    // HTMX normally supplies an object, but lifecycle events are public DOM
+    // events. Box an absent or malformed detail so every resident handler is
+    // total instead of relying on optional chains at each read site.
+    return Object((event as CustomEvent).detail) as HtmxRequestDetail;
+}
+
 // A settled xhr is DONE (4: the load/error/timeout callbacks ran) or UNSENT
 // (0: aborted). Either way htmx is no longer waiting on it, so the entry is
 // reclaimable even when its htmx:afterRequest was dispatched on a detached
@@ -90,48 +105,56 @@ export function pruneSettledListRequests(requests: Set<XMLHttpRequest>): void {
 }
 
 function isPreloadRequest(event: Event): boolean {
-    const cfg = (event as CustomEvent).detail?.requestConfig;
-    return !!cfg && !!cfg.headers && cfg.headers['HX-Preloaded'] === 'true';
+    const config = Object(requestDetail(event).requestConfig) as { headers?: unknown };
+    const headers = Object(config.headers) as Record<string, unknown>;
+    return headers['HX-Preloaded'] === 'true';
 }
 
 // Re-exported for stale.ts (isListRefreshEvent) so the preload exclusion lives
 // in exactly one place.
 export { isPreloadRequest };
 
-// True for a USER-initiated request that will swap #resource-list-content: the
-// target is the container but the issuing element is something else.
+// True for a USER-initiated request that will swap #resource-list-content.
+// The caller has already returned for requests issued by the container itself.
 function isUserListRequest(event: Event): boolean {
-    const detail = (event as CustomEvent).detail;
-    if (!detail?.elt || !detail.target) {
-        return false;
-    }
-    if (detail.elt.id === 'resource-list-content') {
-        return false;
-    }
-    return detail.target.id === 'resource-list-content' && !isPreloadRequest(event);
+    const detail = requestDetail(event);
+    return (
+        detail.elt instanceof Element &&
+        detail.target instanceof Element &&
+        detail.target.id === 'resource-list-content' &&
+        !isPreloadRequest(event)
+    );
 }
 
 // Mark every request the container itself issues (tick / retry / programmatic
 // re-fetch) as non-push: the `_table` handler omits HX-Push-Url for these, so
 // only genuine user gestures create history entries.
-document.addEventListener('htmx:configRequest', (event) => {
-    const elt = (event as CustomEvent).detail?.elt;
-    if (elt && elt.id === 'resource-list-content') {
-        (event as CustomEvent).detail.headers['RO-No-Push'] = 'true';
+export function handleRefreshConfigRequest(event: Event): void {
+    const detail = requestDetail(event);
+    const elt = Object(detail.elt) as { id?: unknown };
+    if (elt.id !== 'resource-list-content') {
+        return;
     }
-});
+    const headers = Object(detail.headers) as Record<string, string>;
+    headers['RO-No-Push'] = 'true';
+}
 
-document.addEventListener('htmx:beforeRequest', (event) => {
-    const detail = (event as CustomEvent).detail;
-    if (detail?.xhr && detail.elt && detail.elt.id === 'resource-list-content') {
-        containerListRequestsInFlight.add(detail.xhr);
+document.addEventListener('htmx:configRequest', handleRefreshConfigRequest);
+
+export function handleRefreshBeforeRequest(event: Event): void {
+    const detail = requestDetail(event);
+    const elt = Object(detail.elt) as { id?: unknown };
+    if (elt.id === 'resource-list-content') {
+        if (detail.xhr) {
+            containerListRequestsInFlight.add(detail.xhr as XMLHttpRequest);
+        }
         return; // container-issued (tick/retry/programmatic) -- tracked, never aborts anything
     }
     if (!isUserListRequest(event)) {
         return;
     }
-    if (detail?.xhr) {
-        userListRequestsInFlight.add(detail.xhr);
+    if (detail.xhr) {
+        userListRequestsInFlight.add(detail.xhr as XMLHttpRequest);
     }
     // The user action wins: abort the container's own in-flight request (a tick
     // that started before the click). htmx aborts the request belonging to the
@@ -142,18 +165,40 @@ document.addEventListener('htmx:beforeRequest', (event) => {
     if (content && htmx) {
         htmx.trigger(content, 'htmx:abort');
     }
-});
+}
+
+document.addEventListener('htmx:beforeRequest', handleRefreshBeforeRequest);
 
 // htmx:afterRequest fires on load, error, abort, AND timeout. When it reaches
 // the document the entry is removed here; when it does not (dispatched on a
 // detached element), the readyState pruning in fireRefresh reclaims it instead.
-document.addEventListener('htmx:afterRequest', (event) => {
-    const xhr = (event as CustomEvent).detail?.xhr;
-    if (xhr) {
-        userListRequestsInFlight.delete(xhr);
-        containerListRequestsInFlight.delete(xhr);
+export function handleRefreshAfterRequest(event: Event): void {
+    const xhr = requestDetail(event).xhr as XMLHttpRequest;
+    // Set.delete is deliberately total for undefined/non-members, so missing
+    // request metadata needs no semantically empty guard branch.
+    userListRequestsInFlight.delete(xhr);
+    containerListRequestsInFlight.delete(xhr);
+}
+
+document.addEventListener('htmx:afterRequest', handleRefreshAfterRequest);
+
+// Persisted numeric modes share one strict parser across migration, polling,
+// UI paint, and explicit picks. Number.parseInt accepts a numeric prefix
+// ("5junk" -> 5), which disagrees with the Go SSR reader and can silently turn a
+// corrupt preference into polling. Fold a finite array of ASCII digits instead
+// of using a mutable regular expression; this accepts the integer spellings
+// strconv.Atoi accepts for a positive cadence and rejects every partial parse.
+function parseRefreshSeconds(mode: unknown): number {
+    if (typeof mode !== 'string') {
+        return 0;
     }
-});
+    const unsigned = mode.startsWith('+') ? mode.slice(1) : mode;
+    const seconds = Array.from(unsigned).reduce((value, char) => {
+        const digit = char.charCodeAt(0) - 48;
+        return digit >= 0 && digit <= 9 ? value * 10 + digit : Number.NaN;
+    }, 0);
+    return Number.isSafeInteger(seconds) ? seconds : 0;
+}
 
 // refreshMode returns the persisted auto-refresh mode ('Off', an interval in
 // seconds as a string, 'Live'; '' = no preference) from the ro_prefs cookie.
@@ -169,20 +214,19 @@ export function refreshMode(): string {
     try {
         legacy = window.localStorage.getItem(REFRESH_KEY);
     } catch {
-        return ''; // localStorage unavailable (e.g. privacy mode) -> no pref
+        // localStorage unavailable (e.g. privacy mode): keep the absent value.
     }
-    if (legacy === null || legacy === '') {
+    if (!legacy) {
         return '';
     }
-    const secs = parseInt(legacy, 10) || 0;
+    const secs = parseRefreshSeconds(legacy);
     const mode = secs > 0 ? String(secs) : 'Off';
     roPrefsSetRefresh(mode); // write-through: the cookie is canonical from here
     return mode;
 }
 
 export function refreshInterval(): number {
-    const secs = parseInt(refreshMode(), 10);
-    return Number.isFinite(secs) && secs > 0 ? secs : 0; // 'Off'/'Live'/junk -> 0
+    return parseRefreshSeconds(refreshMode()); // 'Off'/'Live'/junk -> 0
 }
 
 // listTableURL derives the `_table` partial URL from the LIVE document URL at
@@ -243,7 +287,8 @@ export function fireRefresh(): void {
 // 'Live' with a riding stream stays 0 (the chain self-disarms). The fold lives
 // in live-policy.ts; this reads the live facts.
 export function effectivePollSeconds(): number {
-    return policyEffectivePollSeconds(refreshMode(), refreshInterval(), liveFallbackSeconds());
+    const mode = refreshMode();
+    return policyEffectivePollSeconds(mode, parseRefreshSeconds(mode), liveFallbackSeconds());
 }
 
 // refreshDelaySeconds is the wait until the NEXT tick: the backoff over
@@ -268,12 +313,16 @@ export function scheduleRefreshTick(): void {
         updateStaleCountdown();
         return;
     }
-    refreshNextAt = Date.now() + delay * 1000;
+    // Derive milliseconds once. Besides keeping the countdown and timeout on the
+    // exact same clock, this makes a bad unit conversion immediately observable
+    // without executing a recursively short timer chain.
+    const delayMs = delay * 1000;
+    refreshNextAt = Date.now() + delayMs;
     refreshTimerId = window.setTimeout(() => {
         refreshTimerId = null;
         scheduleRefreshTick();
         fireRefresh();
-    }, delay * 1000);
+    }, delayMs);
     updateStaleCountdown();
 }
 
@@ -291,17 +340,25 @@ export function applyRefresh(): void {
 // Live substate. Re-run on every init pass because an hx-boost swap re-renders
 // the navbar.
 export function syncRefreshUI(): void {
-    const live = refreshMode() === 'Live';
-    const secs = refreshInterval();
+    const mode = refreshMode();
+    const live = mode === 'Live';
+    const secs = parseRefreshSeconds(mode);
     const label = document.getElementById('refresh-label');
     if (label) {
-        label.textContent = live ? 'Live' : secs > 0 ? `${secs}s` : 'Off';
+        if (live) {
+            label.textContent = 'Live';
+        } else if (secs > 0) {
+            label.textContent = `${secs}s`;
+        } else {
+            label.textContent = 'Off';
+        }
     }
     document.querySelectorAll('[data-ro-action="set-refresh"]').forEach((opt) => {
-        const value = (opt as HTMLElement).dataset.roInterval ?? '';
+        const value = (opt as HTMLElement).dataset.roInterval;
         opt.classList.toggle(
             'is-active',
-            live ? value === 'Live' : value !== 'Live' && (parseInt(value, 10) || 0) === secs,
+            value !== undefined &&
+                (live ? value === 'Live' : value !== 'Live' && parseRefreshSeconds(value) === secs),
         );
     });
     const dropdown = document.getElementById('refresh-dropdown');
@@ -337,11 +394,13 @@ export function noteRefreshRecovery(): void {
 // updates right away instead of waiting up to a full poll cadence (the Live
 // fallback's 5s counts -- effectivePollSeconds; a RIDING stream needs no
 // catch-up poll: its reopen pushes a fresh full frame).
-document.addEventListener('visibilitychange', () => {
+export function handleRefreshVisibilityChange(): void {
     if (!document.hidden && effectivePollSeconds() > 0) {
         fireRefresh();
     }
-});
+}
+
+document.addEventListener('visibilitychange', handleRefreshVisibilityChange);
 
 // --- dispatcher bindings ----------------------------------------------------
 // The two refresh-domain click branches that were the LAST resident tails of the
@@ -398,7 +457,7 @@ export const refreshBindings: Binding[] = [
             if (option.dataset.roInterval === 'Live') {
                 roPrefsSetRefresh('Live');
             } else {
-                const interval = parseInt(option.dataset.roInterval ?? '', 10) || 0;
+                const interval = parseRefreshSeconds(option.dataset.roInterval as string);
                 roPrefsSetRefresh(interval > 0 ? String(interval) : 'Off');
             }
             liveApply(true); // force: an explicit pick re-attempts even after a fallback

--- a/internal/assets/src/js/row-selection.dom.test.ts
+++ b/internal/assets/src/js/row-selection.dom.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import {
     BULK_NAMES_MAX,
@@ -73,8 +73,17 @@ describe('row selection state', () => {
         rowState().setSelected('prod/default/api-0', false);
 
         expect(document.getElementById('row-a')).not.toHaveClass('is-selected');
+        expect(document.getElementById('ro-bulk-count')).toHaveTextContent('0 selected');
         expect(document.getElementById('ro-bulkbar')).not.toHaveClass('is-open');
         expect(document.getElementById('ro-bulkbar')).toHaveAttribute('inert');
+    });
+
+    test('keeps painting the bulk bar when its optional count label is absent', () => {
+        document.getElementById('ro-bulk-count')?.remove();
+
+        expect(() => rowState().setSelected('prod/default/api-0', true)).not.toThrow();
+        expect(document.getElementById('ro-bulkbar')).toHaveClass('is-open');
+        expect(document.getElementById('ro-bulk-download')).not.toBeDisabled();
     });
 
     test('keeps the full captured name after a selected row leaves the DOM', () => {
@@ -116,12 +125,18 @@ describe('row selection state', () => {
 
         binding.handler(eventTarget(plain), row);
         expect(rowState().selectedKeys()).toStrictEqual(['prod/default/api-0']);
+        expect(row).toHaveClass('is-selected');
+        expect(document.getElementById('ro-bulk-count')).toHaveTextContent('1 selected');
+        expect(document.getElementById('ro-bulkbar')).toHaveClass('is-open');
 
         binding.handler(eventTarget(anchor), row);
         expect(rowState().selectedKeys()).toStrictEqual(['prod/default/api-0']);
 
         binding.handler(eventTarget(plain), row);
         expect(rowState().selectedKeys()).toStrictEqual([]);
+        expect(row).not.toHaveClass('is-selected');
+        expect(document.getElementById('ro-bulk-count')).toHaveTextContent('0 selected');
+        expect(document.getElementById('ro-bulkbar')).not.toHaveClass('is-open');
     });
 
     test('enforces the bulk cap and rearms its toast after dropping under it', () => {
@@ -145,6 +160,7 @@ describe('row selection state', () => {
 
         rowState().setSelected('prod/default/item-0', false);
         expect(download).not.toBeDisabled();
+        expect(download).toHaveAttribute('title', '');
         rowState().setSelected('prod/default/new-item', true);
         expect(toast).toHaveBeenCalledTimes(2);
     });
@@ -158,10 +174,36 @@ describe('row selection state', () => {
         expect(rowState().selectedKeys()).toStrictEqual([]);
         expect(rowState().focusedKey()).toBeNull();
         expect(document.getElementById('row-a')).not.toHaveClass('is-selected', 'kfocus');
+        expect(document.getElementById('ro-bulk-count')).toHaveTextContent('0 selected');
+        expect(document.getElementById('ro-bulkbar')).not.toHaveClass('is-open');
+        expect(document.getElementById('ro-bulkbar')).toHaveAttribute('inert');
+    });
+
+    test('exports the delegated row-click contract', () => {
+        expect(rowSelectionBindings).toHaveLength(1);
+        expect(rowSelectionBindings[0].event).toBe('click');
+        expect(rowSelectionBindings[0].selector).toBe('#resource-list-content tr[data-key]');
+        expect(rowSelectionBindings[0].stop).toBeUndefined();
     });
 });
 
 describe('clipboard bridge', () => {
+    beforeEach(() => {
+        document.body.replaceChildren();
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: undefined,
+        });
+        Object.defineProperty(document, 'execCommand', {
+            configurable: true,
+            value: undefined,
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
     test('uses the async clipboard API when available', async () => {
         const writeText = vi.fn().mockResolvedValue(undefined);
         Object.defineProperty(navigator, 'clipboard', {
@@ -173,6 +215,70 @@ describe('clipboard bridge', () => {
 
         expect(ok).toBe(true);
         expect(writeText).toHaveBeenCalledWith('api-0');
+    });
+
+    test('uses an off-screen readonly textarea when the async API is unavailable', async () => {
+        const select = vi.spyOn(HTMLTextAreaElement.prototype, 'select');
+        let fallbackTextarea: HTMLTextAreaElement | null = null;
+        let fallbackSnapshot:
+            | {
+                  value: string;
+                  readOnly: boolean;
+                  position: string;
+                  top: string;
+                  attached: boolean;
+              }
+            | undefined;
+        const execCommand = vi.fn(() => {
+            const textarea = document.querySelector('textarea');
+            if (!textarea) {
+                return false;
+            }
+            fallbackTextarea = textarea;
+            fallbackSnapshot = {
+                value: textarea.value,
+                readOnly: textarea.readOnly,
+                position: textarea.style.position,
+                top: textarea.style.top,
+                attached: document.body.contains(textarea),
+            };
+            return false;
+        });
+        Object.defineProperty(document, 'execCommand', {
+            configurable: true,
+            value: execCommand,
+        });
+
+        const ok = await new Promise<boolean>((resolve) => roCopyText('db-0', resolve));
+
+        expect(ok).toBe(false);
+        expect(execCommand).toHaveBeenCalledExactlyOnceWith('copy');
+        expect(select).toHaveBeenCalledOnce();
+        expect(fallbackTextarea).not.toBeNull();
+        expect(fallbackSnapshot).toStrictEqual({
+            value: 'db-0',
+            readOnly: true,
+            position: 'fixed',
+            top: '-1000px',
+            attached: true,
+        });
+        expect(document.querySelector('textarea')).not.toBeInTheDocument();
+    });
+
+    test('reports a throwing fallback as failed and still removes its textarea', async () => {
+        const execCommand = vi.fn(() => {
+            throw new Error('copy blocked');
+        });
+        Object.defineProperty(document, 'execCommand', {
+            configurable: true,
+            value: execCommand,
+        });
+
+        const ok = await new Promise<boolean>((resolve) => roCopyText('db-0', resolve));
+
+        expect(ok).toBe(false);
+        expect(execCommand).toHaveBeenCalledExactlyOnceWith('copy');
+        expect(document.querySelector('textarea')).not.toBeInTheDocument();
     });
 
     test('falls back to execCommand after an async clipboard rejection', async () => {

--- a/internal/assets/src/js/row-selection.ts
+++ b/internal/assets/src/js/row-selection.ts
@@ -135,7 +135,7 @@ export function clearRowState(): void {
 // BULK_NAMES_MAX the Download button disables and ONE toast announces the
 // refusal per cap crossing (re-armed once the selection drops back under).
 export const BULK_NAMES_MAX = 100;
-let bulkOverCapToasted = false;
+let bulkOverCapToasted: boolean | undefined;
 
 export function updateBulkBar(): void {
     const bar = document.getElementById('ro-bulkbar');
@@ -144,7 +144,7 @@ export function updateBulkBar(): void {
     }
     const count = rowSelection.size;
     const label = document.getElementById('ro-bulk-count');
-    if (label && count > 0) {
+    if (label) {
         label.textContent = `${count} selected`;
     }
     bar.classList.toggle('is-open', count > 0);
@@ -180,19 +180,18 @@ export function roCopyText(text: string, done: (ok: boolean) => void): void {
     const fallback = (): boolean => {
         const ta = document.createElement('textarea');
         ta.value = text;
-        ta.setAttribute('readonly', '');
+        ta.readOnly = true;
         ta.style.position = 'fixed';
         ta.style.top = '-1000px';
         document.body.appendChild(ta);
-        ta.select();
-        let ok = false;
         try {
-            ok = document.execCommand('copy');
+            ta.select();
+            return document.execCommand('copy');
         } catch {
-            ok = false;
+            return false;
+        } finally {
+            ta.remove();
         }
-        ta.remove();
-        return ok;
     };
     if (navigator.clipboard?.writeText) {
         navigator.clipboard.writeText(text).then(

--- a/internal/assets/src/js/skeleton-load.dom.test.ts
+++ b/internal/assets/src/js/skeleton-load.dom.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+
+import { afterEach, expect, test, vi } from 'vitest';
+
+const stale = vi.hoisted(() => ({
+    isListRefreshEvent: vi.fn((event: Event) => Boolean((event as CustomEvent).detail?.isList)),
+}));
+
+vi.mock('./stale.js', () => stale);
+
+afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+});
+
+test('the complete skeleton lifecycle works through registered events on a fresh import', async () => {
+    vi.resetModules();
+    await import('./skeleton.js');
+
+    document.body.innerHTML = `
+        <div id="ro-skel-template" hidden>
+            <div class="ro-skel">Loading A</div>
+            <div class="ro-skel">Loading B</div>
+        </div>
+        <div id="resource-list-content"></div>`;
+    const content = document.getElementById('resource-list-content') as HTMLElement;
+    const requestEvent = (type: string) => new CustomEvent(type, { detail: { isList: true } });
+
+    document.dispatchEvent(requestEvent('htmx:beforeRequest'));
+    expect(content.querySelectorAll(':scope > .ro-skel')).toHaveLength(2);
+
+    document.dispatchEvent(requestEvent('htmx:responseError'));
+    expect(content.querySelectorAll(':scope > .ro-skel')).toHaveLength(0);
+
+    document.dispatchEvent(requestEvent('htmx:beforeRequest'));
+    document.dispatchEvent(requestEvent('htmx:sendError'));
+    expect(content.querySelectorAll(':scope > .ro-skel')).toHaveLength(0);
+});

--- a/internal/assets/src/js/skeleton.dom.test.ts
+++ b/internal/assets/src/js/skeleton.dom.test.ts
@@ -55,6 +55,21 @@ describe('list skeleton lifecycle', () => {
         document.getElementById('ro-skel-template')?.remove();
         document.dispatchEvent(requestEvent('htmx:beforeRequest'));
         expect(document.querySelector('#resource-list-content .ro-skel')).not.toBeInTheDocument();
+
+        document.getElementById('resource-list-content')?.remove();
+        expect(() => document.dispatchEvent(requestEvent('htmx:beforeRequest'))).not.toThrow();
+    });
+
+    test('an error clears every skeleton root created by the request lifecycle', () => {
+        document.dispatchEvent(requestEvent('htmx:beforeRequest'));
+        const content = document.getElementById('resource-list-content') as HTMLElement;
+        content.insertAdjacentHTML('beforeend', '<p>Diagnostic</p>');
+        expect(content.querySelectorAll(':scope > .ro-skel')).toHaveLength(2);
+
+        document.dispatchEvent(requestEvent('htmx:responseError'));
+
+        expect(content.querySelectorAll(':scope > .ro-skel')).toHaveLength(0);
+        expect(content).toHaveTextContent('Diagnostic');
     });
 
     test.each(['htmx:responseError', 'htmx:sendError'])(
@@ -73,11 +88,14 @@ describe('list skeleton lifecycle', () => {
         },
     );
 
-    test('error events do not touch a skeleton belonging to another request', () => {
-        renderSkeleton('<div class="ro-skel">Loading</div>');
+    test.each(['htmx:responseError', 'htmx:sendError'])(
+        '%s does not touch a skeleton belonging to another request',
+        (eventType) => {
+            renderSkeleton('<div class="ro-skel">Loading</div>');
 
-        document.dispatchEvent(requestEvent('htmx:responseError', false));
+            document.dispatchEvent(requestEvent(eventType, false));
 
-        expect(document.querySelector('#resource-list-content .ro-skel')).toBeInTheDocument();
-    });
+            expect(document.querySelector('#resource-list-content .ro-skel')).toBeInTheDocument();
+        },
+    );
 });

--- a/internal/assets/src/js/skeleton.ts
+++ b/internal/assets/src/js/skeleton.ts
@@ -41,10 +41,12 @@ document.addEventListener('htmx:beforeRequest', (event) => {
 // a region that had none.
 function clearListSkeleton(): void {
     const content = document.getElementById('resource-list-content');
-    const skel = content?.querySelector(':scope > .ro-skel');
-    if (skel) {
-        skel.remove();
+    if (!content) {
+        return;
     }
+    content.querySelectorAll(':scope > .ro-skel').forEach((skeleton) => {
+        skeleton.remove();
+    });
 }
 document.addEventListener('htmx:responseError', (event) => {
     if (isListRefreshEvent(event)) {

--- a/internal/assets/src/js/stale-load.dom.test.ts
+++ b/internal/assets/src/js/stale-load.dom.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+
+import { afterEach, expect, test, vi } from 'vitest';
+
+const refresh = vi.hoisted(() => ({
+    isPreloadRequest: vi.fn(() => false),
+    noteRefreshFailure: vi.fn(),
+    refreshNextAtMs: vi.fn(() => 0),
+}));
+
+vi.mock('./refresh.js', () => refresh);
+
+afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+});
+
+test('both HTMX error events drive the observable stale lifecycle after a fresh import', async () => {
+    vi.resetModules();
+    const stale = await import('./stale.js');
+
+    document.body.innerHTML = `
+        <div id="resource-list-content">last good rows</div>
+        <aside class="ro-stale-banner" hidden><span data-stale-countdown></span></aside>`;
+    const content = document.getElementById('resource-list-content') as HTMLElement;
+
+    for (const eventType of ['htmx:responseError', 'htmx:sendError']) {
+        document.dispatchEvent(new CustomEvent(eventType, { detail: { target: content } }));
+
+        expect(refresh.noteRefreshFailure).toHaveBeenCalledOnce();
+        expect(content.className).toBe('ro-stale');
+        expect(document.querySelector('.ro-stale-banner')).toBeVisible();
+
+        stale.clearListStale();
+        refresh.noteRefreshFailure.mockClear();
+    }
+});

--- a/internal/assets/src/js/stale.dom.test.ts
+++ b/internal/assets/src/js/stale.dom.test.ts
@@ -89,15 +89,26 @@ describe('stale UI lifecycle', () => {
         refresh.refreshNextAtMs.mockReturnValue(Date.now() + 2501);
 
         updateStaleCountdown();
-        expect(document.querySelector('[data-stale-countdown]')).toHaveTextContent('3s');
+        expect(document.querySelector('[data-stale-countdown]')?.textContent).toBe('3s');
 
         refresh.refreshNextAtMs.mockReturnValue(Date.now() - 1);
         updateStaleCountdown();
-        expect(document.querySelector('[data-stale-countdown]')).toHaveTextContent('0s');
+        expect(document.querySelector('[data-stale-countdown]')?.textContent).toBe('0s');
 
         refresh.refreshNextAtMs.mockReturnValue(0);
         updateStaleCountdown();
-        expect(document.querySelector('[data-stale-countdown]')).toHaveTextContent('…');
+        expect(document.querySelector('[data-stale-countdown]')?.textContent).toBe('…');
+    });
+
+    test('missing stale UI is safe and does not start a useless countdown ticker', () => {
+        vi.useFakeTimers();
+        document.body.replaceChildren();
+
+        expect(() => markListStale()).not.toThrow();
+
+        expect(vi.getTimerCount()).toBe(0);
+        expect(() => updateStaleCountdown()).not.toThrow();
+        expect(() => clearListStale()).not.toThrow();
     });
 
     test('clear restores fresh state, hides the banner, and stops the ticker', () => {
@@ -126,12 +137,15 @@ describe('stale UI lifecycle', () => {
         },
     );
 
-    test('ignores unrelated error events', () => {
-        document.dispatchEvent(
-            htmxEvent('htmx:responseError', { target: document.createElement('main') }),
-        );
+    test.each(['htmx:responseError', 'htmx:sendError'])(
+        '%s ignores unrelated error events',
+        (eventType) => {
+            document.dispatchEvent(
+                htmxEvent(eventType, { target: document.createElement('main') }),
+            );
 
-        expect(refresh.noteRefreshFailure).not.toHaveBeenCalled();
-        expect(document.getElementById('resource-list-content')).not.toHaveClass('ro-stale');
-    });
+            expect(refresh.noteRefreshFailure).not.toHaveBeenCalled();
+            expect(document.getElementById('resource-list-content')).not.toHaveClass('ro-stale');
+        },
+    );
 });

--- a/internal/assets/src/js/stale.ts
+++ b/internal/assets/src/js/stale.ts
@@ -67,9 +67,10 @@ export function markListStale(): void {
         content.classList.add(STALE_DIM_CLASS);
     }
     const banner = document.querySelector('.ro-stale-banner') as HTMLElement | null;
-    if (banner) {
-        banner.hidden = false;
+    if (!banner) {
+        return;
     }
+    banner.hidden = false;
     // Live countdown for the banner's "Retrying in Ns" (the data-stale-countdown
     // hook). The immediate paint lands the right number before the ticker's
     // first 1s beat.

--- a/internal/assets/src/js/theme.dom.test.ts
+++ b/internal/assets/src/js/theme.dom.test.ts
@@ -61,6 +61,7 @@ describe('theme toggle target', () => {
     test('registers exactly one OS-scheme listener at module load', async () => {
         const { listener, syncThemeTogglePostTarget } = await loadTheme(false);
 
+        expect(window.matchMedia).toHaveBeenCalledExactlyOnceWith('(prefers-color-scheme: dark)');
         expect(listener).toHaveBeenCalledOnce();
         expect(listener).toHaveBeenCalledWith('change', syncThemeTogglePostTarget);
     });

--- a/internal/assets/src/js/virtualizer-load.dom.test.ts
+++ b/internal/assets/src/js/virtualizer-load.dom.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+
+import { afterEach, expect, test, vi } from 'vitest';
+
+const dependencies = vi.hoisted(() => ({
+    reapplyRowState: vi.fn(),
+    requestListRefresh: vi.fn(),
+}));
+
+vi.mock('./refresh.js', () => ({
+    requestListRefresh: dependencies.requestListRefresh,
+}));
+
+vi.mock('./row-selection.js', () => ({
+    reapplyRowState: dependencies.reapplyRowState,
+}));
+
+afterEach(() => {
+    document.body.replaceChildren();
+    Reflect.deleteProperty(document, 'fonts');
+    vi.restoreAllMocks();
+});
+
+test('registers passive viewport hooks and remeasures only an active changed font pitch', async () => {
+    vi.resetModules();
+    let fontReady: (() => void) | undefined;
+    const then = vi.fn((callback: () => void) => {
+        fontReady = callback;
+    });
+    Object.defineProperty(document, 'fonts', {
+        configurable: true,
+        value: { ready: { then } },
+    });
+    const addEventListener = vi.spyOn(window, 'addEventListener');
+    const requestAnimationFrame = vi.fn();
+    Object.defineProperty(window, 'requestAnimationFrame', {
+        configurable: true,
+        value: requestAnimationFrame,
+    });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 100 });
+    Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        value: vi.fn(() => ({ matches: false })),
+    });
+    let rowHeight = 20;
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (
+        this: Element,
+    ) {
+        const element = this as HTMLElement;
+        const index = Number(element.dataset.testIndex ?? 0);
+        return {
+            bottom: element.matches('tr[data-key]') ? index * rowHeight + rowHeight : rowHeight,
+            height: rowHeight,
+            left: 0,
+            right: 100,
+            top: element.matches('tr[data-key]') ? index * rowHeight : 0,
+            width: 100,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+        } as DOMRect;
+    });
+    window.roRowModel = { fields: [], rows: [], visibleKeys: null };
+    window.roRowState = {
+        setSelected: vi.fn(),
+        setFocus: vi.fn(),
+        focusedKey: () => null,
+        clear: vi.fn(),
+        selectedKeys: () => [],
+        selectedEntries: () => [],
+    };
+
+    const virtualizer = await import('./virtualizer.js');
+
+    // Passive scroll handling is itself the performance contract; resize is
+    // proven below by dispatching the real window event and observing a re-window.
+    expect(addEventListener).toHaveBeenCalledWith('scroll', expect.any(Function), {
+        passive: true,
+    });
+    expect(then).toHaveBeenCalledOnce();
+    expect(fontReady).toBeTypeOf('function');
+    expect(Object.keys(window.roVirtual)).toStrictEqual([
+        'active',
+        'renderedBounds',
+        'scrollToKey',
+    ]);
+
+    window.dispatchEvent(new Event('scroll'));
+    expect(requestAnimationFrame).not.toHaveBeenCalled();
+    expect(() => fontReady?.()).not.toThrow();
+
+    document.body.innerHTML = `
+        <div id="resource-list-content">
+            <div class="ro-table-wrap ro-windowed">
+                <table class="ro-table">
+                    <thead><tr><th>Name</th><th>Value</th></tr></thead>
+                    <tbody>${Array.from(
+                        { length: 30 },
+                        (_, index) =>
+                            `<tr data-key="row-${index}" data-test-index="${index}"><td>row-${index}</td><td>value-${index}</td></tr>`,
+                    ).join('')}</tbody>
+                </table>
+            </div>
+        </div>`;
+    virtualizer.virtualizeInit();
+    expect(dependencies.reapplyRowState).toHaveBeenCalledOnce();
+    expect(window.roVirtual.renderedBounds()).toStrictEqual({ start: 0, end: 17, total: 30 });
+
+    window.dispatchEvent(new Event('scroll'));
+    expect(requestAnimationFrame).toHaveBeenCalledOnce();
+
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 200 });
+    window.dispatchEvent(new Event('resize'));
+    expect(dependencies.reapplyRowState).toHaveBeenCalledTimes(2);
+    expect(window.roVirtual.renderedBounds()).toStrictEqual({ start: 0, end: 22, total: 30 });
+
+    rowHeight = 30;
+    fontReady?.();
+    expect(dependencies.reapplyRowState).toHaveBeenCalledTimes(3);
+    expect(window.roVirtual.renderedBounds()).toStrictEqual({ start: 0, end: 19, total: 30 });
+
+    fontReady?.();
+    expect(dependencies.reapplyRowState).toHaveBeenCalledTimes(3);
+
+    rowHeight = 30.5;
+    fontReady?.();
+    expect(dependencies.reapplyRowState).toHaveBeenCalledTimes(3);
+
+    rowHeight = 0;
+    fontReady?.();
+    expect(dependencies.reapplyRowState).toHaveBeenCalledTimes(3);
+
+    window.roRowModel.visibleKeys = new Set();
+    virtualizer.virtualizeOnFilterChange();
+    expect(dependencies.reapplyRowState).toHaveBeenCalledTimes(4);
+    expect(() => fontReady?.()).not.toThrow();
+    expect(dependencies.reapplyRowState).toHaveBeenCalledTimes(4);
+});
+
+test.each([
+    ['no FontFaceSet', undefined],
+    ['no ready member', {}],
+    ['non-thenable ready member', { ready: 42 }],
+])('loads safely with %s', async (_case, fonts) => {
+    vi.resetModules();
+    if (fonts === undefined) {
+        Reflect.deleteProperty(document, 'fonts');
+    } else {
+        Object.defineProperty(document, 'fonts', { configurable: true, value: fonts });
+    }
+
+    const virtualizer = await import('./virtualizer.js');
+    expect(virtualizer.virtualizerActive()).toBe(false);
+});

--- a/internal/assets/src/js/virtualizer-math.test.ts
+++ b/internal/assets/src/js/virtualizer-math.test.ts
@@ -125,6 +125,10 @@ test('a row already in the band needs no scroll', () => {
     expect(scrollAdjustToReveal(100, 20, 56, 800)).toBe(0);
 });
 
+test('a row aligned with the top edge still scrolls down when the band is shorter than the row', () => {
+    expect(scrollAdjustToReveal(56, 20, 56, 70)).toBe(6);
+});
+
 // --- clampFocusIndex --------------------------------------------------------
 
 test('a forward step from an unknown focus (-1) lands on row 0', () => {

--- a/internal/assets/src/js/virtualizer-math.ts
+++ b/internal/assets/src/js/virtualizer-math.ts
@@ -44,14 +44,8 @@ export function windowBounds(
     const n = visibleCount;
     const first = Math.floor((0 - tbodyTop) / pitch);
     const last = Math.ceil((innerHeight - tbodyTop) / pitch);
-    let start = Math.max(0, first - buffer);
-    let end = Math.min(n, last + buffer);
-    if (start > n) {
-        start = n;
-    }
-    if (end < start) {
-        end = start;
-    }
+    const start = Math.min(n, Math.max(0, first - buffer));
+    const end = Math.max(start, Math.min(n, last + buffer));
     return { start, end };
 }
 
@@ -110,14 +104,11 @@ export function scrollAdjustToReveal(
     topMin: number,
     innerHeight: number,
 ): number {
-    const rowBottom = rowTop + rowH;
-    if (rowTop < topMin) {
-        return rowTop - topMin;
+    const topOverflow = rowTop - topMin;
+    if (topOverflow < 0) {
+        return topOverflow;
     }
-    if (rowBottom > innerHeight) {
-        return rowBottom - innerHeight;
-    }
-    return 0;
+    return Math.max(0, rowTop + rowH - innerHeight);
 }
 
 // clampFocusIndex steps a focus index by delta and clamps to [0, n-1]; when the

--- a/internal/assets/src/js/virtualizer.dom.test.ts
+++ b/internal/assets/src/js/virtualizer.dom.test.ts
@@ -35,15 +35,18 @@ interface VirtualizerSeam {
 
 interface ListOptions {
     changedValues?: Readonly<Record<string, string>>;
+    columnCount?: number;
     filteredKeys?: ReadonlySet<string>;
+    lineHeight?: string;
     windowed?: boolean;
 }
 
 const ROW_HEIGHT = 20;
-const HEADER_WIDTHS = [120, 180];
 
 let animationFrames: FrameRequestCallback[];
 let focusedKey: string | null;
+let geometryRowHeight: number;
+let headerWidths: number[];
 let reducedMotion: boolean;
 let scrollYValue: number;
 let tbodyDocumentTop: number;
@@ -81,7 +84,10 @@ function buildList(keys: readonly string[], options: ListOptions = {}): HTMLElem
     table.className = 'ro-table';
     const thead = table.createTHead();
     const header = thead.insertRow();
-    header.append(document.createElement('th'), document.createElement('th'));
+    const columnCount = options.columnCount ?? 2;
+    for (let column = 0; column < columnCount; column += 1) {
+        header.append(document.createElement('th'));
+    }
     const tbody = table.createTBody();
 
     keys.forEach((key, index) => {
@@ -94,8 +100,19 @@ function buildList(keys: readonly string[], options: ListOptions = {}): HTMLElem
         }
         const identity = row.insertCell();
         identity.textContent = key;
-        const value = row.insertCell();
-        value.textContent = options.changedValues?.[key] ?? `value-${key}`;
+        if (options.lineHeight) {
+            identity.style.lineHeight = options.lineHeight;
+        }
+        for (let column = 1; column < columnCount; column += 1) {
+            const value = row.insertCell();
+            value.textContent =
+                column === 1
+                    ? (options.changedValues?.[key] ?? `value-${key}`)
+                    : `extra-${column}-${key}`;
+            if (options.lineHeight) {
+                value.style.lineHeight = options.lineHeight;
+            }
+        }
     });
 
     wrap.append(table);
@@ -150,14 +167,18 @@ function installBrowserGeometry(): void {
         const element = this as HTMLElement;
         if (element.tagName === 'TH') {
             const index = Array.from(element.parentElement?.children ?? []).indexOf(element);
-            return rect(0, HEADER_WIDTHS[index] ?? 100, ROW_HEIGHT);
+            return rect(0, headerWidths[index] ?? 100, ROW_HEIGHT);
         }
         if (element.tagName === 'TBODY') {
             return rect(tbodyDocumentTop - scrollYValue, 300, ROW_HEIGHT);
         }
         if (element.matches('tr[data-key]')) {
             const index = Number(element.dataset.testIndex ?? 0);
-            return rect(tbodyDocumentTop - scrollYValue + index * ROW_HEIGHT, 300, ROW_HEIGHT);
+            return rect(
+                tbodyDocumentTop - scrollYValue + index * geometryRowHeight,
+                300,
+                geometryRowHeight,
+            );
         }
         if (element.matches('header.ro-topbar')) {
             return rect(0, 300, 30);
@@ -214,10 +235,13 @@ function installBrowserGeometry(): void {
 beforeEach(() => {
     animationFrames = [];
     focusedKey = null;
+    geometryRowHeight = ROW_HEIGHT;
+    headerWidths = [120, 180];
     reducedMotion = false;
     scrollYValue = 0;
     tbodyDocumentTop = 0;
     viewportHeight = 100;
+    document.documentElement.style.removeProperty('--row-py');
     setFocusMock = vi.fn((key: string) => {
         focusedKey = key;
     });
@@ -266,6 +290,7 @@ describe('engagement', () => {
         expect(spacers).toHaveLength(2);
         expect(spacers[0]).toHaveAttribute('aria-hidden', 'true');
         expect(spacers[0].firstElementChild).toHaveAttribute('colspan', '2');
+        expect((spacers[0].firstElementChild as HTMLElement).style.height).toBe('0px');
         expect(markedTbody.closest('table')).toHaveClass('ro-virtualized');
         expect(markedTbody.closest('table')?.querySelectorAll('th')[0]).toHaveStyle({
             width: '120px',
@@ -297,6 +322,115 @@ describe('engagement', () => {
         expect(virtRows()).toStrictEqual([]);
         expect(tbody).toContainElement(cachedSpacer);
     });
+
+    test('refetches a cached spacer mounted on a different tbody from the active one', () => {
+        renderList(rowKeys(20));
+        virtualizeInit();
+        expect(virtualizerActive()).toBe(true);
+        const cached = renderList(['cached-row']);
+        const cachedSpacer = document.createElement('tr');
+        cachedSpacer.className = 'ro-vspacer';
+        cachedSpacer.append(document.createElement('td'));
+        cached.replaceChildren(cachedSpacer);
+
+        virtualizeInit();
+
+        expect(dependencies.requestListRefresh).toHaveBeenCalledOnce();
+        expect(virtualizerActive()).toBe(false);
+        expect(virtRows()).toStrictEqual([]);
+    });
+
+    test('fully disengages when a live list becomes plain, malformed, or empty', () => {
+        const engage = () => {
+            renderList(['row-0', 'row-1']);
+            virtualizeInit();
+            expect(virtualizerActive()).toBe(true);
+        };
+
+        engage();
+        const plain = renderList(['plain-row'], { windowed: false });
+        virtualizeInit();
+        expect(virtualizerActive()).toBe(false);
+        expect(virtRows()).toStrictEqual([]);
+        expect(virtVisible()).toStrictEqual([]);
+        expect(directRowKeys(plain)).toStrictEqual(['plain-row']);
+        expect(virtualizerSeam().renderedBounds()).toStrictEqual({ start: 0, end: 0, total: 0 });
+        expect(virtualizerSeam().scrollToKey('plain-row')).toBe(false);
+
+        engage();
+        document.body.innerHTML = `
+            <div id="resource-list-content">
+                <div class="ro-table-wrap ro-windowed">
+                    <table class="ro-table"><thead><tr><th>Name</th></tr></thead></table>
+                </div>
+            </div>`;
+        virtualizeInit();
+        expect(virtualizerActive()).toBe(false);
+        expect(virtRows()).toStrictEqual([]);
+
+        engage();
+        renderList([]);
+        virtualizeInit();
+        expect(virtualizerActive()).toBe(false);
+        expect(virtRows()).toStrictEqual([]);
+    });
+
+    test('reports a detached mount as inactive and leaves its viewport events inert', () => {
+        const tbody = renderList(rowKeys(40));
+        virtualizeInit();
+        expect(dependencies.reapplyRowState).toHaveBeenCalledOnce();
+
+        tbody.closest('#resource-list-content')?.remove();
+
+        expect(virtualizerActive()).toBe(false);
+        expect(virtualizerSeam().scrollToKey('row-0')).toBe(false);
+        // If the inactive guard regresses, the changed geometry would re-window
+        // the detached tbody and call reapplyRowState a second time.
+        scrollYValue = 400;
+        window.dispatchEvent(new Event('scroll'));
+        expect(animationFrames).toHaveLength(1);
+        flushAnimationFrames();
+        expect(dependencies.reapplyRowState).toHaveBeenCalledOnce();
+    });
+
+    test('uses CSS fallback geometry for a non-positive measured pitch and survives style errors', () => {
+        geometryRowHeight = 0;
+        document.documentElement.style.setProperty('--row-py', '5px');
+        let tbody = renderList(rowKeys(40), { lineHeight: '24px' });
+
+        virtualizeInit();
+
+        expect(virtualizerSeam().renderedBounds()).toStrictEqual({ start: 0, end: 15, total: 40 });
+        expect(tbody.querySelector(':scope > tr.ro-vspacer:last-child td')).toHaveStyle({
+            height: '875px',
+        });
+
+        const computedStyle = vi.spyOn(window, 'getComputedStyle').mockImplementation(() => {
+            throw new Error('style engine unavailable');
+        });
+        tbody = renderList(rowKeys(40));
+
+        expect(() => virtualizeInit()).not.toThrow();
+        computedStyle.mockRestore();
+        expect(virtualizerSeam().renderedBounds()).toStrictEqual({ start: 0, end: 15, total: 40 });
+        expect(tbody.querySelector(':scope > tr.ro-vspacer:last-child td')).toHaveStyle({
+            height: '925px',
+        });
+    });
+
+    test('a fresh full render clears any abandoned pending adoption', () => {
+        renderList(rowKeys(20));
+        virtualizeInit();
+        virtualizePrepareSwap(listFragment(rowKeys(25)));
+
+        renderList(rowKeys(30));
+        virtualizeInit();
+        setVisibleKeys(new Set(['row-29']));
+        virtualizeOnFilterChange();
+
+        expect(virtVisible().map((row) => row.dataset.key)).toStrictEqual(['row-29']);
+        expect(dependencies.reapplyRowState).toHaveBeenCalledTimes(3);
+    });
 });
 
 describe('swap adoption', () => {
@@ -312,6 +446,9 @@ describe('swap adoption', () => {
         });
 
         const incomingKeys = rowKeys(65);
+        const originalSpacers = Array.from(document.querySelectorAll('tr.ro-vspacer'));
+        headerWidths = [140, 200];
+        geometryRowHeight = 30;
         const fragment = listFragment(incomingKeys, {
             changedValues: { 'row-20': 'new value' },
         });
@@ -345,6 +482,9 @@ describe('swap adoption', () => {
         const liveTable = document.querySelector('table.ro-table');
         expect(liveTable).toHaveClass('ro-virtualized');
         expect(liveTable?.querySelectorAll('th')[1]).toHaveStyle({ width: '180px' });
+        expect(Array.from(document.querySelectorAll('tr.ro-vspacer'))).toStrictEqual(
+            originalSpacers,
+        );
     });
 
     test('does not animate adopted cell changes when reduced motion is requested', () => {
@@ -365,6 +505,129 @@ describe('swap adoption', () => {
         expect(changedCell).toHaveTextContent('after');
         expect(changedCell).not.toHaveClass('ro-cell-changed');
         expect(window.matchMedia).toHaveBeenCalledWith('(prefers-reduced-motion: reduce)');
+    });
+
+    test('cold-adopts a windowed fragment without a redundant correction at the exact fallback pitch', () => {
+        document.documentElement.style.setProperty('--row-py', '0.5px');
+        const fragment = listFragment(rowKeys(40));
+
+        virtualizePrepareSwap(fragment);
+
+        const prepared = fragment.querySelector('tbody') as HTMLTableSectionElement;
+        expect(
+            (prepared.querySelector(':scope > tr.ro-vspacer:first-child td') as HTMLElement).style
+                .height,
+        ).toBe('0px');
+        expect(prepared.querySelector(':scope > tr.ro-vspacer:last-child td')).toHaveStyle({
+            height: '800px',
+        });
+        document.body.replaceChildren(fragment.firstElementChild as Element);
+        virtualizeAfterSwap();
+
+        expect(virtualizerActive()).toBe(true);
+        expect(virtRows()).toHaveLength(40);
+        expect(dependencies.reapplyRowState).toHaveBeenCalledOnce();
+        expect(window.matchMedia).not.toHaveBeenCalled();
+        expect(scrollToMock).not.toHaveBeenCalled();
+    });
+
+    test('cold adoption corrects an approximate fallback pitch exactly once', () => {
+        const fragment = listFragment(rowKeys(40));
+        virtualizePrepareSwap(fragment);
+        document.body.replaceChildren(fragment.firstElementChild as Element);
+
+        virtualizeAfterSwap();
+
+        expect(virtualizerActive()).toBe(true);
+        expect(dependencies.reapplyRowState).toHaveBeenCalledTimes(2);
+        expect(virtualizerSeam().renderedBounds()).toStrictEqual({ start: 0, end: 17, total: 40 });
+    });
+
+    test('does not correct a cold pitch at the exact half-pixel tolerance', () => {
+        document.documentElement.style.setProperty('--row-py', '0.5px');
+        const fragment = listFragment(rowKeys(40));
+        virtualizePrepareSwap(fragment);
+        geometryRowHeight = 20.5;
+        document.body.replaceChildren(fragment.firstElementChild as Element);
+
+        virtualizeAfterSwap();
+
+        expect(dependencies.reapplyRowState).toHaveBeenCalledOnce();
+        expect(virtualizerSeam().renderedBounds()).toStrictEqual({ start: 0, end: 17, total: 40 });
+    });
+
+    test('remeasures column pins when an adopted table changes its column set', () => {
+        renderList(rowKeys(20));
+        virtualizeInit();
+        const fragment = listFragment(rowKeys(20), { columnCount: 3 });
+        virtualizePrepareSwap(fragment);
+        document.body.replaceChildren(fragment.firstElementChild as Element);
+
+        virtualizeAfterSwap();
+
+        const headers = document.querySelectorAll('table.ro-table th');
+        expect(headers).toHaveLength(3);
+        expect(headers[0]).toHaveStyle({ width: '120px' });
+        expect(headers[1]).toHaveStyle({ width: '180px' });
+        expect(headers[2]).toHaveStyle({ width: '100px' });
+        expect(document.querySelector('table.ro-table')).toHaveClass('ro-virtualized');
+        expect(document.querySelectorAll('tr.ro-vspacer td')[0]).toHaveAttribute('colspan', '3');
+        expect(document.querySelectorAll('tr.ro-vspacer td')[1]).toHaveAttribute('colspan', '3');
+    });
+
+    test('disengages after a below-threshold fragment or failed adoption mount', () => {
+        renderList(rowKeys(20));
+        virtualizeInit();
+        const plain = listFragment(['plain'], { windowed: false });
+        virtualizePrepareSwap(plain);
+        document.body.replaceChildren(plain.firstElementChild as Element);
+        virtualizeAfterSwap();
+        expect(virtualizerActive()).toBe(false);
+        expect(virtRows()).toStrictEqual([]);
+
+        renderList(rowKeys(20));
+        virtualizeInit();
+        const pending = listFragment(rowKeys(20));
+        virtualizePrepareSwap(pending);
+        document.body.innerHTML = '<div id="resource-list-content">state block</div>';
+        virtualizeAfterSwap();
+        expect(virtualizerActive()).toBe(false);
+        expect(virtRows()).toStrictEqual([]);
+    });
+
+    test('leaves a windowed fragment with no keyed rows untouched', () => {
+        const fragment = listFragment([]);
+        const tbody = fragment.querySelector('tbody') as HTMLTableSectionElement;
+        const unkeyed = tbody.insertRow();
+        unkeyed.insertCell().textContent = 'state row';
+
+        virtualizePrepareSwap(fragment);
+
+        expect(tbody.children).toHaveLength(1);
+        expect(tbody).toHaveTextContent('state row');
+        document.body.replaceChildren(fragment.firstElementChild as Element);
+        virtualizeAfterSwap();
+        expect(virtualizerActive()).toBe(false);
+    });
+
+    test('ignores unkeyed incoming rows and does not animate unchanged, added, or non-data cells', () => {
+        renderList(['row-0']);
+        virtualizeInit();
+        const fragment = listFragment(['row-0', 'row-1'], { columnCount: 3 });
+        const incomingBody = fragment.querySelector('tbody') as HTMLTableSectionElement;
+        const unkeyed = incomingBody.insertRow();
+        unkeyed.insertCell().textContent = 'not an identity row';
+        const row0 = incomingBody.querySelector('#id-row-0') as HTMLTableRowElement;
+        const replacementHeader = document.createElement('th');
+        replacementHeader.textContent = 'changed but not a data cell';
+        row0.replaceChild(replacementHeader, row0.children[1]);
+
+        virtualizePrepareSwap(fragment);
+        document.body.replaceChildren(fragment.firstElementChild as Element);
+        virtualizeAfterSwap();
+
+        expect(virtRows().map((row) => row.dataset.key)).toStrictEqual(['row-0', 'row-1']);
+        expect(document.querySelectorAll('.ro-cell-changed')).toHaveLength(0);
     });
 });
 
@@ -412,9 +675,59 @@ describe('full-set filtering and focus', () => {
         expect(virtMoveFocus(1)).toBe(false);
         expect(virtualizerSeam().scrollToKey('row-0')).toBe(false);
     });
+
+    test('starts an unknown focus at the first row and does not scroll a row already in view', () => {
+        renderList(rowKeys(20));
+        virtualizeInit();
+        focusedKey = 'detached-key';
+
+        expect(virtMoveFocus(1)).toBe(true);
+        expect(setFocusMock).toHaveBeenCalledExactlyOnceWith('row-0');
+        expect(scrollByMock).not.toHaveBeenCalled();
+        expect(virtualizerSeam().scrollToKey('row-1')).toBe(true);
+        expect(scrollByMock).not.toHaveBeenCalled();
+    });
+
+    test('keeps filtering inert while an adoption is pending and when disengaged', () => {
+        setVisibleKeys(new Set());
+        virtualizeOnFilterChange();
+        expect(dependencies.reapplyRowState).not.toHaveBeenCalled();
+
+        renderList(rowKeys(20));
+        virtualizeInit();
+        const visibleBefore = virtVisible();
+        const fragment = listFragment(rowKeys(25));
+        virtualizePrepareSwap(fragment);
+        setVisibleKeys(new Set(['row-24']));
+
+        virtualizeOnFilterChange();
+
+        expect(virtVisible()).toBe(visibleBefore);
+        expect(dependencies.reapplyRowState).toHaveBeenCalledOnce();
+    });
 });
 
 describe('viewport events', () => {
+    test('is inert before engagement', () => {
+        window.dispatchEvent(new Event('scroll'));
+
+        expect(animationFrames).toHaveLength(0);
+        expect(dependencies.reapplyRowState).not.toHaveBeenCalled();
+    });
+
+    test('rerenders when only the window start changes', () => {
+        renderList(rowKeys(15));
+        virtualizeInit();
+        expect(virtualizerSeam().renderedBounds()).toStrictEqual({ start: 0, end: 15, total: 15 });
+
+        scrollYValue = 400;
+        window.dispatchEvent(new Event('scroll'));
+        flushAnimationFrames();
+
+        expect(virtualizerSeam().renderedBounds()).toStrictEqual({ start: 8, end: 15, total: 15 });
+        expect(dependencies.reapplyRowState).toHaveBeenCalledTimes(2);
+    });
+
     test('rAF-throttles scrolls, skips unchanged bounds, and reacts to viewport resize', () => {
         const tbody = renderList(rowKeys(80));
         virtualizeInit();

--- a/internal/assets/src/js/virtualizer.ts
+++ b/internal/assets/src/js/virtualizer.ts
@@ -103,7 +103,7 @@ const virtState: VirtState = {
 };
 
 export function virtualizerActive(): boolean {
-    return virtState.active && !!virtState.tbody && virtState.tbody.isConnected;
+    return virtState.active && virtState.tbody?.isConnected === true;
 }
 
 function virtReset(): void {
@@ -156,7 +156,7 @@ function virtMeasureRowHeight(): number {
     const first = rendered[0].getBoundingClientRect();
     const last = rendered[rendered.length - 1].getBoundingClientRect();
     const pitch = (last.bottom - first.top) / rendered.length;
-    return pitch > 0 ? pitch : 0;
+    return Math.max(0, pitch);
 }
 
 // virtFallbackRowHeight is the fixed-row-height formula (--row-py×2 + line-height + the row
@@ -212,7 +212,7 @@ function virtComputeVisible(): void {
     const keys = roRowModel().visibleKeys;
     virtState.visible = keys
         ? virtState.rows.filter((tr) => keys.has(tr.dataset.key as string))
-        : virtState.rows.slice();
+        : virtState.rows;
 }
 
 // virtRenderWindow renders the current slice between the two spacers and re-keys
@@ -244,14 +244,11 @@ function virtRenderWindow(): void {
 function virtBindMounts(): boolean {
     const content = document.getElementById('resource-list-content');
     const wrap = content?.querySelector('.ro-table-wrap.ro-windowed');
-    const table = wrap?.querySelector('table.ro-table');
-    const tbody =
-        table && (table as HTMLTableElement).tBodies.length > 0
-            ? (table as HTMLTableElement).tBodies[0]
-            : null;
-    virtState.table = (table as HTMLTableElement) || null;
-    virtState.tbody = tbody || null;
-    return !!tbody;
+    const table = wrap?.querySelector<HTMLTableElement>('table.ro-table') ?? null;
+    const tbody = table?.tBodies.item(0) ?? null;
+    virtState.table = table;
+    virtState.tbody = tbody;
+    return tbody !== null;
 }
 
 // virtualizeInit is the runInit engagement step. ORDER CONTRACT: it runs AFTER
@@ -264,8 +261,8 @@ export function virtualizeInit(): void {
         virtReset(); // small list / non-list page: windowing disengaged
         return;
     }
-    const table = wrap.querySelector('table.ro-table') as HTMLTableElement | null;
-    const tbody = table && table.tBodies.length > 0 ? table.tBodies[0] : null;
+    const table = wrap.querySelector<HTMLTableElement>('table.ro-table');
+    const tbody = table?.tBodies.item(0) ?? null;
     if (!tbody) {
         virtReset();
         return;
@@ -317,12 +314,7 @@ export function virtualizePrepareSwap(fragment: DocumentFragment): void {
     if (!tbody) {
         return; // below-threshold fragment -> plain morph; afterSwap disengages
     }
-    const rows: HTMLElement[] = [];
-    Array.prototype.forEach.call(tbody.children, (el: HTMLElement) => {
-        if (el.tagName === 'TR' && el.dataset.key) {
-            rows.push(el);
-        }
-    });
+    const rows = Array.from(tbody.querySelectorAll<HTMLElement>(':scope > tr[data-key]'));
     if (rows.length === 0) {
         return;
     }
@@ -348,9 +340,7 @@ export function virtualizeAfterSwap(): void {
         // The fragment fell below the threshold (or was a whole-list state
         // block): the morph landed the complete content in the DOM, so the
         // virtualizer disengages and leaves it alone.
-        if (virtState.active) {
-            virtReset();
-        }
+        virtReset();
         return;
     }
     const prior = virtState.byKey;
@@ -403,11 +393,7 @@ export function virtualizeAfterSwap(): void {
 // window is diffed here against the prior row set by identity. Disabled under
 // prefers-reduced-motion exactly like the idiomorph hooks.
 function virtFlashChangedCells(prior: Map<string, HTMLElement>): void {
-    if (
-        !prior ||
-        prior.size === 0 ||
-        window.matchMedia('(prefers-reduced-motion: reduce)').matches
-    ) {
+    if (prior.size === 0 || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
         return;
     }
     (virtState.tbody as HTMLTableSectionElement)
@@ -417,17 +403,18 @@ function virtFlashChangedCells(prior: Map<string, HTMLElement>): void {
             if (!old) {
                 return;
             }
-            const oldCells = old.children;
-            const newCells = tr.children;
-            for (let i = 0; i < newCells.length; i++) {
-                const o = oldCells[i];
-                const nd = newCells[i];
-                if (o && nd && nd.tagName === 'TD' && o.textContent !== nd.textContent) {
-                    nd.classList.remove('ro-cell-changed');
-                    void (nd as HTMLElement).offsetWidth; // restart the animation
-                    nd.classList.add('ro-cell-changed');
+            Array.from(tr.children).forEach((newCell, index) => {
+                const oldCell = old.children.item(index);
+                if (
+                    oldCell &&
+                    newCell.tagName === 'TD' &&
+                    oldCell.textContent !== newCell.textContent
+                ) {
+                    newCell.classList.remove('ro-cell-changed');
+                    void (newCell as HTMLElement).offsetWidth; // restart the animation
+                    newCell.classList.add('ro-cell-changed');
                 }
-            }
+            });
         });
 }
 
@@ -453,14 +440,8 @@ export function virtMoveFocus(delta: number): boolean {
     if (list.length === 0) {
         return false;
     }
-    let current = -1;
     const focusKey = roRowState().focusedKey();
-    for (let i = 0; i < list.length; i++) {
-        if (list[i].dataset.key === focusKey) {
-            current = i;
-            break;
-        }
-    }
+    const current = list.findIndex((row) => row.dataset.key === focusKey);
     const next = clampFocusIndex(current, delta, list.length);
     virtualizeScrollToIndex(next);
     roRowState().setFocus(list[next].dataset.key as string);
@@ -535,8 +516,9 @@ window.addEventListener('resize', virtOnScroll);
 // Web-font activation can shift the line-height the row pitch was measured
 // against (engagement at DOMContentLoaded can precede the Geist swap-in);
 // re-measure once the fonts settle.
-if (document.fonts?.ready && typeof document.fonts.ready.then === 'function') {
-    document.fonts.ready.then(() => {
+const fontReady = document.fonts?.ready;
+if (fontReady && typeof fontReady.then === 'function') {
+    void fontReady.then(() => {
         if (!virtualizerActive()) {
             return;
         }

--- a/internal/assets/src/js/yaml-folds.dom.test.ts
+++ b/internal/assets/src/js/yaml-folds.dom.test.ts
@@ -12,18 +12,59 @@ function renderYaml(): HTMLElement {
         <table class="highlighttable">
             <tbody><tr>
                 <td class="linenos"><a href="#doc-line-4">4</a></td>
-                <td class="code"><pre><span id="yaml-doc-line-1"><a></a>spec:\n</span><span id="yaml-doc-line-2"><a></a>  template:\n</span><span id="yaml-doc-line-3"><a></a>    metadata:\n</span><span id="yaml-doc-line-4"><a></a>      name: api\n</span><span id="yaml-doc-line-5"><a></a>status: ready\n</span></pre></td>
+                <td class="code"><pre><span id="yaml-doc-line-1"><a></a><span>spec:</span>\n</span><span id="yaml-doc-line-2"><a></a><span>  template:</span>\n</span><span id="yaml-doc-line-3"><a></a><span>    metadata:</span>\n</span><span id="yaml-doc-line-4"><a></a><span>      name: api</span>\n</span><span id="yaml-doc-line-5"><a></a><span>status: ready</span>\n</span></pre></td>
             </tr></tbody>
         </table>
     `;
     return document.querySelector('td.code') as HTMLElement;
 }
 
-function binding(selector: string): Binding {
-    const found = foldBindings.find((item) => item.selector === selector);
+function binding(selector: string, bindings: readonly Binding[] = foldBindings): Binding {
+    const found = bindings.find((item) => item.selector === selector);
     expect(found).toBeDefined();
     return found as Binding;
 }
+
+function expectFoldBindingContract(bindings: readonly Binding[]): void {
+    expect(bindings.map(({ event, selector, stop }) => ({ event, selector, stop }))).toStrictEqual([
+        { event: 'click', selector: '[data-ro-action="toggle-fold"]', stop: true },
+        { event: 'click', selector: '.linenos a', stop: true },
+    ]);
+}
+
+test('fold binding descriptors preserve their dispatcher contracts', () => {
+    expectFoldBindingContract(foldBindings);
+});
+
+test('freshly loaded bindings drive fold and gutter behavior', async () => {
+    vi.resetModules();
+    const fresh = await import('./yaml-folds.js');
+    const code = renderYaml();
+    expectFoldBindingContract(fresh.foldBindings);
+
+    fresh.buildYamlFolds();
+    const toggle = code.querySelector('[data-fold="yaml-doc-line-2"]') as HTMLButtonElement;
+    const foldEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+
+    expect(
+        binding('[data-ro-action="toggle-fold"]', fresh.foldBindings).handler(foldEvent, toggle),
+    ).toBe(true);
+    expect(foldEvent.defaultPrevented).toBe(true);
+    expect(foldEvent.cancelBubble).toBe(true);
+    expect(document.getElementById('yaml-doc-line-3')).toHaveClass('ro-line-folded');
+    expect(document.getElementById('yaml-doc-line-4')).toHaveClass('ro-line-folded');
+
+    const target = document.getElementById('yaml-doc-line-4') as HTMLElement;
+    target.scrollIntoView = vi.fn();
+    const anchor = document.querySelector('.linenos a') as HTMLAnchorElement;
+    const gutterEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+
+    expect(binding('.linenos a', fresh.foldBindings).handler(gutterEvent, anchor)).toBe(true);
+    expect(window.location.hash).toBe('#doc-line-4');
+    expect(target).toHaveClass('yaml-line-highlight');
+    expect(target.scrollIntoView).toHaveBeenCalledExactlyOnceWith({ block: 'center' });
+    expect(gutterEvent.defaultPrevented).toBe(true);
+});
 
 describe('YAML fold builder', () => {
     beforeEach(() => {
@@ -35,10 +76,20 @@ describe('YAML fold builder', () => {
 
         const toggles = document.querySelectorAll('[data-ro-action="toggle-fold"]');
         expect(toggles).toHaveLength(3);
+        expect(toggles[0]).toHaveAttribute('type', 'button');
+        expect(toggles[0]).toHaveClass('ro-fold-toggle');
         expect(toggles[0]).toHaveAttribute('data-fold', 'yaml-doc-line-1');
-        expect(toggles[0].parentElement).toHaveTextContent('… 3 lines');
-        expect(toggles[1].parentElement).toHaveTextContent('… 2 lines');
-        expect(toggles[2].parentElement).toHaveTextContent('… 1 line');
+        expect(toggles[0]).toHaveAttribute('aria-expanded', 'true');
+        expect(toggles[0]).toHaveAttribute('aria-label', 'Toggle block');
+
+        const notes = document.querySelectorAll('[data-ro-fold-control="note"]');
+        expect(notes).toHaveLength(3);
+        expect(notes[0]).toHaveClass('ro-fold-note');
+        expect(notes[0].textContent).toBe(' … 3 lines');
+        expect(notes[1].textContent).toBe(' … 2 lines');
+        expect(notes[2].textContent).toBe(' … 1 line');
+        expect(notes[0].nextSibling).toBeInstanceOf(Text);
+        expect((notes[0].nextSibling as Text).data).toBe('\n');
         expect(document.getElementById('yaml-doc-line-4')).toHaveAttribute(
             'data-fold-of',
             'yaml-doc-line-1 yaml-doc-line-2 yaml-doc-line-3',
@@ -94,6 +145,27 @@ describe('YAML fold builder', () => {
         expect(yamlCodeText(code)).not.toContain('…');
     });
 
+    test('reads a large control-free code cell without cloning or cleaning a copy', () => {
+        const code = document.createElement('div');
+        const expected = Array.from(
+            { length: 2_048 },
+            (_, index) => `key-${index}: value-${index}\n`,
+        );
+        const fragment = document.createDocumentFragment();
+        expected.forEach((text) => {
+            const line = document.createElement('span');
+            line.textContent = text;
+            fragment.append(line);
+        });
+        code.append(fragment);
+        const cloneNode = vi.spyOn(code, 'cloneNode');
+        const querySelectorAll = vi.spyOn(code, 'querySelectorAll');
+
+        expect(yamlCodeText(code)).toBe(expected.join(''));
+        expect(cloneNode).not.toHaveBeenCalled();
+        expect(querySelectorAll).not.toHaveBeenCalled();
+    });
+
     test('marks a short block processed without injecting meaningless controls', () => {
         document.body.innerHTML = `
             <table class="highlighttable"><tbody><tr><td class="code"><pre>
@@ -106,6 +178,71 @@ describe('YAML fold builder', () => {
 
         expect(document.querySelector('pre')).toHaveAttribute('data-ro-folds', '1');
         expect(document.querySelector('[data-ro-action="toggle-fold"]')).not.toBeInTheDocument();
+    });
+
+    test('three-line blocks fold with no anchor or with an anchor-only opener', () => {
+        document.body.innerHTML = `
+            <table class="highlighttable"><tbody><tr><td class="code"><pre><span id="yaml-no-anchor-line-1"><span>root:</span>\n</span><span id="yaml-no-anchor-line-2">  child:\n</span><span id="yaml-no-anchor-line-3">    leaf: yes\n</span></pre></td></tr></tbody></table>
+            <table class="highlighttable"><tbody><tr><td class="code"><pre><span id="yaml-anchor-line-1"><a>root:</a></span><span id="yaml-anchor-line-2">  child: yes\n</span><span id="yaml-anchor-line-3">done: yes\n</span></pre></td></tr></tbody></table>
+            <table class="highlighttable"><tbody><tr><td class="code"><pre><span id="yaml-text-line-1"><a></a>root:</span><span id="yaml-text-line-2">  child: yes\n</span><span id="yaml-text-line-3">done: yes\n</span></pre></td></tr></tbody></table>
+        `;
+
+        buildYamlFolds();
+
+        expect(document.querySelectorAll('[data-ro-action="toggle-fold"]')).toHaveLength(4);
+
+        const noAnchorOpener = document.getElementById('yaml-no-anchor-line-1') as HTMLElement;
+        const noAnchorToggle = noAnchorOpener.querySelector('button') as HTMLButtonElement;
+        const noAnchorNote = noAnchorOpener.querySelector('.ro-fold-note') as HTMLElement;
+        expect(noAnchorOpener.firstElementChild).toBe(noAnchorToggle);
+        expect(noAnchorNote.textContent).toBe(' … 2 lines');
+        expect(noAnchorNote.nextSibling).toBeInstanceOf(Text);
+        expect((noAnchorNote.nextSibling as Text).data).toBe('\n');
+
+        const anchorOpener = document.getElementById('yaml-anchor-line-1') as HTMLElement;
+        const anchorToggle = anchorOpener.querySelector('button') as HTMLButtonElement;
+        const anchorNote = anchorOpener.querySelector('.ro-fold-note') as HTMLElement;
+        expect(anchorToggle.previousElementSibling?.tagName).toBe('A');
+        expect(anchorNote).toBe(anchorOpener.lastChild);
+        expect(anchorNote.textContent).toBe(' … 1 line');
+
+        const textOpener = document.getElementById('yaml-text-line-1') as HTMLElement;
+        const textNote = textOpener.querySelector('.ro-fold-note') as HTMLElement;
+        expect(textNote).toBe(textOpener.lastChild);
+        expect(textNote.previousSibling).toBeInstanceOf(Text);
+        expect((textNote.previousSibling as Text).data).toBe('root:');
+    });
+
+    test('blank lines neither end a block nor count as folded children', () => {
+        document.body.innerHTML = `
+            <table class="highlighttable"><tbody><tr><td class="code"><pre><span id="yaml-blank-line-1">root:\n</span><span id="yaml-blank-line-2">  \n</span><span id="yaml-blank-line-3">    child: yes\n</span><span id="yaml-blank-line-4">\n</span><span id="yaml-blank-line-5">sibling: yes\n</span></pre></td></tr></tbody></table>
+        `;
+
+        buildYamlFolds();
+
+        expect(document.querySelectorAll('[data-ro-action="toggle-fold"]')).toHaveLength(1);
+        expect(document.querySelector('.ro-fold-note')?.textContent).toBe(' … 1 line');
+        expect(document.getElementById('yaml-blank-line-3')).toHaveAttribute(
+            'data-fold-of',
+            'yaml-blank-line-1',
+        );
+        expect(document.getElementById('yaml-blank-line-2')).not.toHaveAttribute('data-fold-of');
+        expect(document.getElementById('yaml-blank-line-4')).not.toHaveAttribute('data-fold-of');
+        expect(document.getElementById('yaml-blank-line-5')).not.toHaveAttribute('data-fold-of');
+    });
+
+    test('a blank tail has no next line and an equal-indent neighbor is not a body', () => {
+        document.body.innerHTML = `
+            <table class="highlighttable"><tbody><tr><td class="code"><pre><span id="yaml-tail-line-1">root:\n</span><span id="yaml-tail-line-2">  child: yes\n</span><span id="yaml-tail-line-3">  \n</span></pre></td></tr></tbody></table>
+            <table class="highlighttable"><tbody><tr><td class="code"><pre><span id="yaml-equal-line-1">first: yes\n</span><span id="yaml-equal-line-2">second: yes\n</span><span id="yaml-equal-line-3">third: yes\n</span></pre></td></tr></tbody></table>
+        `;
+
+        buildYamlFolds();
+
+        expect(document.querySelectorAll('[data-ro-action="toggle-fold"]')).toHaveLength(1);
+        expect(document.getElementById('yaml-tail-line-2')?.querySelector('button')).toBeNull();
+        expect(document.getElementById('yaml-tail-line-3')?.querySelector('button')).toBeNull();
+        expect(document.getElementById('yaml-equal-line-1')?.querySelector('button')).toBeNull();
     });
 });
 
@@ -142,7 +279,13 @@ describe('YAML line anchors', () => {
     });
 
     test('does nothing for an empty or unknown fragment', () => {
+        window.history.replaceState(null, '', '/resource');
+        const current = document.getElementById('yaml-doc-line-1') as HTMLElement;
+        current.classList.add('yaml-line-highlight');
+
         expect(() => highlightYamlLine()).not.toThrow();
+        expect(current).toHaveClass('yaml-line-highlight');
+
         window.history.replaceState(null, '', '/resource#missing-line');
         expect(() => highlightYamlLine()).not.toThrow();
         expect(document.querySelector('.yaml-line-highlight')).not.toBeInTheDocument();

--- a/internal/assets/src/js/yaml-folds.test.ts
+++ b/internal/assets/src/js/yaml-folds.test.ts
@@ -7,12 +7,14 @@
 
 import { expect, test } from 'vitest';
 
-import { yamlEffectiveIndent } from './yaml-folds.js';
+import { planYamlFolds, yamlEffectiveIndent } from './yaml-folds.js';
 
 test('plain leading spaces give the indent depth', () => {
     expect(yamlEffectiveIndent('key: value')).toBe(0);
     expect(yamlEffectiveIndent('  key: value')).toBe(2);
     expect(yamlEffectiveIndent('    nested: x')).toBe(4);
+    expect(yamlEffectiveIndent('   ')).toBe(3);
+    expect(yamlEffectiveIndent('\tkey: value')).toBe(0);
 });
 
 test('a block-sequence item counts as +2 over its space indent', () => {
@@ -36,8 +38,55 @@ test('a leading newline is stripped before counting', () => {
     expect(yamlEffectiveIndent('\n\n    deep: y')).toBe(4);
 });
 
+test('only leading newlines are stripped', () => {
+    // A later physical line must not be joined onto a space-only prefix and
+    // reinterpreted as a sequence item.
+    expect(yamlEffectiveIndent('  \n- item')).toBe(2);
+});
+
 test('a key whose value happens to start with a dash is NOT a sequence item', () => {
     // The "- " sequence rule keys off the FIRST non-space chars; "key: -1" has a
     // dash inside the value, not at the line head, so it stays at its space depth.
     expect(yamlEffectiveIndent('  replicas: -1')).toBe(2);
+});
+
+test('fold planning preserves blank-line boundaries and outer-to-inner ownership', () => {
+    const plan = planYamlFolds(
+        [0, 2, 2, 4, 0, 2, 0],
+        [false, true, false, false, true, false, false],
+    );
+
+    expect(plan).toStrictEqual({
+        bodyCounts: [3, 0, 1, 0, 0, 0, 0],
+        ownersByLine: [[], [], [0], [0, 2], [], [0], []],
+    });
+});
+
+test('fold planning reads a large flat input only linearly', () => {
+    const size = 2_048;
+    const readBudget = size * 8;
+    let indexedReads = 0;
+    const counted = <T>(values: readonly T[]): readonly T[] =>
+        new Proxy(values, {
+            get(target, property, receiver) {
+                if (typeof property === 'string' && Number.isInteger(Number(property))) {
+                    indexedReads += 1;
+                    if (indexedReads > readBudget) {
+                        throw new Error('fold planning exceeded its linear input-read budget');
+                    }
+                }
+                return Reflect.get(target, property, receiver);
+            },
+        });
+
+    const plan = planYamlFolds(
+        counted(new Array<number>(size).fill(0)),
+        counted(new Array<boolean>(size).fill(false)),
+    );
+
+    expect(plan.bodyCounts).toHaveLength(size);
+    expect(plan.ownersByLine).toHaveLength(size);
+    expect(plan.bodyCounts.every((count) => count === 0)).toBe(true);
+    expect(plan.ownersByLine.every((owners) => owners.length === 0)).toBe(true);
+    expect(indexedReads).toBeLessThanOrEqual(readBudget);
 });

--- a/internal/assets/src/js/yaml-folds.ts
+++ b/internal/assets/src/js/yaml-folds.ts
@@ -35,31 +35,66 @@ import type { Binding } from './events.js';
 // exactly as the object structure does. Exported for Vitest (pure, no DOM).
 export function yamlEffectiveIndent(text: string): number {
     const stripped = text.replace(/^\n+/, '');
-    let i = 0;
-    while (i < stripped.length && stripped[i] === ' ') {
-        i++;
-    }
-    const rest = stripped.slice(i);
+    const indent = stripped.length - stripped.replace(/^ +/, '').length;
+    const rest = stripped.slice(indent);
     if (rest === '-' || rest.startsWith('- ') || rest.startsWith('-\t')) {
-        return i + 2;
+        return indent + 2;
     }
-    return i;
+    return indent;
+}
+
+// Plan fold ownership in one forward pass. The active stack contains only
+// openers whose bodies include the current non-blank line, ordered outermost
+// first. Stack pops are amortized O(lines), while emitting owners costs exactly
+// the ownership relationships the DOM pass must materialize.
+export function planYamlFolds(
+    indents: readonly number[],
+    isBlank: readonly boolean[],
+): { bodyCounts: number[]; ownersByLine: number[][] } {
+    const bodyCounts = new Array<number>(indents.length).fill(0);
+    const ownersByLine = Array.from({ length: indents.length }, () => [] as number[]);
+    const active: Array<{ index: number; indent: number }> = [];
+    let previous: { index: number; indent: number } | undefined;
+
+    indents.forEach((indent, index) => {
+        if (isBlank[index]) {
+            return;
+        }
+
+        // Active indents are strictly increasing. Finding the first closed
+        // owner scans only owners retained for this line plus, at most, the
+        // first one removed; splice work across the whole pass is linear.
+        const firstClosed = active.findIndex((owner) => owner.indent >= indent);
+        if (firstClosed !== -1) {
+            active.splice(firstClosed);
+        }
+        if (previous && previous.indent < indent) {
+            active.push(previous);
+        }
+        active.forEach((owner) => {
+            ownersByLine[index].push(owner.index);
+            bodyCounts[owner.index] += 1;
+        });
+
+        previous = { index, indent };
+    });
+
+    return { bodyCounts, ownersByLine };
 }
 
 // The raw YAML text of a Pygments `td.code` cell, with any injected fold
 // controls removed. Folded child lines stay in the DOM (only hidden), so this is
 // the FULL source YAML in any fold state -- the per-section copy stays correct.
 export function yamlCodeText(codeCell: Element): string {
-    if (!codeCell.querySelector('[data-ro-action="toggle-fold"], [data-ro-fold-control]')) {
-        return codeCell.textContent || ''; // no folds injected -> raw text already clean
+    const controlSelector = '[data-ro-action="toggle-fold"], [data-ro-fold-control]';
+    if (!codeCell.querySelector(controlSelector)) {
+        return codeCell.textContent as string;
     }
     const clone = codeCell.cloneNode(true) as Element;
-    clone
-        .querySelectorAll('[data-ro-action="toggle-fold"], [data-ro-fold-control]')
-        .forEach((el) => {
-            el.remove();
-        });
-    return clone.textContent || '';
+    clone.querySelectorAll(controlSelector).forEach((el) => {
+        el.remove();
+    });
+    return clone.textContent as string;
 }
 
 // Toggle one nested block: flip the opener's `is-folded` + aria-expanded and
@@ -77,7 +112,7 @@ function toggleYamlFold(toggle: HTMLElement): void {
     toggle.classList.toggle('is-folded', folded);
     toggle.setAttribute('aria-expanded', folded ? 'false' : 'true');
     pre.querySelectorAll('[data-fold-of]').forEach((line) => {
-        const owners = ((line as HTMLElement).dataset.foldOf || '').split(' ');
+        const owners = ((line as HTMLElement).dataset.foldOf as string).split(' ');
         if (owners.indexOf(id) !== -1) {
             line.classList.toggle('ro-line-folded', folded);
         }
@@ -119,7 +154,7 @@ function injectFoldControls(lineSpan: Element, bodyCount: number): void {
     // Append the note at the very end of the line content, BEFORE the trailing
     // newline text node so the collapsed note renders on the opener's own line.
     const last = lineSpan.lastChild;
-    if (last && last.nodeType === 3 && (last.textContent || '').indexOf('\n') !== -1) {
+    if (last?.nodeType === Node.TEXT_NODE && (last as Text).data.includes('\n')) {
         lineSpan.insertBefore(note, last);
     } else {
         lineSpan.appendChild(note);
@@ -147,45 +182,25 @@ export function buildYamlFolds(): void {
             if (lines.length < 3) {
                 return; // too small to have a meaningful nested block
             }
-            const indents = lines.map((el) => yamlEffectiveIndent(el.textContent || ''));
-            const isBlank = lines.map((el) => (el.textContent || '').trim() === '');
+            const texts = lines.map((line) => line.textContent as string);
+            const indents = texts.map(yamlEffectiveIndent);
+            const isBlank = texts.map((text) => text.trim() === '');
+            const { bodyCounts, ownersByLine } = planYamlFolds(indents, isBlank);
 
-            for (let i = 0; i < lines.length; i++) {
-                if (isBlank[i]) {
-                    continue;
+            lines.forEach((line, index) => {
+                const owners = ownersByLine[index];
+                if (owners.length === 0) {
+                    return;
                 }
-                // next non-blank line
-                let j = i + 1;
-                while (j < lines.length && isBlank[j]) {
-                    j++;
+                const element = line as HTMLElement;
+                const ownerIds = owners.map((owner) => lines[owner].id).join(' ');
+                element.dataset.foldOf = ownerIds;
+            });
+            lines.forEach((line, index) => {
+                if (bodyCounts[index] > 0) {
+                    injectFoldControls(line, bodyCounts[index]);
                 }
-                if (j >= lines.length || indents[j] <= indents[i]) {
-                    continue; // not an opener (no deeper-indented body follows)
-                }
-                // body = contiguous following lines indented deeper than the opener
-                let end = i + 1;
-                let bodyCount = 0;
-                while (end < lines.length) {
-                    if (isBlank[end]) {
-                        end++;
-                        continue;
-                    }
-                    if (indents[end] > indents[i]) {
-                        const cur = lines[end] as HTMLElement;
-                        cur.dataset.foldOf = cur.dataset.foldOf
-                            ? `${cur.dataset.foldOf} ${lines[i].id}`
-                            : lines[i].id;
-                        bodyCount++;
-                        end++;
-                    } else {
-                        break;
-                    }
-                }
-                if (bodyCount === 0) {
-                    continue;
-                }
-                injectFoldControls(lines[i], bodyCount);
-            }
+            });
         } catch (_e) {
             // Anything unexpected -> leave this block plainly highlighted (the
             // accepted graceful fallback). The cell is already marked, so we do

--- a/internal/assets/static/readout.js
+++ b/internal/assets/static/readout.js
@@ -6,23 +6,31 @@
   }
 
   // internal/assets/src/js/filters-parse.ts
+  var goFieldWhitespaceRun = /\p{White_Space}+/gu;
+  var goFieldWhitespaceEdges = /^\p{White_Space}+|\p{White_Space}+$/gu;
+  function trimFilterWhitespace(s) {
+    return (s || "").replace(goFieldWhitespaceEdges, "");
+  }
+  function normalizeFieldWhitespace(s) {
+    return trimFilterWhitespace((s || "").replace(goFieldWhitespaceRun, " "));
+  }
   function normalizeFieldName(s) {
-    return (s || "").toLowerCase().replace(/-/g, " ").trim();
+    return normalizeFieldWhitespace((s || "").toLowerCase().replace(/-/g, " "));
   }
   function fieldSuggestionText(label) {
-    return (label || "").toLowerCase().trim().replace(/\s+/g, "-");
+    return normalizeFieldName(label).replace(/ /g, "-");
   }
   function splitFilterDraft(s) {
-    for (let i = 0; i < s.length; i++) {
-      const c = s[i];
-      if (c === "!" && s[i + 1] === "=") {
-        return { field: s.slice(0, i).trim(), op: "!=", value: s.slice(i + 2) };
-      }
-      if (c === ":" || c === ">" || c === "<") {
-        return { field: s.slice(0, i).trim(), op: c, value: s.slice(i + 1) };
-      }
+    const operator = /!=|[:<>]/.exec(s);
+    if (!operator) {
+      return null;
     }
-    return null;
+    const op = operator[0];
+    return {
+      field: trimFilterWhitespace(s.slice(0, operator.index)),
+      op,
+      value: s.slice(operator.index + op.length)
+    };
   }
   function hasModelColumn(fields, normName) {
     return fields.some((f) => !!f.hint && normalizeFieldName(f.label) === normName);
@@ -76,15 +84,14 @@
   }
   function rankFieldSuggestions(fields, draft) {
     const q = normalizeFieldName(draft);
-    const matched = filterSuggestionFields(fields).filter(
-      (f) => normalizeFieldName(f.text).indexOf(q) !== -1
-    );
-    matched.sort((a, b) => {
-      const ap = normalizeFieldName(a.text).indexOf(q) === 0 ? 0 : 1;
-      const bp = normalizeFieldName(b.text).indexOf(q) === 0 ? 0 : 1;
-      return ap - bp;
+    const ranked = [[], []];
+    filterSuggestionFields(fields).forEach((field) => {
+      const matchAt = normalizeFieldName(field.text).indexOf(q);
+      if (matchAt >= 0) {
+        ranked[matchAt === 0 ? 0 : 1].push(field);
+      }
     });
-    return matched.map((f) => ({
+    return [...ranked[0], ...ranked[1]].map((f) => ({
       label: f.text,
       hint: f.hint,
       insert: `${f.text}:`,
@@ -103,21 +110,20 @@
         freq.set(v, (freq.get(v) || 0) + 1);
       }
     });
-    const typed = split.value.trim().toLowerCase();
-    let entries = Array.from(freq.entries());
-    if (typed) {
-      entries = entries.filter(([v]) => v.toLowerCase().indexOf(typed) !== -1);
-    }
+    const typed = trimFilterWhitespace(split.value).toLowerCase();
+    const entries = Array.from(freq.entries()).filter(
+      ([v]) => v.toLowerCase().indexOf(typed) !== -1
+    );
     entries.sort((a, b) => b[1] - a[1]);
     return entries.slice(0, 8).map(([v, n]) => ({
       label: v,
       hint: `×${n}`,
-      insert: `${split.field.trim()}:${v}`,
+      insert: `${trimFilterWhitespace(split.field)}:${v}`,
       kind: "value"
     }));
   }
   function liveNameMatchKeys(rows, draft) {
-    const text = !draft || splitFilterDraft(draft) ? "" : draft.trim().toLowerCase();
+    const text = !draft || splitFilterDraft(draft) ? "" : trimFilterWhitespace(draft).toLowerCase();
     if (!text) {
       return null;
     }
@@ -148,14 +154,12 @@
     return mode === "Live" ? liveFallbackSeconds2 : 0;
   }
   function refreshDelaySeconds(effectiveSeconds, failureStage) {
-    if (effectiveSeconds <= 0) {
-      return 0;
-    }
+    const baseSeconds = Math.max(effectiveSeconds, 0);
     if (failureStage <= 1) {
-      return effectiveSeconds;
+      return baseSeconds;
     }
     const factor = failureStage === 2 ? 2 : 4;
-    return Math.min(effectiveSeconds * factor, 60);
+    return Math.min(baseSeconds * factor, 60);
   }
   function nextFailureStage(stage) {
     return Math.min(stage + 1, 3);
@@ -222,9 +226,10 @@
       content.classList.add(STALE_DIM_CLASS);
     }
     const banner = document.querySelector(".ro-stale-banner");
-    if (banner) {
-      banner.hidden = false;
+    if (!banner) {
+      return;
     }
+    banner.hidden = false;
     if (staleCountdownId === null) {
       staleCountdownId = window.setInterval(updateStaleCountdown, 1e3);
     }
@@ -271,7 +276,6 @@
     streamPath: ""
     // the stream URL sans ?g= -- the page/params identity
   };
-  var liveGenSeq = 0;
   var liveDiscards = 0;
   var liveFallbackSecs = 0;
   function liveFallbackSeconds() {
@@ -296,10 +300,7 @@
     liveState.abort = null;
     liveFallbackSecs = 0;
     if (ctrl) {
-      try {
-        ctrl.abort();
-      } catch {
-      }
+      ctrl.abort();
     }
   }
   function liveEngageFallback(banner) {
@@ -313,18 +314,17 @@
   }
   function liveOpen(base) {
     liveTeardown();
-    liveFallbackSecs = 0;
     liveState.streamPath = base;
     if (!base) {
       liveEngageFallback(false);
       return;
     }
     liveState.status = "connecting";
-    liveGenSeq += 1;
-    liveState.gen = `${Date.now().toString(36)}.${liveGenSeq}`;
+    liveState.gen = window.crypto.getRandomValues(new Uint32Array(4)).toString();
     const ctrl = new AbortController();
     liveState.abort = ctrl;
-    const url = `${base + (base.indexOf("?") === -1 ? "?" : "&")}g=${encodeURIComponent(liveState.gen)}`;
+    const separator = base.includes("?") ? "&" : "?";
+    const url = `${base}${separator}g=${liveState.gen}`;
     scheduleRefreshTick();
     void liveConnect(url, ctrl);
   }
@@ -347,47 +347,43 @@
     const reader = res.body.getReader();
     const decoder = new TextDecoder();
     let buffered = "";
-    let eventName = "";
-    let dataText = "";
-    try {
-      for (; ; ) {
-        const chunk = await reader.read();
-        if (liveState.abort !== ctrl) {
-          return;
-        }
-        if (chunk.done) {
-          break;
-        }
-        buffered += decoder.decode(chunk.value, { stream: true });
-        let nl = buffered.indexOf("\n");
-        while (nl !== -1) {
-          const line = buffered.slice(0, nl).replace(/\r$/, "");
-          buffered = buffered.slice(nl + 1);
-          if (line === "") {
-            const ended = liveHandleFrame(eventName, dataText, ctrl);
-            eventName = "";
-            dataText = "";
-            if (ended || liveState.abort !== ctrl) {
-              return;
-            }
-          } else if (line.indexOf("event:") === 0) {
-            eventName = line.slice(6).trim();
-          } else if (line.indexOf("data:") === 0) {
-            const piece = line.slice(5).replace(/^ /, "");
-            dataText = dataText === "" ? piece : `${dataText}
-${piece}`;
+    let eventName = null;
+    let dataLines = [];
+    const readAndHandleChunk = async () => {
+      const chunk = await reader.read();
+      if (liveState.abort !== ctrl) {
+        return;
+      }
+      const value = chunk.value;
+      buffered += decoder.decode(value.subarray(), { stream: true });
+      const completeLines = buffered.split("\n");
+      buffered = completeLines.pop();
+      for (const rawLine of completeLines) {
+        const line = rawLine === "\r" ? "" : rawLine;
+        if (line.length === 0) {
+          liveHandleFrame(eventName, dataLines.join("\n"));
+          eventName = null;
+          dataLines = [];
+          if (liveState.abort !== ctrl) {
+            return;
           }
-          nl = buffered.indexOf("\n");
+        } else if (line.startsWith("event:")) {
+          eventName = line.slice(6).trim();
+        } else if (line.startsWith("data:")) {
+          dataLines.push(line.slice(5));
         }
       }
+      return value;
+    };
+    try {
+      while (await readAndHandleChunk()) {
+      }
     } catch {
-      applyClose({ superseded: liveState.abort !== ctrl, cause: "read-error" });
-      return;
     }
     if (liveState.abort !== ctrl) {
       return;
     }
-    applyClose({ superseded: false, cause: "eof" });
+    liveEngageFallback(true);
   }
   function applyClose(facts) {
     const action = classifyStreamClose(facts);
@@ -396,41 +392,44 @@ ${piece}`;
     }
     liveEngageFallback(action.banner);
   }
-  function liveHandleFrame(name, text, ctrl) {
-    if (liveState.abort !== ctrl || text === "") {
-      return false;
-    }
-    let payload = null;
+  function liveHandleFrame(name, text) {
+    let parsed;
     try {
-      payload = JSON.parse(text);
+      parsed = JSON.parse(text);
     } catch {
-      return false;
     }
-    if (!payload || typeof payload !== "object") {
-      return false;
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return;
     }
+    const payload = parsed;
     if (name === "ro-terminal") {
       applyClose({ superseded: false, cause: "terminal-frame" });
-      return true;
+      return;
     }
     if (name !== "ro-table") {
-      return false;
+      return;
+    }
+    if (typeof payload.g !== "string" || typeof payload.html !== "string") {
+      return;
     }
     pruneSettledListRequests(userListRequestsInFlight);
     pruneSettledListRequests(containerListRequestsInFlight);
     const reason = shouldDiscardPush({
-      frameGeneration: String(payload.g),
+      frameGeneration: payload.g,
       currentGeneration: liveState.gen,
-      liveStreamBase: liveStreamBase(),
+      // The Go bundle contract pins the literal page comparison below. Feed
+      // equal page identities here so the policy supplies the first and third
+      // ordered gates (generation, then request); the literal supplies the
+      // page gate between them without evaluating it twice.
+      liveStreamBase: liveState.streamPath,
       openedStreamBase: liveState.streamPath,
       requestInFlight: userListRequestsInFlight.size > 0 || containerListRequestsInFlight.size > 0
     });
-    if (reason !== "none" || liveStreamBase() !== liveState.streamPath) {
+    if (reason === "stale-generation" || liveStreamBase() !== liveState.streamPath || reason === "request-in-flight") {
       liveDiscards += 1;
-      return false;
+      return;
     }
-    liveMorph(String(payload.html));
-    return false;
+    liveMorph(payload.html);
   }
   function liveMorph(html) {
     const content = document.getElementById("resource-list-content");
@@ -457,21 +456,22 @@ ${piece}`;
       return;
     }
     let base = liveStreamBase();
-    const pathInfo = detail?.pathInfo;
-    const requestPath = pathInfo && (pathInfo.finalRequestPath || pathInfo.requestPath);
-    if (requestPath && requestPath.indexOf("/_table") !== -1) {
-      base = requestPath.replace("/_table", "/_stream");
+    const requestPath = detail?.pathInfo?.finalRequestPath || detail?.pathInfo?.requestPath;
+    if (typeof requestPath === "string") {
+      const queryStart = requestPath.indexOf("?");
+      const pathname = queryStart === -1 ? requestPath : requestPath.slice(0, queryStart);
+      if (pathname.endsWith("/_table")) {
+        const query = queryStart === -1 ? "" : requestPath.slice(queryStart);
+        base = `${pathname.slice(0, -"/_table".length)}/_stream${query}`;
+      }
     }
     liveOpen(base);
   }
   function liveApply(force) {
     if (refreshMode() !== "Live") {
-      if (liveState.status !== "idle") {
-        liveTeardown();
-        liveState.status = "idle";
-        liveState.streamPath = "";
-        liveFallbackSecs = 0;
-      }
+      liveTeardown();
+      liveState.status = "idle";
+      liveState.streamPath = "";
       return;
     }
     const base = liveSupported() ? liveStreamBase() : "";
@@ -506,39 +506,68 @@ ${piece}`;
   var REFRESH_KEY = "roRefresh";
   function b64urlEncodeUTF8(text) {
     const bytes = new TextEncoder().encode(text);
-    let bin = "";
-    for (let i = 0; i < bytes.length; i++) {
-      bin += String.fromCharCode(bytes[i]);
-    }
-    return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    const bin = Array.from(bytes, (byte) => String.fromCharCode(byte)).join("");
+    return btoa(bin).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
   }
   function b64urlDecodeUTF8(encoded) {
-    const b64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
-    const bin = atob(b64 + "====".slice(b64.length % 4 || 4));
-    const bytes = new Uint8Array(bin.length);
-    for (let i = 0; i < bin.length; i++) {
-      bytes[i] = bin.charCodeAt(i);
+    const compact = encoded.replaceAll("\r", "").replaceAll("\n", "");
+    if (!/^[A-Za-z0-9_-]*$/.test(compact)) {
+      throw new TypeError();
     }
-    return new TextDecoder().decode(bytes);
+    const b64 = compact.replaceAll("-", "+").replaceAll("_", "/");
+    const bin = atob(b64);
+    const bytes = Uint8Array.from(bin, (char) => char.charCodeAt(0));
+    return new TextDecoder("utf-8", { ignoreBOM: true }).decode(bytes);
+  }
+  function isRecord(value) {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+  }
+  function setOwnNamespace(ns, cluster, namespace) {
+    Object.defineProperty(ns, cluster, {
+      value: namespace,
+      enumerable: true,
+      configurable: true,
+      writable: true
+    });
+  }
+  function compareUTF8(left, right) {
+    const mismatch = left.subarray(0, right.length).findIndex((byte, index) => byte !== right[index]);
+    if (mismatch !== -1) {
+      return left[mismatch] - right[mismatch];
+    }
+    return left.length - right.length;
+  }
+  function stringifyPrefsJSON(value) {
+    const encoded = JSON.stringify(value);
+    return encoded.replaceAll("\u2028", "\\u2028").replaceAll("\u2029", "\\u2029");
+  }
+  function canonicalNamespaceJSON(ns) {
+    const encoder = new TextEncoder();
+    const entries = Object.entries(ns).map(([cluster, namespace]) => ({
+      cluster,
+      namespace,
+      encodedCluster: encoder.encode(cluster)
+    }));
+    entries.sort((left, right) => compareUTF8(left.encodedCluster, right.encodedCluster));
+    return `{${entries.map(
+      ({ cluster, namespace }) => `${stringifyPrefsJSON(cluster)}:${stringifyPrefsJSON(namespace)}`
+    ).join(",")}}`;
   }
   function decodePrefsValue(value) {
     const empty = { kinds: [], refresh: "", ns: {} };
-    if (value?.indexOf(PREFS_VERSION_PREFIX) !== 0) {
+    if (!value?.startsWith(PREFS_VERSION_PREFIX)) {
       return { prefs: empty, ok: false };
     }
     const payload = value.slice(PREFS_VERSION_PREFIX.length);
-    if (!payload) {
-      return { prefs: empty, ok: false };
-    }
     try {
       const decoded = JSON.parse(b64urlDecodeUTF8(payload));
-      if (!decoded || typeof decoded !== "object") {
+      if (!isRecord(decoded)) {
         return { prefs: empty, ok: false };
       }
       const kinds = [];
       if (Array.isArray(decoded.kinds)) {
         decoded.kinds.forEach((raw) => {
-          if (!raw || typeof raw !== "object") {
+          if (!isRecord(raw)) {
             return;
           }
           const e = raw;
@@ -556,10 +585,10 @@ ${piece}`;
         });
       }
       const ns = {};
-      if (decoded.ns && typeof decoded.ns === "object" && !Array.isArray(decoded.ns)) {
-        Object.keys(decoded.ns).forEach((cluster) => {
-          if (typeof decoded.ns[cluster] === "string") {
-            ns[cluster] = decoded.ns[cluster];
+      if (isRecord(decoded.ns)) {
+        Object.entries(decoded.ns).forEach(([cluster, namespace]) => {
+          if (typeof namespace === "string") {
+            setOwnNamespace(ns, cluster, namespace);
           }
         });
       }
@@ -575,35 +604,38 @@ ${piece}`;
       return { prefs: empty, ok: false };
     }
   }
+  function encodePrefsCandidate(kinds, refresh, ns) {
+    const fields = [];
+    if (kinds.length > 0) {
+      fields.push(`"kinds":${stringifyPrefsJSON(kinds)}`);
+    }
+    if (refresh) {
+      fields.push(`"refresh":${stringifyPrefsJSON(refresh)}`);
+    }
+    if (Object.keys(ns).length > 0) {
+      fields.push(`"ns":${canonicalNamespaceJSON(ns)}`);
+    }
+    return PREFS_VERSION_PREFIX + b64urlEncodeUTF8(`{${fields.join(",")}}`);
+  }
   function encodePrefsValue(prefs) {
-    const out = {};
-    if (prefs.kinds && prefs.kinds.length > 0) {
-      out.kinds = prefs.kinds;
+    const kinds = prefs.kinds ?? [];
+    const refresh = prefs.refresh ?? "";
+    const ns = prefs.ns ?? {};
+    const evictionBoundary = PREFS_MAX_ENCODED + 1;
+    let value = encodePrefsCandidate(kinds, refresh, ns);
+    if (value.length < evictionBoundary) {
+      return value;
     }
-    if (prefs.refresh) {
-      out.refresh = prefs.refresh;
-    }
-    if (prefs.ns && Object.keys(prefs.ns).length > 0) {
-      out.ns = prefs.ns;
-    }
-    let value = PREFS_VERSION_PREFIX + b64urlEncodeUTF8(JSON.stringify(out));
-    while (value.length > PREFS_MAX_ENCODED && out.kinds && out.kinds.length > 0) {
-      out.kinds = out.kinds.slice(0, -1);
-      if (out.kinds.length === 0) {
-        delete out.kinds;
-      }
-      value = PREFS_VERSION_PREFIX + b64urlEncodeUTF8(JSON.stringify(out));
-    }
+    Array.from({ length: kinds.length }).some((_, evicted) => {
+      const kept = kinds.length - evicted - 1;
+      value = encodePrefsCandidate(kinds.slice(0, kept), refresh, ns);
+      return value.length < evictionBoundary;
+    });
     return value;
   }
   function prefsCookieValue() {
-    const parts = document.cookie ? document.cookie.split("; ") : [];
-    for (let i = 0; i < parts.length; i++) {
-      if (parts[i].indexOf(`${PREFS_COOKIE}=`) === 0) {
-        return parts[i].slice(PREFS_COOKIE.length + 1);
-      }
-    }
-    return "";
+    const prefix = `${PREFS_COOKIE}=`;
+    return document.cookie.split("; ").find((part) => part.startsWith(prefix))?.slice(prefix.length);
   }
   function readPrefs() {
     return decodePrefsValue(prefsCookieValue()).prefs;
@@ -619,16 +651,10 @@ ${piece}`;
     }
   }
   function prefsTouchKind(prefs, plural) {
-    for (let i = 0; i < prefs.kinds.length; i++) {
-      if (prefs.kinds[i].k === plural) {
-        const entry = prefs.kinds.splice(i, 1)[0];
-        prefs.kinds.unshift(entry);
-        return entry;
-      }
-    }
-    const fresh = { k: plural };
-    prefs.kinds.unshift(fresh);
-    return fresh;
+    const index = prefs.kinds.findIndex((entry2) => entry2.k === plural);
+    const entry = index < 0 ? { k: plural } : prefs.kinds.splice(index, 1)[0];
+    prefs.kinds.unshift(entry);
+    return entry;
   }
   function roPrefsSetSort(plural, sort) {
     const prefs = readPrefs();
@@ -637,7 +663,7 @@ ${piece}`;
   }
   function roPrefsSetHiddenColumns(plural, names) {
     const prefs = readPrefs();
-    prefsTouchKind(prefs, plural).hide = Array.isArray(names) ? names : [];
+    prefsTouchKind(prefs, plural).hide = names;
     writePrefs(prefs);
   }
   function roPrefsSetRefresh(mode) {
@@ -650,7 +676,7 @@ ${piece}`;
       return;
     }
     const prefs = readPrefs();
-    prefs.ns[cluster] = namespace;
+    setOwnNamespace(prefs.ns, cluster, namespace);
     writePrefs(prefs);
   }
 
@@ -666,6 +692,9 @@ ${piece}`;
   }
   var userListRequestsInFlight = /* @__PURE__ */ new Set();
   var containerListRequestsInFlight = /* @__PURE__ */ new Set();
+  function requestDetail(event) {
+    return Object(event.detail);
+  }
   function pruneSettledListRequests(requests) {
     requests.forEach((xhr) => {
       if (xhr.readyState === 4 || xhr.readyState === 0) {
@@ -674,35 +703,37 @@ ${piece}`;
     });
   }
   function isPreloadRequest(event) {
-    const cfg = event.detail?.requestConfig;
-    return !!cfg && !!cfg.headers && cfg.headers["HX-Preloaded"] === "true";
+    const config = Object(requestDetail(event).requestConfig);
+    const headers = Object(config.headers);
+    return headers["HX-Preloaded"] === "true";
   }
   function isUserListRequest(event) {
-    const detail = event.detail;
-    if (!detail?.elt || !detail.target) {
-      return false;
-    }
-    if (detail.elt.id === "resource-list-content") {
-      return false;
-    }
-    return detail.target.id === "resource-list-content" && !isPreloadRequest(event);
+    const detail = requestDetail(event);
+    return detail.elt instanceof Element && detail.target instanceof Element && detail.target.id === "resource-list-content" && !isPreloadRequest(event);
   }
-  document.addEventListener("htmx:configRequest", (event) => {
-    const elt = event.detail?.elt;
-    if (elt && elt.id === "resource-list-content") {
-      event.detail.headers["RO-No-Push"] = "true";
+  function handleRefreshConfigRequest(event) {
+    const detail = requestDetail(event);
+    const elt = Object(detail.elt);
+    if (elt.id !== "resource-list-content") {
+      return;
     }
-  });
-  document.addEventListener("htmx:beforeRequest", (event) => {
-    const detail = event.detail;
-    if (detail?.xhr && detail.elt && detail.elt.id === "resource-list-content") {
-      containerListRequestsInFlight.add(detail.xhr);
+    const headers = Object(detail.headers);
+    headers["RO-No-Push"] = "true";
+  }
+  document.addEventListener("htmx:configRequest", handleRefreshConfigRequest);
+  function handleRefreshBeforeRequest(event) {
+    const detail = requestDetail(event);
+    const elt = Object(detail.elt);
+    if (elt.id === "resource-list-content") {
+      if (detail.xhr) {
+        containerListRequestsInFlight.add(detail.xhr);
+      }
       return;
     }
     if (!isUserListRequest(event)) {
       return;
     }
-    if (detail?.xhr) {
+    if (detail.xhr) {
       userListRequestsInFlight.add(detail.xhr);
     }
     const content = document.getElementById("resource-list-content");
@@ -710,14 +741,25 @@ ${piece}`;
     if (content && htmx2) {
       htmx2.trigger(content, "htmx:abort");
     }
-  });
-  document.addEventListener("htmx:afterRequest", (event) => {
-    const xhr = event.detail?.xhr;
-    if (xhr) {
-      userListRequestsInFlight.delete(xhr);
-      containerListRequestsInFlight.delete(xhr);
+  }
+  document.addEventListener("htmx:beforeRequest", handleRefreshBeforeRequest);
+  function handleRefreshAfterRequest(event) {
+    const xhr = requestDetail(event).xhr;
+    userListRequestsInFlight.delete(xhr);
+    containerListRequestsInFlight.delete(xhr);
+  }
+  document.addEventListener("htmx:afterRequest", handleRefreshAfterRequest);
+  function parseRefreshSeconds(mode) {
+    if (typeof mode !== "string") {
+      return 0;
     }
-  });
+    const unsigned = mode.startsWith("+") ? mode.slice(1) : mode;
+    const seconds = Array.from(unsigned).reduce((value, char) => {
+      const digit = char.charCodeAt(0) - 48;
+      return digit >= 0 && digit <= 9 ? value * 10 + digit : Number.NaN;
+    }, 0);
+    return Number.isSafeInteger(seconds) ? seconds : 0;
+  }
   function refreshMode() {
     const stored = readPrefs().refresh;
     if (stored) {
@@ -727,19 +769,14 @@ ${piece}`;
     try {
       legacy = window.localStorage.getItem(REFRESH_KEY);
     } catch {
+    }
+    if (!legacy) {
       return "";
     }
-    if (legacy === null || legacy === "") {
-      return "";
-    }
-    const secs = parseInt(legacy, 10) || 0;
+    const secs = parseRefreshSeconds(legacy);
     const mode = secs > 0 ? String(secs) : "Off";
     roPrefsSetRefresh(mode);
     return mode;
-  }
-  function refreshInterval() {
-    const secs = parseInt(refreshMode(), 10);
-    return Number.isFinite(secs) && secs > 0 ? secs : 0;
   }
   function listTableURL() {
     const u = new URL(window.location.href);
@@ -777,7 +814,8 @@ ${piece}`;
     requestListRefresh();
   }
   function effectivePollSeconds2() {
-    return effectivePollSeconds(refreshMode(), refreshInterval(), liveFallbackSeconds());
+    const mode = refreshMode();
+    return effectivePollSeconds(mode, parseRefreshSeconds(mode), liveFallbackSeconds());
   }
   function refreshDelaySeconds2() {
     return refreshDelaySeconds(effectivePollSeconds2(), refreshFailureStage);
@@ -793,12 +831,13 @@ ${piece}`;
       updateStaleCountdown();
       return;
     }
-    refreshNextAt = Date.now() + delay * 1e3;
+    const delayMs = delay * 1e3;
+    refreshNextAt = Date.now() + delayMs;
     refreshTimerId = window.setTimeout(() => {
       refreshTimerId = null;
       scheduleRefreshTick();
       fireRefresh();
-    }, delay * 1e3);
+    }, delayMs);
     updateStaleCountdown();
   }
   function applyRefresh() {
@@ -806,17 +845,24 @@ ${piece}`;
     scheduleRefreshTick();
   }
   function syncRefreshUI() {
-    const live = refreshMode() === "Live";
-    const secs = refreshInterval();
+    const mode = refreshMode();
+    const live = mode === "Live";
+    const secs = parseRefreshSeconds(mode);
     const label = document.getElementById("refresh-label");
     if (label) {
-      label.textContent = live ? "Live" : secs > 0 ? `${secs}s` : "Off";
+      if (live) {
+        label.textContent = "Live";
+      } else if (secs > 0) {
+        label.textContent = `${secs}s`;
+      } else {
+        label.textContent = "Off";
+      }
     }
     document.querySelectorAll('[data-ro-action="set-refresh"]').forEach((opt) => {
-      const value = opt.dataset.roInterval ?? "";
+      const value = opt.dataset.roInterval;
       opt.classList.toggle(
         "is-active",
-        live ? value === "Live" : value !== "Live" && (parseInt(value, 10) || 0) === secs
+        value !== void 0 && (live ? value === "Live" : value !== "Live" && parseRefreshSeconds(value) === secs)
       );
     });
     const dropdown = document.getElementById("refresh-dropdown");
@@ -839,11 +885,12 @@ ${piece}`;
       toast("Refresh resumed");
     }
   }
-  document.addEventListener("visibilitychange", () => {
+  function handleRefreshVisibilityChange() {
     if (!document.hidden && effectivePollSeconds2() > 0) {
       fireRefresh();
     }
-  });
+  }
+  document.addEventListener("visibilitychange", handleRefreshVisibilityChange);
   var refreshBindings = [
     // Stale-banner retry: re-fire the (read-only) auto-refresh GET on
     // #resource-list-content through the shared refresh path (the v2 loop derives
@@ -889,7 +936,7 @@ ${piece}`;
         if (option.dataset.roInterval === "Live") {
           roPrefsSetRefresh("Live");
         } else {
-          const interval = parseInt(option.dataset.roInterval ?? "", 10) || 0;
+          const interval = parseRefreshSeconds(option.dataset.roInterval);
           roPrefsSetRefresh(interval > 0 ? String(interval) : "Off");
         }
         liveApply(true);
@@ -985,7 +1032,7 @@ ${piece}`;
     }
   };
   var BULK_NAMES_MAX = 100;
-  var bulkOverCapToasted = false;
+  var bulkOverCapToasted;
   function updateBulkBar() {
     const bar = document.getElementById("ro-bulkbar");
     if (!bar) {
@@ -993,7 +1040,7 @@ ${piece}`;
     }
     const count = rowSelection.size;
     const label = document.getElementById("ro-bulk-count");
-    if (label && count > 0) {
+    if (label) {
       label.textContent = `${count} selected`;
     }
     bar.classList.toggle("is-open", count > 0);
@@ -1019,19 +1066,18 @@ ${piece}`;
     const fallback = () => {
       const ta = document.createElement("textarea");
       ta.value = text;
-      ta.setAttribute("readonly", "");
+      ta.readOnly = true;
       ta.style.position = "fixed";
       ta.style.top = "-1000px";
       document.body.appendChild(ta);
-      ta.select();
-      let ok = false;
       try {
-        ok = document.execCommand("copy");
+        ta.select();
+        return document.execCommand("copy");
       } catch {
-        ok = false;
+        return false;
+      } finally {
+        ta.remove();
       }
-      ta.remove();
-      return ok;
     };
     if (navigator.clipboard?.writeText) {
       navigator.clipboard.writeText(text).then(
@@ -1076,14 +1122,8 @@ ${piece}`;
     const n = visibleCount;
     const first = Math.floor((0 - tbodyTop) / pitch);
     const last = Math.ceil((innerHeight - tbodyTop) / pitch);
-    let start = Math.max(0, first - buffer);
-    let end = Math.min(n, last + buffer);
-    if (start > n) {
-      start = n;
-    }
-    if (end < start) {
-      end = start;
-    }
+    const start = Math.min(n, Math.max(0, first - buffer));
+    const end = Math.max(start, Math.min(n, last + buffer));
     return { start, end };
   }
   function spacerHeights(start, end, visibleCount, rowH) {
@@ -1103,14 +1143,11 @@ ${piece}`;
     return tbodyTop + index * rowH;
   }
   function scrollAdjustToReveal(rowTop, rowH, topMin, innerHeight) {
-    const rowBottom = rowTop + rowH;
-    if (rowTop < topMin) {
-      return rowTop - topMin;
+    const topOverflow = rowTop - topMin;
+    if (topOverflow < 0) {
+      return topOverflow;
     }
-    if (rowBottom > innerHeight) {
-      return rowBottom - innerHeight;
-    }
-    return 0;
+    return Math.max(0, rowTop + rowH - innerHeight);
   }
   function clampFocusIndex(current, delta, visibleCount) {
     return Math.max(0, Math.min(visibleCount - 1, current + delta));
@@ -1141,7 +1178,7 @@ ${piece}`;
     pendingScrollY: null
   };
   function virtualizerActive() {
-    return virtState.active && !!virtState.tbody && virtState.tbody.isConnected;
+    return virtState.active && virtState.tbody?.isConnected === true;
   }
   function virtReset() {
     virtState.active = false;
@@ -1181,7 +1218,7 @@ ${piece}`;
     const first = rendered[0].getBoundingClientRect();
     const last = rendered[rendered.length - 1].getBoundingClientRect();
     const pitch = (last.bottom - first.top) / rendered.length;
-    return pitch > 0 ? pitch : 0;
+    return Math.max(0, pitch);
   }
   function virtFallbackRowHeight() {
     let py = 9;
@@ -1215,7 +1252,7 @@ ${piece}`;
   }
   function virtComputeVisible() {
     const keys = roRowModel().visibleKeys;
-    virtState.visible = keys ? virtState.rows.filter((tr) => keys.has(tr.dataset.key)) : virtState.rows.slice();
+    virtState.visible = keys ? virtState.rows.filter((tr) => keys.has(tr.dataset.key)) : virtState.rows;
   }
   function virtRenderWindow() {
     const s = virtState;
@@ -1237,11 +1274,11 @@ ${piece}`;
   function virtBindMounts() {
     const content = document.getElementById("resource-list-content");
     const wrap = content?.querySelector(".ro-table-wrap.ro-windowed");
-    const table = wrap?.querySelector("table.ro-table");
-    const tbody = table && table.tBodies.length > 0 ? table.tBodies[0] : null;
-    virtState.table = table || null;
-    virtState.tbody = tbody || null;
-    return !!tbody;
+    const table = wrap?.querySelector("table.ro-table") ?? null;
+    const tbody = table?.tBodies.item(0) ?? null;
+    virtState.table = table;
+    virtState.tbody = tbody;
+    return tbody !== null;
   }
   function virtualizeInit() {
     const content = document.getElementById("resource-list-content");
@@ -1251,7 +1288,7 @@ ${piece}`;
       return;
     }
     const table = wrap.querySelector("table.ro-table");
-    const tbody = table && table.tBodies.length > 0 ? table.tBodies[0] : null;
+    const tbody = table?.tBodies.item(0) ?? null;
     if (!tbody) {
       virtReset();
       return;
@@ -1291,12 +1328,7 @@ ${piece}`;
     if (!tbody) {
       return;
     }
-    const rows = [];
-    Array.prototype.forEach.call(tbody.children, (el) => {
-      if (el.tagName === "TR" && el.dataset.key) {
-        rows.push(el);
-      }
-    });
+    const rows = Array.from(tbody.querySelectorAll(":scope > tr[data-key]"));
     if (rows.length === 0) {
       return;
     }
@@ -1315,9 +1347,7 @@ ${piece}`;
     const pending = virtState.pendingRows;
     virtState.pendingRows = null;
     if (!pending) {
-      if (virtState.active) {
-        virtReset();
-      }
+      virtReset();
       return;
     }
     const prior = virtState.byKey;
@@ -1357,7 +1387,7 @@ ${piece}`;
     virtFlashChangedCells(prior);
   }
   function virtFlashChangedCells(prior) {
-    if (!prior || prior.size === 0 || window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    if (prior.size === 0 || window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
       return;
     }
     virtState.tbody.querySelectorAll(":scope > tr[data-key]").forEach((tr) => {
@@ -1365,17 +1395,14 @@ ${piece}`;
       if (!old) {
         return;
       }
-      const oldCells = old.children;
-      const newCells = tr.children;
-      for (let i = 0; i < newCells.length; i++) {
-        const o = oldCells[i];
-        const nd = newCells[i];
-        if (o && nd && nd.tagName === "TD" && o.textContent !== nd.textContent) {
-          nd.classList.remove("ro-cell-changed");
-          void nd.offsetWidth;
-          nd.classList.add("ro-cell-changed");
+      Array.from(tr.children).forEach((newCell, index) => {
+        const oldCell = old.children.item(index);
+        if (oldCell && newCell.tagName === "TD" && oldCell.textContent !== newCell.textContent) {
+          newCell.classList.remove("ro-cell-changed");
+          void newCell.offsetWidth;
+          newCell.classList.add("ro-cell-changed");
         }
-      }
+      });
     });
   }
   function virtualizeOnFilterChange() {
@@ -1390,14 +1417,8 @@ ${piece}`;
     if (list.length === 0) {
       return false;
     }
-    let current = -1;
     const focusKey = roRowState().focusedKey();
-    for (let i = 0; i < list.length; i++) {
-      if (list[i].dataset.key === focusKey) {
-        current = i;
-        break;
-      }
-    }
+    const current = list.findIndex((row) => row.dataset.key === focusKey);
     const next = clampFocusIndex(current, delta, list.length);
     virtualizeScrollToIndex(next);
     roRowState().setFocus(list[next].dataset.key);
@@ -1454,8 +1475,9 @@ ${piece}`;
     { passive: true }
   );
   window.addEventListener("resize", virtOnScroll);
-  if (document.fonts?.ready && typeof document.fonts.ready.then === "function") {
-    document.fonts.ready.then(() => {
+  var fontReady = document.fonts?.ready;
+  if (fontReady && typeof fontReady.then === "function") {
+    void fontReady.then(() => {
       if (!virtualizerActive()) {
         return;
       }
@@ -1504,7 +1526,7 @@ ${piece}`;
     }
     const fields = [];
     table.querySelectorAll("thead th").forEach((th) => {
-      const label = (th.textContent || "").trim();
+      const label = normalizeFieldWhitespace(th.textContent || "");
       fields.push({
         label,
         name: fieldSuggestionText(label),
@@ -1515,12 +1537,12 @@ ${piece}`;
     table.querySelectorAll("tbody tr[data-key]").forEach((tr) => {
       const cells = [];
       tr.querySelectorAll("td").forEach((td) => {
-        cells.push((td.textContent || "").trim());
+        cells.push(trimFilterWhitespace(td.textContent || ""));
       });
       const nameLink = tr.querySelector("td.cell-name a");
       rows.push({
         key: tr.dataset.key,
-        name: nameLink ? (nameLink.textContent || "").trim() : cells[0] || "",
+        name: nameLink ? trimFilterWhitespace(nameLink.textContent || "") : cells[0] || "",
         cells
       });
     });
@@ -1566,13 +1588,11 @@ ${piece}`;
       target: "#resource-list-content",
       swap: "morph"
     });
-    if (request && typeof request.catch === "function") {
-      request.catch(() => {
-      });
-    }
+    void request?.catch(() => {
+    });
   }
   function commitFilterChip(draft) {
-    const text = draft.trim();
+    const text = trimFilterWhitespace(draft);
     const parsed = splitFilterDraft(text);
     if (!parsed) {
       return;
@@ -1611,7 +1631,7 @@ ${piece}`;
       return;
     }
     const names = filterSuggestionFields(roRowModel2.fields).slice(0, 3).map((f) => f.text);
-    el.textContent = `no such field — try ${names.length ? names.join(", ") : "status, node, age"}…`;
+    el.textContent = `no such field — try ${names.join(", ")}…`;
     el.hidden = false;
   }
   function hideFilterFieldHint() {
@@ -1621,7 +1641,7 @@ ${piece}`;
     }
   }
   var filterACItems = [];
-  var filterACActive = -1;
+  var filterACActive = 0;
   function filterACOpen() {
     const ac = document.getElementById("ro-filter-ac");
     return !!ac && !ac.hidden;
@@ -1633,7 +1653,7 @@ ${piece}`;
       ac.textContent = "";
     }
     filterACItems = [];
-    filterACActive = -1;
+    filterACActive = 0;
   }
   function openFilterAC(items) {
     const ac = document.getElementById("ro-filter-ac");
@@ -1656,21 +1676,16 @@ ${piece}`;
       name.className = "ac-name";
       name.textContent = item.label;
       row.appendChild(name);
-      if (item.hint) {
-        const hint = document.createElement("span");
-        hint.className = "ac-hint";
-        hint.textContent = item.hint;
-        row.appendChild(hint);
-      }
+      const hint = document.createElement("span");
+      hint.className = "ac-hint";
+      hint.textContent = item.hint;
+      row.appendChild(hint);
       row.addEventListener("mousemove", () => setFilterACActive(idx));
       ac.appendChild(row);
     });
     ac.hidden = false;
   }
   function setFilterACActive(index) {
-    if (filterACItems.length === 0) {
-      return;
-    }
     filterACActive = Math.max(0, Math.min(filterACItems.length - 1, index));
     const ac = document.getElementById("ro-filter-ac");
     if (!ac) {
@@ -1683,9 +1698,6 @@ ${piece}`;
     });
   }
   function moveFilterACActive(delta) {
-    if (filterACItems.length === 0) {
-      return;
-    }
     setFilterACActive((filterACActive + delta + filterACItems.length) % filterACItems.length);
   }
   function updateFilterAC() {
@@ -1694,7 +1706,7 @@ ${piece}`;
       return;
     }
     const draft = input.value;
-    if (!draft.trim()) {
+    if (!trimFilterWhitespace(draft)) {
       closeFilterAC();
       return;
     }
@@ -1703,17 +1715,11 @@ ${piece}`;
       openFilterAC(rankFieldSuggestions(roRowModel2.fields, draft));
       return;
     }
-    const isLabel = normalizeFieldName(parsed.field) === "label";
-    if (parsed.op !== ":" || isLabel || !filterFieldKnown(roRowModel2.fields, parsed.field)) {
+    if (parsed.op !== ":" || !filterFieldKnown(roRowModel2.fields, parsed.field)) {
       closeFilterAC();
       return;
     }
-    const items = rankValueSuggestions(roRowModel2.fields, roRowModel2.rows, parsed);
-    if (items.length === 0) {
-      closeFilterAC();
-      return;
-    }
-    openFilterAC(items);
+    openFilterAC(rankValueSuggestions(roRowModel2.fields, roRowModel2.rows, parsed));
   }
   function acceptFilterAC(commitValues) {
     const input = document.getElementById("ro-filter-input");
@@ -1722,7 +1728,6 @@ ${piece}`;
       return;
     }
     input.value = item.insert;
-    closeFilterAC();
     if (item.kind === "value" && commitValues) {
       commitFilterChip(input.value);
     } else {
@@ -1734,7 +1739,7 @@ ${piece}`;
     const input = event.target;
     if (event.key === "Enter") {
       event.preventDefault();
-      if (filterACOpen() && filterACActive >= 0) {
+      if (filterACOpen() && filterACItems.length > 0) {
         acceptFilterAC(true);
         return;
       }
@@ -1855,24 +1860,22 @@ ${piece}`;
   ];
 
   // internal/assets/src/js/morph.ts
-  var idiomorph = typeof Idiomorph === "undefined" ? void 0 : Idiomorph;
+  var idiomorph = typeof Idiomorph !== "undefined" && typeof Idiomorph.morph === "function" ? Idiomorph : void 0;
   if (idiomorph?.defaults?.callbacks && !window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
     const PRIOR = /* @__PURE__ */ new WeakMap();
     idiomorph.defaults.callbacks.beforeNodeMorphed = (oldNode) => {
-      if (oldNode && oldNode.nodeType === 1 && oldNode.tagName === "TD") {
-        PRIOR.set(oldNode, oldNode.textContent);
+      if (oldNode.nodeName !== "TD") {
+        return;
       }
+      PRIOR.set(oldNode, oldNode.textContent);
     };
     idiomorph.defaults.callbacks.afterNodeMorphed = (oldNode) => {
-      if (oldNode?.nodeType !== 1 || oldNode.tagName !== "TD") {
+      if (!PRIOR.has(oldNode)) {
         return;
       }
       const el = oldNode;
-      if (!PRIOR.has(el)) {
-        return;
-      }
-      const before = PRIOR.get(el);
-      PRIOR.delete(el);
+      const before = PRIOR.get(oldNode);
+      PRIOR.delete(oldNode);
       if (before !== el.textContent) {
         el.classList.remove("ro-cell-changed");
         void el.offsetWidth;
@@ -1880,14 +1883,14 @@ ${piece}`;
       }
     };
   }
-  if (typeof htmx !== "undefined" && idiomorph) {
+  if (typeof htmx !== "undefined" && typeof htmx.defineExtension === "function" && idiomorph) {
     htmx.defineExtension("ro-morph", {
       isInlineSwap: (swapStyle) => swapStyle === "morph",
       handleSwap: (swapStyle, target, fragment) => {
         if (swapStyle !== "morph") {
           return false;
         }
-        if (target && target.id === "resource-list-content") {
+        if (target.id === "resource-list-content") {
           captureRowModel(fragment);
           virtualizePrepareSwap(fragment);
         }
@@ -1927,10 +1930,10 @@ ${piece}`;
     if (entries.length === 0 || entries.length > BULK_NAMES_MAX) {
       return;
     }
-    const clusterPrefix = `${bar.dataset.bulkCluster || ""}/`;
+    const cluster = bar.dataset.bulkCluster;
     const names = entries.map((entry) => {
-      if (bar.dataset.bulkAllns === "true" && entry.key.indexOf(clusterPrefix) === 0) {
-        return entry.key.slice(clusterPrefix.length);
+      if (bar.dataset.bulkAllns === "true" && cluster && entry.key.startsWith(`${cluster}/`)) {
+        return entry.key.slice(cluster.length + 1);
       }
       return entry.name;
     });
@@ -2130,11 +2133,17 @@ ${piece}`;
         item.hidden = true;
       }
     };
-    bind("open", tr.dataset.href || "");
-    bind("yaml", tr.dataset.yaml || "");
-    bind("logs", tr.dataset.logs || "");
-    bind("download", tr.dataset.download || "");
-    menu.dataset.name = tr.dataset.name || lastKeySegment(tr.dataset.key || "");
+    bind("open", tr.dataset.href);
+    bind("yaml", tr.dataset.yaml);
+    bind("logs", tr.dataset.logs);
+    bind("download", tr.dataset.download);
+    const key = tr.dataset.key;
+    const name = tr.dataset.name || (key ? lastKeySegment(key) : void 0);
+    if (name) {
+      menu.dataset.name = name;
+    } else {
+      delete menu.dataset.name;
+    }
     menu.style.left = `${Math.max(8, Math.min(x, window.innerWidth - CTX_CLAMP_W))}px`;
     menu.style.top = `${Math.max(8, Math.min(y, window.innerHeight - CTX_CLAMP_H))}px`;
     menu.classList.add("is-open");
@@ -2169,14 +2178,18 @@ ${piece}`;
         event.preventDefault();
         const item = matched;
         const menu = item.closest("#ro-ctxmenu");
-        const name = menu?.dataset.name || "";
-        const href = item.dataset.href || "";
         closeRowMenu();
         if (item.dataset.roAction === "copy") {
-          roCopyText(name, () => {
-          });
-        } else if (href) {
-          window.location.assign(href);
+          const name = menu?.dataset.name;
+          if (name !== void 0) {
+            roCopyText(name, () => {
+            });
+          }
+        } else {
+          const href = item.dataset.href;
+          if (href) {
+            window.location.assign(href);
+          }
         }
         return true;
       }
@@ -2212,12 +2225,10 @@ ${piece}`;
     return window.roRowState;
   }
   function keyboardTargetIsTextEntry(target) {
-    const el = target;
-    if (el?.nodeType !== 1) {
+    if (!(target instanceof HTMLElement)) {
       return false;
     }
-    const tag = el.tagName;
-    return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || !!el.isContentEditable;
+    return target.matches("input, textarea, select") || target.isContentEditable;
   }
   function keyboardSurfaceBusy() {
     const palette = document.getElementById(PALETTE_ID);
@@ -2259,10 +2270,10 @@ ${piece}`;
     if (!key) {
       return false;
     }
-    let row = visibleKeyRows().find((tr) => tr.dataset.key === key) || null;
+    let row = visibleKeyRows().find((tr) => tr.dataset.key === key) ?? null;
     if (!row && virtualizerActive()) {
       const tr = virtRowByKey(key);
-      if (tr && virtVisible().indexOf(tr) !== -1) {
+      if (tr && virtVisible().includes(tr)) {
         row = tr;
       }
     }
@@ -2301,7 +2312,7 @@ ${piece}`;
     overlay.classList.remove("open");
     overlay.setAttribute("aria-hidden", "true");
     const prior = kbdPriorFocus;
-    if (prior && document.contains(prior) && typeof prior.focus === "function") {
+    if (prior && document.contains(prior)) {
       prior.focus();
     }
     kbdPriorFocus = null;
@@ -2312,7 +2323,7 @@ ${piece}`;
     {
       event: "click",
       handler: (event) => {
-        if (event.target.id === "ro-kbd-overlay") {
+        if (event.target === kbdOverlayEl()) {
           closeKbdOverlay();
         }
       }
@@ -2353,7 +2364,7 @@ ${piece}`;
         }
         if (e.key === "Enter") {
           const target = e.target;
-          if (target?.closest?.("a, button, summary")) {
+          if (target instanceof Element && target.closest("a, button, summary")) {
             return;
           }
           if (openFocusedRow()) {
@@ -2443,9 +2454,6 @@ ${piece}`;
 
   // internal/assets/src/js/collapse-hash.ts
   function parseCollapsedNames(hash) {
-    if (!hash) {
-      return [];
-    }
     const names = [];
     hash.replace(/^#/, "").split(";").forEach((param) => {
       const keyVal = param.split("=");
@@ -2463,25 +2471,47 @@ ${piece}`;
   // internal/assets/src/js/yaml-folds.ts
   function yamlEffectiveIndent(text) {
     const stripped = text.replace(/^\n+/, "");
-    let i = 0;
-    while (i < stripped.length && stripped[i] === " ") {
-      i++;
-    }
-    const rest = stripped.slice(i);
+    const indent = stripped.length - stripped.replace(/^ +/, "").length;
+    const rest = stripped.slice(indent);
     if (rest === "-" || rest.startsWith("- ") || rest.startsWith("-	")) {
-      return i + 2;
+      return indent + 2;
     }
-    return i;
+    return indent;
+  }
+  function planYamlFolds(indents, isBlank) {
+    const bodyCounts = new Array(indents.length).fill(0);
+    const ownersByLine = Array.from({ length: indents.length }, () => []);
+    const active = [];
+    let previous;
+    indents.forEach((indent, index) => {
+      if (isBlank[index]) {
+        return;
+      }
+      const firstClosed = active.findIndex((owner) => owner.indent >= indent);
+      if (firstClosed !== -1) {
+        active.splice(firstClosed);
+      }
+      if (previous && previous.indent < indent) {
+        active.push(previous);
+      }
+      active.forEach((owner) => {
+        ownersByLine[index].push(owner.index);
+        bodyCounts[owner.index] += 1;
+      });
+      previous = { index, indent };
+    });
+    return { bodyCounts, ownersByLine };
   }
   function yamlCodeText(codeCell) {
-    if (!codeCell.querySelector('[data-ro-action="toggle-fold"], [data-ro-fold-control]')) {
-      return codeCell.textContent || "";
+    const controlSelector = '[data-ro-action="toggle-fold"], [data-ro-fold-control]';
+    if (!codeCell.querySelector(controlSelector)) {
+      return codeCell.textContent;
     }
     const clone = codeCell.cloneNode(true);
-    clone.querySelectorAll('[data-ro-action="toggle-fold"], [data-ro-fold-control]').forEach((el) => {
+    clone.querySelectorAll(controlSelector).forEach((el) => {
       el.remove();
     });
-    return clone.textContent || "";
+    return clone.textContent;
   }
   function toggleYamlFold(toggle) {
     const id = toggle.dataset.fold;
@@ -2496,7 +2526,7 @@ ${piece}`;
     toggle.classList.toggle("is-folded", folded);
     toggle.setAttribute("aria-expanded", folded ? "false" : "true");
     pre.querySelectorAll("[data-fold-of]").forEach((line) => {
-      const owners = (line.dataset.foldOf || "").split(" ");
+      const owners = line.dataset.foldOf.split(" ");
       if (owners.indexOf(id) !== -1) {
         line.classList.toggle("ro-line-folded", folded);
       }
@@ -2524,7 +2554,7 @@ ${piece}`;
       lineSpan.insertBefore(toggle, lineSpan.firstChild);
     }
     const last = lineSpan.lastChild;
-    if (last && last.nodeType === 3 && (last.textContent || "").indexOf("\n") !== -1) {
+    if (last?.nodeType === Node.TEXT_NODE && last.data.includes("\n")) {
       lineSpan.insertBefore(note, last);
     } else {
       lineSpan.appendChild(note);
@@ -2544,40 +2574,24 @@ ${piece}`;
         if (lines.length < 3) {
           return;
         }
-        const indents = lines.map((el) => yamlEffectiveIndent(el.textContent || ""));
-        const isBlank = lines.map((el) => (el.textContent || "").trim() === "");
-        for (let i = 0; i < lines.length; i++) {
-          if (isBlank[i]) {
-            continue;
+        const texts = lines.map((line) => line.textContent);
+        const indents = texts.map(yamlEffectiveIndent);
+        const isBlank = texts.map((text) => text.trim() === "");
+        const { bodyCounts, ownersByLine } = planYamlFolds(indents, isBlank);
+        lines.forEach((line, index) => {
+          const owners = ownersByLine[index];
+          if (owners.length === 0) {
+            return;
           }
-          let j = i + 1;
-          while (j < lines.length && isBlank[j]) {
-            j++;
+          const element = line;
+          const ownerIds = owners.map((owner) => lines[owner].id).join(" ");
+          element.dataset.foldOf = ownerIds;
+        });
+        lines.forEach((line, index) => {
+          if (bodyCounts[index] > 0) {
+            injectFoldControls(line, bodyCounts[index]);
           }
-          if (j >= lines.length || indents[j] <= indents[i]) {
-            continue;
-          }
-          let end = i + 1;
-          let bodyCount = 0;
-          while (end < lines.length) {
-            if (isBlank[end]) {
-              end++;
-              continue;
-            }
-            if (indents[end] > indents[i]) {
-              const cur = lines[end];
-              cur.dataset.foldOf = cur.dataset.foldOf ? `${cur.dataset.foldOf} ${lines[i].id}` : lines[i].id;
-              bodyCount++;
-              end++;
-            } else {
-              break;
-            }
-          }
-          if (bodyCount === 0) {
-            continue;
-          }
-          injectFoldControls(lines[i], bodyCount);
-        }
+        });
       } catch (_e) {
       }
     });
@@ -2726,7 +2740,7 @@ ${piece}`;
         } else {
           window.history.replaceState(
             null,
-            "",
+            document.title,
             window.location.pathname + window.location.search
           );
         }
@@ -2744,9 +2758,8 @@ ${piece}`;
       selector: '#namespace-dropdown [data-ro-action="pick-namespace"]',
       stop: true,
       handler: (_event, matched) => {
-        const hrefMatch = /^\/clusters\/([^/]+)\/namespaces\/([^/]+)\//.exec(
-          matched.getAttribute("href") || ""
-        );
+        const href = matched.getAttribute("href");
+        const hrefMatch = href ? /^\/clusters\/([^/]+)\/namespaces\/([^/]+)\//.exec(href) : null;
         if (hrefMatch) {
           roPrefsSetNamespace(
             decodeURIComponent(hrefMatch[1]),
@@ -2787,7 +2800,7 @@ ${piece}`;
       handler: (_event, matched) => {
         const filterText = matched.value.toLowerCase();
         document.querySelectorAll('[data-ro-action="pick-namespace"]').forEach((element) => {
-          const text = (element.innerText || "").toLowerCase();
+          const text = element.innerText.toLowerCase();
           if (text.indexOf(filterText) === -1) {
             element.classList.add("is-hidden");
           } else {
@@ -2807,13 +2820,10 @@ ${piece}`;
         if (event.key !== "Enter") {
           return true;
         }
-        const elements = document.querySelectorAll('[data-ro-action="pick-namespace"]');
-        for (let i = 0; i < elements.length; i++) {
-          if (!elements[i].classList.contains("is-hidden")) {
-            elements[i].click();
-            break;
-          }
-        }
+        const firstVisible = Array.from(
+          document.querySelectorAll('[data-ro-action="pick-namespace"]')
+        ).find((element) => !element.classList.contains("is-hidden"));
+        firstVisible?.click();
         return true;
       }
     },
@@ -2916,35 +2926,41 @@ ${piece}`;
   ];
 
   // internal/assets/src/js/palette-rank.ts
+  var WORD_SEPARATORS = " -_./:";
+  function isAsciiUppercase(character) {
+    return character >= "A" && character <= "Z";
+  }
   function roFuzzyScore(query, text) {
-    const source = String(text || "");
-    const q = String(query || "").toLowerCase();
+    const source = text;
+    const q = query.toLowerCase();
     const t = source.toLowerCase();
     if (!q) {
       return 0;
     }
-    let from = 0;
-    let first = -1;
-    let last = -1;
-    for (let i = 0; i < q.length; i++) {
+    const first = t.indexOf(q[0]);
+    if (first === -1) {
+      return -1;
+    }
+    let from = first + 1;
+    for (let i = 1; i < q.length; i++) {
       const at = t.indexOf(q[i], from);
       if (at === -1) {
         return -1;
       }
-      if (first === -1) {
-        first = at;
-      }
-      last = at;
       from = at + 1;
     }
-    const gaps = last - first + 1 - q.length;
-    const camelHump = source[first] >= "A" && source[first] <= "Z" && !(source[first - 1] >= "A" && source[first - 1] <= "Z");
-    const wordStart = first === 0 || " -_./:".indexOf(t[first - 1]) !== -1 || camelHump;
+    const gaps = from - first - q.length;
     let tier = 2;
-    if (gaps === 0 && first === 0) {
-      tier = 0;
-    } else if (gaps === 0 && wordStart) {
-      tier = 1;
+    if (gaps === 0) {
+      if (first === 0) {
+        tier = 0;
+      } else {
+        const separatorBoundary = WORD_SEPARATORS.includes(t[first - 1]);
+        const camelHump = isAsciiUppercase(source[first]) && !isAsciiUppercase(source[first - 1]);
+        if (separatorBoundary || camelHump) {
+          tier = 1;
+        }
+      }
     }
     return tier * 1e5 + gaps * 100 + Math.min(first, 99);
   }
@@ -2983,7 +2999,7 @@ ${piece}`;
     return String(entry.name || entry.label || "");
   }
   function buildPaletteGroups(query, feed, recents, pageObjects) {
-    const q = (query || "").trim();
+    const q = query.trim();
     const groups = [];
     if (q) {
       groups.push({ title: "Everywhere", key: "everywhere", entries: [{ query: q }] });
@@ -3007,6 +3023,19 @@ ${piece}`;
   // internal/assets/src/js/palette.ts
   var PALETTE_ID2 = "ro-palette";
   window.roFuzzy = roFuzzyScore;
+  function asPropertyRecord(value) {
+    return Object(value);
+  }
+  function nonEmptyString(value) {
+    if (typeof value !== "string") {
+      return void 0;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : void 0;
+  }
+  function feedEntryLabel2(entry, kindEntry) {
+    return kindEntry ? nonEmptyString(entry.kind) ?? nonEmptyString(entry.plural) : nonEmptyString(entry.name) ?? nonEmptyString(entry.label);
+  }
   function readPaletteData() {
     const empty = {
       currentCluster: null,
@@ -3020,78 +3049,60 @@ ${piece}`;
     if (!el) {
       return empty;
     }
-    const raw = (el.textContent || "").trim();
-    if (!raw) {
-      return empty;
-    }
     try {
-      const data = JSON.parse(raw);
-      if (!data || typeof data !== "object" || Array.isArray(data)) {
-        return empty;
-      }
-      ["clusters", "namespaces", "kinds", "actions"].forEach((k) => {
-        if (!Array.isArray(data[k])) {
-          data[k] = [];
-          return;
-        }
-        data[k] = data[k].filter(
-          (entry) => entry !== null && typeof entry === "object" && !Array.isArray(entry)
-        );
-      });
-      return data;
+      const data = asPropertyRecord(JSON.parse(el.textContent));
+      const records = (value, kindEntries = false) => Array.isArray(value) ? value.map(asPropertyRecord).filter((entry) => feedEntryLabel2(entry, kindEntries) !== void 0).filter(
+        (entry) => paletteHrefSafe(entry.href) !== "" || nonEmptyString(entry.action) !== void 0
+      ) : [];
+      return {
+        currentCluster: nonEmptyString(data.currentCluster) ?? null,
+        currentNamespace: nonEmptyString(data.currentNamespace) ?? null,
+        clusters: records(data.clusters),
+        namespaces: records(data.namespaces),
+        kinds: records(data.kinds, true),
+        actions: records(data.actions)
+      };
     } catch {
       return empty;
     }
   }
-  function paletteHrefSafe(href) {
-    if (!href || typeof href !== "string") {
+  function paletteHrefSafe(href, pageHref = window.location.href) {
+    if (typeof href !== "string") {
       return "";
     }
     const trimmed = href.trim();
-    if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed) && !/^https?:/i.test(trimmed)) {
+    try {
+      const page = new URL(pageHref);
+      const parsed = new URL(trimmed, page);
+      const networkProtocol = parsed.protocol === "http:" || parsed.protocol === "https:";
+      return networkProtocol && parsed.origin === page.origin ? trimmed : "";
+    } catch {
       return "";
     }
-    return trimmed;
   }
   var PALETTE_RECENTS_KEY = "ro-pref-recents";
   var PALETTE_RECENTS_MAX = 5;
   function readPaletteRecents() {
-    let raw = null;
     try {
-      raw = window.localStorage.getItem(PALETTE_RECENTS_KEY);
-    } catch {
-      return [];
-    }
-    if (!raw) {
-      return [];
-    }
-    try {
-      const list = JSON.parse(raw);
-      if (!Array.isArray(list)) {
+      const raw = window.localStorage.getItem(PALETTE_RECENTS_KEY);
+      if (!raw) {
         return [];
       }
+      const list = JSON.parse(raw);
       const recents = [];
       const seen = /* @__PURE__ */ new Set();
       for (const value of list) {
-        if (!value || typeof value !== "object" || Array.isArray(value)) {
+        const record = asPropertyRecord(value);
+        const label = nonEmptyString(record.label);
+        if (!label) {
           continue;
         }
-        const candidate = value;
-        if (typeof candidate.label !== "string" || candidate.label === "") {
-          continue;
-        }
-        const href = paletteHrefSafe(candidate.href);
-        const action = typeof candidate.action === "string" && candidate.action !== "" ? candidate.action : "";
+        const href = paletteHrefSafe(record.href);
+        const action = nonEmptyString(record.action);
         if (!href && !action) {
           continue;
         }
-        const recent = { label: candidate.label };
-        if (href) {
-          recent.href = href;
-        }
-        if (action) {
-          recent.action = action;
-        }
+        const recent = { label, href: href || void 0, action };
         const target = paletteRecentTarget(recent);
         if (seen.has(target)) {
           continue;
@@ -3111,13 +3122,7 @@ ${piece}`;
     if (!label || !href && !action) {
       return;
     }
-    const entry = { label };
-    if (href) {
-      entry.href = href;
-    }
-    if (action) {
-      entry.action = action;
-    }
+    const entry = { label, href, action };
     const kept = dedupeRecents(readPaletteRecents(), entry, PALETTE_RECENTS_MAX);
     try {
       window.localStorage.setItem(PALETTE_RECENTS_KEY, JSON.stringify(kept));
@@ -3130,91 +3135,78 @@ ${piece}`;
     cluster: null,
     namespace: null
   };
-  function buildPaletteRow(entry, key) {
+  function createPaletteRow() {
     const row = document.createElement("div");
     row.className = "ro-pal-item";
     row.dataset.roAction = "pick-palette-row";
     row.setAttribute("role", "option");
-    row.setAttribute("aria-selected", "false");
-    if (key === "kinds" && entry.icon) {
-      const holder = document.createElement("template");
-      holder.innerHTML = String(entry.icon);
-      row.appendChild(holder.content);
-    }
-    const labelText = key === "kinds" ? String(entry.kind || entry.plural || "") : String(entry.name || entry.label || "");
-    const display = typeof entry.display === "string" && entry.display !== "" ? entry.display : labelText;
+    return row;
+  }
+  function appendPaletteLabel(row, text) {
     const label = document.createElement("span");
     label.className = "pal-label";
-    label.textContent = display;
+    label.textContent = text;
+    row.appendChild(label);
+    return label;
+  }
+  function buildPaletteRow(entry, key) {
+    const row = createPaletteRow();
+    const kindRow = key === "kinds";
+    const icon = nonEmptyString(entry.icon);
+    if (kindRow && icon) {
+      const holder = document.createElement("template");
+      holder.innerHTML = icon;
+      row.appendChild(holder.content);
+    }
+    const labelText = feedEntryLabel2(entry, kindRow);
+    const display = nonEmptyString(entry.display) ?? labelText;
+    const label = appendPaletteLabel(row, display);
     if (display !== labelText) {
       row.title = labelText;
     }
-    const isCurrent = key === "clusters" && entry.name && entry.name === paletteScope.cluster || key === "namespaces" && entry.name && entry.name === paletteScope.namespace;
-    if (isCurrent) {
+    const entryName = nonEmptyString(entry.name);
+    const currentScope = key === "clusters" ? paletteScope.cluster : key === "namespaces" ? paletteScope.namespace : null;
+    if (entryName && entryName === currentScope) {
       const ctx = document.createElement("span");
       ctx.className = "pal-ctx";
       ctx.textContent = "current";
       label.appendChild(ctx);
     }
-    row.appendChild(label);
-    if (key === "kinds") {
+    if (kindRow) {
       const meta = document.createElement("span");
       meta.className = "pal-meta";
-      meta.textContent = String(entry.group || "core");
+      meta.textContent = nonEmptyString(entry.group) ?? "core";
       row.appendChild(meta);
       const scope = document.createElement("span");
-      scope.className = `pal-scope ${entry.namespaced ? "ns" : "cluster"}`;
-      scope.textContent = entry.namespaced ? "namespaced" : "cluster";
+      const namespaced = entry.namespaced === true;
+      scope.className = `pal-scope ${namespaced ? "ns" : "cluster"}`;
+      scope.textContent = namespaced ? "namespaced" : "cluster";
       row.appendChild(scope);
     }
     const href = paletteHrefSafe(entry.href);
     if (href) {
       row.dataset.href = href;
     }
-    if (entry.action) {
-      row.dataset.action = String(entry.action);
+    const action = nonEmptyString(entry.action);
+    if (action) {
+      row.dataset.action = action;
     }
     row.dataset.label = labelText;
     return row;
   }
   function buildEverywhereRow(query) {
-    const row = document.createElement("div");
-    row.className = "ro-pal-item";
-    row.dataset.roAction = "pick-palette-row";
-    row.setAttribute("role", "option");
-    row.setAttribute("aria-selected", "false");
+    const row = createPaletteRow();
     const glyph = document.querySelector(`#${PALETTE_ID2} .ro-pal-search .ico`);
     if (glyph) {
       row.appendChild(glyph.cloneNode(true));
     }
-    const label = document.createElement("span");
-    label.className = "pal-label";
-    label.textContent = `Search all clusters for “${query}”`;
-    row.appendChild(label);
+    const labelText = `Search all clusters for “${query}”`;
+    appendPaletteLabel(row, labelText);
     row.dataset.href = `/search?q=${encodeURIComponent(query)}`;
-    row.dataset.label = label.textContent;
+    row.dataset.label = labelText;
     return row;
   }
-  function buildRecentRow(entry) {
-    const row = document.createElement("div");
-    row.className = "ro-pal-item";
-    row.dataset.roAction = "pick-palette-row";
-    row.setAttribute("role", "option");
-    row.setAttribute("aria-selected", "false");
-    const label = document.createElement("span");
-    label.className = "pal-label";
-    label.textContent = entry.label;
-    row.appendChild(label);
-    const href = paletteHrefSafe(entry.href);
-    if (href) {
-      row.dataset.href = href;
-    }
-    if (entry.action) {
-      row.dataset.action = entry.action;
-    }
-    row.dataset.label = entry.label;
-    return row;
-  }
+  var PALETTE_STATUS_TONES = ["ok", "warn", "err", "info", "mute"];
   function harvestPageObjects() {
     const out = [];
     const rows = virtualizerActive() ? virtRows() : document.querySelectorAll("#resource-list-content table.ro-table tbody tr");
@@ -3224,42 +3216,32 @@ ${piece}`;
         return;
       }
       const href = paletteHrefSafe(a.getAttribute("href"));
-      const name = (a.textContent || "").trim();
+      const name = a.textContent.trim();
       if (!href || !name) {
         return;
       }
-      let status = "";
-      let tone = "";
+      const object = { name, href };
       const st = tr.querySelector(".cell-status");
       if (st) {
-        status = (st.textContent || "").trim();
-        ["ok", "warn", "err", "info", "mute"].forEach((t) => {
-          if (!tone && st.classList.contains(t)) {
-            tone = t;
-          }
-        });
+        object.status = st.textContent.trim();
+        object.tone = PALETTE_STATUS_TONES.find(
+          (candidate) => st.classList.contains(candidate)
+        );
       }
-      out.push({ name, href, status, tone });
+      out.push(object);
     });
     return out;
   }
   function buildObjectRow(o) {
-    const row = document.createElement("div");
-    row.className = "ro-pal-item";
-    row.dataset.roAction = "pick-palette-row";
-    row.setAttribute("role", "option");
-    row.setAttribute("aria-selected", "false");
-    const label = document.createElement("span");
-    label.className = "pal-label";
-    label.textContent = o.name;
-    row.appendChild(label);
+    const row = createPaletteRow();
+    appendPaletteLabel(row, o.name);
     if (o.status) {
       const st = document.createElement("span");
-      st.className = `pal-status${o.tone ? ` ${String(o.tone)}` : ""}`;
-      st.textContent = String(o.status);
+      st.className = `pal-status${o.tone ? ` ${o.tone}` : ""}`;
+      st.textContent = o.status;
       row.appendChild(st);
     }
-    row.dataset.href = String(o.href);
+    row.dataset.href = o.href;
     row.dataset.label = o.name;
     return row;
   }
@@ -3269,23 +3251,21 @@ ${piece}`;
       return;
     }
     const data = readPaletteData();
-    paletteScope.cluster = data.currentCluster || null;
-    paletteScope.namespace = data.currentNamespace || null;
+    paletteScope.cluster = data.currentCluster;
+    paletteScope.namespace = data.currentNamespace;
     const scope = document.getElementById("ro-palette-scope");
     if (scope) {
-      const scopeText = paletteScope.namespace || paletteScope.cluster || "";
-      scope.textContent = scopeText;
-      scope.hidden = scopeText === "";
+      const scopeText = paletteScope.namespace ?? paletteScope.cluster;
+      scope.textContent = scopeText ?? "";
+      scope.hidden = scopeText === null;
     }
-    const q = (query || "").trim();
-    list.textContent = "";
+    const q = query;
+    list.replaceChildren();
     paletteRows = [];
     const rowFor = (item, key) => {
       switch (key) {
         case "everywhere":
           return buildEverywhereRow(item.query);
-        case "recents":
-          return buildRecentRow(item);
         case "objects":
           return buildObjectRow(item);
         default:
@@ -3313,7 +3293,7 @@ ${piece}`;
         const idx = paletteRows.length;
         row.addEventListener("mousemove", () => setPaletteActive(idx));
         list.appendChild(row);
-        paletteRows.push({ el: row, item, key: group.key });
+        paletteRows.push({ el: row });
       });
     });
     if (paletteRows.length === 0) {
@@ -3336,39 +3316,21 @@ ${piece}`;
     }
   }
   function setPaletteActive(index) {
-    if (paletteRows.length === 0) {
-      return;
-    }
-    let i = index;
-    if (i < 0) {
-      i = 0;
-    }
-    if (i > paletteRows.length - 1) {
-      i = paletteRows.length - 1;
-    }
-    paletteActive = i;
+    paletteActive = index;
     paintPaletteActive();
   }
   function movePaletteActive(delta) {
-    if (paletteRows.length === 0) {
-      return;
-    }
-    paletteActive = (paletteActive + delta + paletteRows.length) % paletteRows.length;
+    const length = paletteRows.length;
+    paletteActive = (paletteActive + delta + length) % length;
     paintPaletteActive();
   }
   function choosePaletteRow(rowEl) {
-    if (!rowEl) {
-      return;
-    }
     const action = rowEl.dataset.action;
     const href = rowEl.dataset.href;
-    recordPaletteRecent(rowEl.dataset.label || "", href || "", action || "");
+    recordPaletteRecent(rowEl.dataset.label, href, action);
     closePalette();
     if (action === "theme") {
-      const toggle = document.getElementById("btn-theme-toggle");
-      if (toggle) {
-        toggle.click();
-      }
+      document.getElementById("btn-theme-toggle")?.click();
       return;
     }
     if (href) {
@@ -3382,7 +3344,7 @@ ${piece}`;
     }
   }
   var palettePriorFocus = null;
-  var paletteRestoringFocus = false;
+  var paletteRestoringFocus;
   function openPalette(prefill) {
     const palette = document.getElementById(PALETTE_ID2);
     const input = document.getElementById("ro-palette-input");
@@ -3406,12 +3368,21 @@ ${piece}`;
     }
     palette.classList.remove("open");
     palette.setAttribute("aria-hidden", "true");
-    if (palettePriorFocus && document.contains(palettePriorFocus) && !palette.contains(palettePriorFocus) && typeof palettePriorFocus.focus === "function") {
-      paletteRestoringFocus = true;
-      palettePriorFocus.focus();
-      paletteRestoringFocus = false;
-    }
+    const prior = palettePriorFocus;
     palettePriorFocus = null;
+    if (!prior || !document.contains(prior) || palette.contains(prior)) {
+      return;
+    }
+    const focus = prior.focus;
+    if (typeof focus !== "function") {
+      return;
+    }
+    paletteRestoringFocus = true;
+    try {
+      focus.call(prior);
+    } finally {
+      paletteRestoringFocus = void 0;
+    }
   }
   var paletteBindings = [
     // ⌘K palette result row: a click on a result row activates it (navigate or
@@ -3447,21 +3418,20 @@ ${piece}`;
       stop: true,
       handler: (event, matched) => {
         event.preventDefault();
-        openPalette(matched.dataset.query || "");
+        openPalette(matched.dataset.query);
         return true;
       }
     },
     // A click on the palette backdrop ITSELF (the dimmed area outside the panel)
     // closes it, like Esc. A click inside the panel does not match. The selector
-    // is the backdrop root id; the handler still verifies target.id === PALETTE_ID
-    // so a click that bubbles from a descendant (closest matched the root) does
-    // NOT close it -- the monolith's exact `target.id === PALETTE_ID` test.
+    // is the backdrop root id; the handler still verifies that the original
+    // target is that matched root, so a descendant click does NOT close it.
     {
       event: "click",
       selector: `#${PALETTE_ID2}`,
       stop: true,
-      handler: (event) => {
-        if (event.target.id === PALETTE_ID2) {
+      handler: (event, matched) => {
+        if (event.target === matched) {
           closePalette();
           return true;
         }
@@ -3552,9 +3522,7 @@ ${piece}`;
         }
         openPalette();
         const t = event.target;
-        if (typeof t.blur === "function") {
-          t.blur();
-        }
+        t.blur();
       }
     }
   ];
@@ -3588,15 +3556,12 @@ ${piece}`;
 
   // internal/assets/src/js/events.ts
   function closestElement(event, selector) {
-    let node = event.target;
-    while (node && node.nodeType !== 1) {
-      node = node.parentNode;
-    }
-    return node ? node.closest(selector) : null;
+    const target = event.target;
+    const element = target instanceof Element ? target : target?.parentElement;
+    return element?.closest(selector) ?? null;
   }
   function dispatch(bindings2, event) {
-    for (let i = 0; i < bindings2.length; i++) {
-      const binding = bindings2[i];
+    for (const binding of bindings2) {
       let matched = null;
       if (binding.selector !== void 0) {
         matched = closestElement(event, binding.selector);
@@ -3687,10 +3652,12 @@ ${piece}`;
   });
   function clearListSkeleton() {
     const content = document.getElementById("resource-list-content");
-    const skel = content?.querySelector(":scope > .ro-skel");
-    if (skel) {
-      skel.remove();
+    if (!content) {
+      return;
     }
+    content.querySelectorAll(":scope > .ro-skel").forEach((skeleton) => {
+      skeleton.remove();
+    });
   }
   document.addEventListener("htmx:responseError", (event) => {
     if (isListRefreshEvent(event)) {
@@ -3705,33 +3672,49 @@ ${piece}`;
 
   // internal/assets/src/js/init.ts
   window.roToast = showToast;
-  document.addEventListener("htmx:beforeRequest", (event) => {
-    const detail = event.detail;
-    const cfg = detail?.requestConfig;
-    if (!cfg || !detail.elt || !detail.target || detail.target.id !== "resource-list-content") {
+  function handleSortPreferenceRequest(event) {
+    const detail = Object(event.detail);
+    const rawCfg = Object(detail.requestConfig);
+    const cfg = {
+      ...rawCfg,
+      headers: Object(rawCfg.headers)
+    };
+    const target = Object(detail.target);
+    if (target.id !== "resource-list-content") {
       return;
     }
-    if (cfg.headers && (cfg.headers["RO-No-Push"] || cfg.headers["HX-Preloaded"] === "true")) {
+    if (cfg.headers["RO-No-Push"] || cfg.headers["HX-Preloaded"] === "true") {
       return;
     }
-    if (typeof detail.elt.closest !== "function" || !detail.elt.closest("thead th")) {
-      return;
-    }
-    const pathMatch = /\/([^/]+)\/_table(?:[?#]|$)/.exec(cfg.path || "");
-    if (!pathMatch) {
-      return;
-    }
-    let sort = "";
+    const elt = Object(detail.elt);
+    let sortHeader = null;
     try {
-      sort = new URL(cfg.path, window.location.href).searchParams.get("sort") || "";
+      sortHeader = elt.closest("thead th");
+    } catch {
+    }
+    if (!sortHeader) {
+      return;
+    }
+    let plural;
+    let sort;
+    try {
+      const requestURL = new URL(String(cfg.path), window.location.href);
+      const rawSort = requestURL.searchParams.get("sort");
+      if (!rawSort) {
+        return;
+      }
+      const pathMatch = /\/([^/]+)\/_table$/.exec(requestURL.pathname);
+      if (!pathMatch) {
+        return;
+      }
+      sort = rawSort;
+      plural = decodeURIComponent(pathMatch[1]);
     } catch {
       return;
     }
-    const plural = decodeURIComponent(pathMatch[1]);
-    if (plural && sort) {
-      roPrefsSetSort(plural, sort);
-    }
-  });
+    roPrefsSetSort(plural, sort);
+  }
+  document.addEventListener("htmx:beforeRequest", handleSortPreferenceRequest);
   document.addEventListener("htmx:afterSwap", (event) => {
     if (isListRefreshEvent(event)) {
       noteRefreshRecovery();

--- a/internal/web/filter.go
+++ b/internal/web/filter.go
@@ -258,9 +258,10 @@ func filterFieldAlias(field string) (string, bool) {
 }
 
 // resolveFilterColumn resolves a field name against the table columns: exact
-// case-insensitive first, then dash/space-normalized so multi-word columns
-// match both ways (`nominated node` / `nominated-node` -> "Nominated Node",
-// while "External-IP" still matches `external-ip` exactly).
+// case-insensitive first, then dash/whitespace-normalized so multi-word columns
+// match despite dashes or irregular whitespace (`nominated node` /
+// `nominated-node` -> "Nominated Node", while "External-IP" still matches
+// `external-ip` exactly).
 func resolveFilterColumn(cols []kube.Column, field string) int {
 	for i := range cols {
 		if strings.EqualFold(cols[i].Name, field) {
@@ -277,7 +278,7 @@ func resolveFilterColumn(cols []kube.Column, field string) int {
 }
 
 func normalizeFieldName(s string) string {
-	return strings.ToLower(strings.ReplaceAll(s, "-", " "))
+	return strings.Join(strings.Fields(strings.ReplaceAll(strings.ToLower(s), "-", " ")), " ")
 }
 
 // substringMatcher implements `:` (any alternative is a case-insensitive

--- a/internal/web/filter_test.go
+++ b/internal/web/filter_test.go
@@ -121,6 +121,14 @@ func TestFilterChipParsing(t *testing.T) {
 			[]filterChip{{Field: "nominated node", Op: opContains, Values: []string{"worker"}, Raw: "nominated+node:worker"}},
 		},
 		{
+			"U+0085 trims like unicode.IsSpace", "f=%C2%85status%C2%85:Running",
+			[]filterChip{{Field: "status", Op: opContains, Values: []string{"Running"}, Raw: "%C2%85status%C2%85:Running"}},
+		},
+		{
+			"U+FEFF is field data, not unicode.IsSpace", "f=%EF%BB%BFstatus%EF%BB%BF:Running",
+			[]filterChip{{Field: "\uFEFFstatus\uFEFF", Op: opContains, Values: []string{"Running"}, Raw: "%EF%BB%BFstatus%EF%BB%BF:Running"}},
+		},
+		{
 			"trailing comma dropped", "f=status:Running,",
 			[]filterChip{{Field: "status", Op: opContains, Values: []string{"Running"}, Raw: "status:Running,"}},
 		},
@@ -191,6 +199,47 @@ func TestFilterRowMatching(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestFilterSuggestedFieldNormalization pins the client/server contract for a
+// generated autocomplete field: the client collapses an irregularly spaced
+// header to `workload-status`, which must resolve back to the original column.
+func TestFilterSuggestedFieldNormalization(t *testing.T) {
+	newTable := func() kube.Table {
+		return kube.Table{
+			Resource: kube.ResourceType{Plural: "widgets", Kind: "Widget", Namespaced: true},
+			Columns: []kube.Column{
+				{Name: "Name"},
+				{Name: " Workload\t\u0085 Status\u00a0\n"},
+				{Name: "\uFEFFBuild\uFEFFState\uFEFF"},
+			},
+			Rows: []kube.Row{{
+				Cells:  []any{"api-1", "Active", "Ready"},
+				Object: map[string]any{"metadata": map[string]any{"name": "api-1", "namespace": "default"}},
+			}},
+		}
+	}
+
+	t.Run("unicode.IsSpace includes U+0085", func(t *testing.T) {
+		table := newTable()
+		got := runFilter(t, "widgets", "f=workload-status:active", &table)
+		if !reflect.DeepEqual(got, []string{"api-1"}) {
+			t.Fatalf("client-suggested odd-whitespace field matched %v, want api-1", got)
+		}
+	})
+
+	t.Run("unicode.IsSpace excludes U+FEFF", func(t *testing.T) {
+		table := newTable()
+		if got := runFilter(t, "widgets", "f=build-state:ready", &table); len(got) != 0 {
+			t.Fatalf("dashed field incorrectly erased U+FEFF and matched %v", got)
+		}
+
+		table = newTable()
+		got := runFilter(t, "widgets", "f=\uFEFFbuild\uFEFFstate\uFEFF:ready", &table)
+		if !reflect.DeepEqual(got, []string{"api-1"}) {
+			t.Fatalf("field preserving U+FEFF matched %v, want api-1", got)
+		}
+	})
 }
 
 // TestFilterQuantityAlias pins the cpu/memory alias contract: the fields bind

--- a/internal/web/prefs_golden_test.go
+++ b/internal/web/prefs_golden_test.go
@@ -16,7 +16,8 @@ package web
 // Fixture classes (see each file's "doc"): simple payload; UTF-8 CRD column
 // names; < > & metachars (the bug); the at-cap boundary; over-cap eviction
 // (ASCII) with documented victims; over-cap eviction (multibyte) pinning the
-// byte-vs-UTF-16-code-unit cap equivalence; and corrupt decode inputs.
+// byte-vs-UTF-16-code-unit cap equivalence; namespace-map ordering/escaping;
+// and corrupt decode inputs.
 
 import (
 	"encoding/json"
@@ -75,6 +76,7 @@ func TestPrefsGoldenEncode(t *testing.T) {
 		"04_at_cap_boundary.json",
 		"05_over_cap_eviction.json",
 		"06_over_cap_multibyte.json",
+		"08_namespace_key_order.json",
 	}
 	for _, name := range encodeFiles {
 		t.Run(name, func(t *testing.T) {

--- a/internal/web/prefs_test.go
+++ b/internal/web/prefs_test.go
@@ -67,8 +67,16 @@ func TestPrefsEnvelopeRoundTrip(t *testing.T) {
 			{Plural: "deployments", Hide: &[]string{}}, // explicit "hide nothing"
 			{Plural: "nodes", Sort: "Created"},         // no column preference at all
 		},
-		Refresh:    "30",
-		Namespaces: map[string]string{"test": "_all", "prod": "kube-system"},
+		Refresh: "30",
+		Namespaces: map[string]string{
+			"test":           "_all",
+			"prod":           "kube-system",
+			"__proto__":      "proto-ns",
+			"constructor":    "constructor-ns",
+			"prototype":      "prototype-ns",
+			"toString":       "string-ns",
+			"hasOwnProperty": "own-ns",
+		},
 	}
 	value := encodePrefs(in)
 	if !strings.HasPrefix(value, "v1.") {
@@ -102,6 +110,11 @@ func TestPrefsEnvelopeRoundTrip(t *testing.T) {
 	if out.Namespaces["test"] != "_all" {
 		t.Fatalf("namespace _all round-trip = %q, want _all", out.Namespaces["test"])
 	}
+	for cluster, namespace := range in.Namespaces {
+		if out.Namespaces[cluster] != namespace {
+			t.Fatalf("special namespace key %q round-trip = %q, want %q", cluster, out.Namespaces[cluster], namespace)
+		}
+	}
 }
 
 // TestPrefsDecodeLenient: a corrupt/foreign cookie yields zero prefs (never an
@@ -123,6 +136,21 @@ func TestPrefsDecodeLenient(t *testing.T) {
 	p := prefsGet(t, app, "/clusters/test/namespaces/default/pods", "v1.!!!", nil)
 	if got := p.texts("table.ro-table td.cell-name"); strings.Join(got, "|") != "nginx|my-app" {
 		t.Fatalf("junk-cookie render rows = %v, want the plain fixture order", got)
+	}
+}
+
+// TestPrefsRawURLNewlineParity pins the non-obvious RawURLEncoding rule shared
+// with the browser decoder: CR and LF are ignored anywhere in the payload, but
+// other ASCII whitespace is not.
+func TestPrefsRawURLNewlineParity(t *testing.T) {
+	for _, value := range []string{"v1.\r\ne30", "v1.e\r\n30", "v1.e\n3\r0\n"} {
+		p, ok := decodePrefs(value)
+		if !ok || len(p.Kinds) != 0 || p.Refresh != "" || len(p.Namespaces) != 0 {
+			t.Fatalf("decodePrefs(%q) = (%+v, %v), want accepted empty prefs", value, p, ok)
+		}
+	}
+	if p, ok := decodePrefs("v1.e\t30"); ok || len(p.Kinds) != 0 || p.Refresh != "" || len(p.Namespaces) != 0 {
+		t.Fatalf("decodePrefs with tab = (%+v, %v), want zero prefs and ok=false", p, ok)
 	}
 }
 
@@ -481,19 +509,14 @@ func TestPrefsReadoutJSContract(t *testing.T) {
 		"#namespace-dropdown [data-ro-action='pick-namespace']", // the namespace-switch surface
 		"localStorage.getItem(REFRESH_KEY)",                     // the read-once roRefresh migration
 		"refreshMode",                                           // cookie-canonical mode reader
-		// readPrefs drops wrongly-typed INNER fields instead of perpetuating
-		// them: Go's decodePrefs rejects the whole payload on one mistyped
-		// field (json.Unmarshal is all-or-nothing), so a passthrough JS reader
-		// would keep rewriting a cookie SSR can never apply. Field-level type
-		// guards make the next JS write self-heal the cookie.
-		"typeof e.sort === 'string'",              // kind sort kept only as a string
-		"Array.isArray(e.hide) && e.hide.every",   // hide kept only as an all-string array
-		"typeof decoded.ns[cluster] === 'string'", // ns map rebuilt from string values only
 	} {
 		if !strings.Contains(js, needle) {
 			t.Fatalf("readout.js prefs contract missing %q", needle)
 		}
 	}
+	// Decoder normalization is behavior-tested in prefs.test.ts against the
+	// shared Go/TypeScript golden fixtures. Do not pin its emitted JavaScript
+	// spelling here: equivalent iteration or narrowing must remain a safe refactor.
 	// The sort-write hook treats programmatic traffic as do-not-write: the
 	// RO-No-Push marker and preload warm-ups are guarded in the SAME
 	// beforeRequest gate (one expression) that then discriminates on the

--- a/internal/web/testdata/prefs_golden/07_corrupt_decode.json
+++ b/internal/web/testdata/prefs_golden/07_corrupt_decode.json
@@ -1,5 +1,5 @@
 {
-  "doc": "Decode-direction fixtures: malformed cookie values that must yield empty prefs (ok=false), never an error -- the page renders as if no preferences existed. Mirrors readout.js readPrefs leniency.",
+  "doc": "Decode-direction fixtures: malformed cookie values that must yield empty prefs (ok=false), never an error -- the page renders as if no preferences existed. Shared by Go and TypeScript, including RawURLEncoding alphabet/padding parity.",
   "decode_cases": [
     {
       "why": "no version prefix",
@@ -19,6 +19,21 @@
     {
       "why": "invalid base64url",
       "value": "v1.@@@not-base64@@@",
+      "want_ok": false
+    },
+    {
+      "why": "padded base64url is not RawURLEncoding",
+      "value": "v1.e30=",
+      "want_ok": false
+    },
+    {
+      "why": "standard base64 alphabet is not RawURLEncoding",
+      "value": "v1.eyJyZWZyZXNoIjoi4KC+4KC/In0",
+      "want_ok": false
+    },
+    {
+      "why": "UTF-8 BOM before JSON is not accepted",
+      "value": "v1.77u_e30",
       "want_ok": false
     },
     {

--- a/internal/web/testdata/prefs_golden/08_namespace_key_order.json
+++ b/internal/web/testdata/prefs_golden/08_namespace_key_order.json
@@ -1,0 +1,20 @@
+{
+  "doc": "Namespace-map canonical JSON: Go encoding/json sorts map keys lexicographically by UTF-8 bytes and always escapes U+2028/U+2029. The input order is deliberately non-canonical; 2/10 catch JavaScript's numeric property enumeration, a/aa exercise prefix ordering, __proto__/constructor/toString pin special own keys, U+E000 versus U+10000 catches default JavaScript UTF-16 sorting (which orders the astral key first while UTF-8 orders U+E000 first), and the line/paragraph separators catch JSON.stringify's literal spelling.",
+  "payload": {
+    "kinds": [],
+    "refresh": "",
+    "ns": {
+      "\ud800\udc00": "astral",
+      "\ue000": "bmp-private",
+      "2": "two",
+      "aa": "double-a",
+      "a": "single-a",
+      "10": "ten",
+      "toString": "string-ns",
+      "__proto__": "proto-ns",
+      "constructor": "constructor-ns",
+      "\u2028": "line\u2029separator"
+    }
+  },
+  "encoded": "v1.eyJucyI6eyIxMCI6InRlbiIsIjIiOiJ0d28iLCJfX3Byb3RvX18iOiJwcm90by1ucyIsImEiOiJzaW5nbGUtYSIsImFhIjoiZG91YmxlLWEiLCJjb25zdHJ1Y3RvciI6ImNvbnN0cnVjdG9yLW5zIiwidG9TdHJpbmciOiJzdHJpbmctbnMiLCJcdTIwMjgiOiJsaW5lXHUyMDI5c2VwYXJhdG9yIiwi7oCAIjoiYm1wLXByaXZhdGUiLCLwkICAIjoiYXN0cmFsIn19"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,14 @@
       "name": "readout-assets",
       "devDependencies": {
         "@biomejs/biome": "2.5.5",
+        "@stryker-mutator/core": "10.0.0",
+        "@stryker-mutator/typescript-checker": "10.0.0",
+        "@stryker-mutator/vitest-runner": "10.0.0",
         "@testing-library/dom": "10.4.1",
         "@testing-library/jest-dom": "7.0.1",
         "@types/node": "24.13.3",
+        "@typescript/legacy": "npm:@typescript/typescript6@6.0.2",
+        "@typescript/native": "npm:typescript@7.0.2",
         "@vitest/coverage-v8": "4.1.11",
         "esbuild": "0.28.1",
         "jsdom": "30.0.1",
@@ -18,7 +23,7 @@
         "vitest": "4.1.11"
       },
       "engines": {
-        "node": ">=24.15.0 <25"
+        "node": ">=24.19.0 <25"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -76,6 +81,533 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/compat-data": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+      "integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+      "integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-compilation-targets": "^8.0.0",
+        "@babel/helpers": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/template": "^8.0.0",
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@types/gensync": "^1.0.5",
+        "convert-source-map": "^2.0.0",
+        "empathic": "^2.0.1",
+        "gensync": "^1.0.0-beta.2",
+        "import-meta-resolve": "^4.2.0",
+        "json5": "^2.2.3",
+        "obug": "^2.1.1",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/code-frame": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/parser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/generator": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "@types/jsesc": "^2.5.0",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@babel/parser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-8.0.0.tgz",
+      "integrity": "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+      "integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^8.0.0",
+        "@babel/helper-validator-option": "^8.0.0",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^11.0.0",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-8.0.1.tgz",
+      "integrity": "sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-member-expression-to-functions": "^8.0.0",
+        "@babel/helper-optimise-call-expression": "^8.0.0",
+        "@babel/helper-replace-supers": "^8.0.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+        "@babel/traverse": "^8.0.0",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+      "integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-8.0.0.tgz",
+      "integrity": "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-8.0.0.tgz",
+      "integrity": "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-8.0.1.tgz",
+      "integrity": "sha512-UgAhl1kqiW5ciE0yCXqqvnb4H2n3IELJ7lIIQRezwDPilPEZX5i+Rvbja9MFTkwUn2biEiSMeV31aUzR4Lwakw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "@babel/traverse": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-8.0.0.tgz",
+      "integrity": "sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+      "integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-8.0.1.tgz",
+      "integrity": "sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^8.0.0",
+        "@babel/helper-optimise-call-expression": "^8.0.0",
+        "@babel/traverse": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-8.0.0.tgz",
+      "integrity": "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
@@ -96,6 +628,64 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+      "integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
     "node_modules/@babel/parser": {
       "version": "7.29.8",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
@@ -112,6 +702,285 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/plugin-proposal-decorators": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-8.0.2.tgz",
+      "integrity": "sha512-+C6O6KKXU7BBq1GNaIkFJxrALUVGRcr+WeWm4OcuRl3h+l/CmNfcTLMrT2Lm3uvGBimBH/8pEBRrXJFLoO67Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/plugin-syntax-decorators": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-decorators": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-8.0.1.tgz",
+      "integrity": "sha512-NI+0S/6MvR6GlcQFwjDZ+WIc2qvG6TXN534lYs9llNldwW4b7Dh6KTtk030FA0xWdYGs4t1lWo+OEWN8wGB+Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-8.0.1.tgz",
+      "integrity": "sha512-n0jtCOxEovhU7METqSQjcZO9pX53nu9uNIjMS+hEt+Nt9jA7oOZoBIgbCxhhASmF6T6rPDGge5UAvh6Z4eFz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-8.0.3.tgz",
+      "integrity": "sha512-jmTPwps7oSQSZaV1SxkQ3C12UWyufGysGc5OzDpZzvPAIX4mO7dJT3hoqkWVrSImvkcMiknir1iLN1SNV/CZzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-destructuring": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-8.0.1.tgz",
+      "integrity": "sha512-RtR8uLDl0QcCmqMNIkM8gmDeYZ3rS0ZH+sa+I6sfc09yFoqfp9AEPgBstq9KyfVb0lFCVSRFfJXCI70FIl5ccw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-explicit-resource-management": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-8.0.1.tgz",
+      "integrity": "sha512-VzDIYwBlLCpV6mJfloRdJm8HmYnMqs7O+bGha8yfg2kP7jAdxeCw6yZBVBeaKKQUThtSU52iy+3lB7DhYsbOBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/plugin-transform-destructuring": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-8.0.1.tgz",
+      "integrity": "sha512-PMuzulWrrzFNmY3lXSk/tV9NRb7y0eZZLJY4UEo2TKszroxvUZHAPPi+T9FDyrQhod+TQA+t+8/QYaaMpiEuhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-display-name": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-8.0.1.tgz",
+      "integrity": "sha512-soLishXlkyu6jcICPyO3HEP7A3GCzKEnn7XfvYrImuWEOwFAz93qShmWSYPf5ww0ZkO4By0zsN2bVIDF54fSdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-8.0.1.tgz",
+      "integrity": "sha512-NgkoF7Uq+30TmOPDdNUimT0Nta02uVjqJRFNlVWKrbOCu/CkzfHa4aMnIs0lMpkMmZmWA1e42Va+F04i/pY1zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-module-imports": "^8.0.0",
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/plugin-syntax-jsx": "^8.0.1",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-development": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-8.0.1.tgz",
+      "integrity": "sha512-Hb+HUZpV9KFHjm+F+P3aLDMi8QXU9l3ROCQv20z18Me2sGyW5nNNR5YTevNlgHvCpFek3BnAwhDGq/BRndXViw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-pure-annotations": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-8.0.1.tgz",
+      "integrity": "sha512-7/8UwU8hoPBurXa9tUiTTC8aACTRy5tCqLUtqikHp2eGiWoEB57AduOdbQ71OOMTEvawKrGhv3WfzkDpI+/oSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-8.0.1.tgz",
+      "integrity": "sha512-0Svqp3413Eg0GElldykF/T7SNsxQO5YVGD70fZyAdZTnX8WRgcopmbiU7GTa5xY5ZnJcEpNbfns8/GjX+/1yeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-create-class-features-plugin": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+        "@babel/plugin-syntax-typescript": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/preset-react": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-8.0.1.tgz",
+      "integrity": "sha512-jrFuPp/pTddFZbtmWhdLNAYc6UMcpboeUPnw0BBrm4nOmcAko/1TRcFi1PzWCeOFRU+VaSiKmat87W1HvR7mIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-validator-option": "^8.0.0",
+        "@babel/plugin-transform-react-display-name": "^8.0.1",
+        "@babel/plugin-transform-react-jsx": "^8.0.1",
+        "@babel/plugin-transform-react-jsx-development": "^8.0.1",
+        "@babel/plugin-transform-react-pure-annotations": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-8.0.1.tgz",
+      "integrity": "sha512-qrPhQIN1NLrPmzgazF9XKQqXrOcp/WJly+K+6ReFonn24FZqRJO7clxOJo6Ni75L+2vAqI3cHVU2OJLBxoPp5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-validator-option": "^8.0.0",
+        "@babel/plugin-transform-modules-commonjs": "^8.0.1",
+        "@babel/plugin-transform-typescript": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
@@ -121,6 +990,182 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/template": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+      "integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/code-frame": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/parser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/traverse": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+      "integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-globals": "^8.0.0",
+        "@babel/parser": "^8.0.4",
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.4",
+        "obug": "^2.1.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/parser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/types": {
       "version": "7.29.8",
@@ -934,6 +1979,361 @@
         }
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.2.tgz",
+      "integrity": "sha512-Y5/bAScMy5Y+9isCx0SKbyJebMCaXXX5em0kxkj115eZNscgV9srOHrgyfS0e5xAVymIfOh9piYBKDILktsMMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^12.0.0",
+        "@inquirer/figures": "^2.0.8",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.2.0.tgz",
+      "integrity": "sha512-SKXarWrYhtpqOEctf9XGCGy29QjsvJAM0Aq9ZR9z4Ns94OmpqudOly+aSEfNqUf9SwsQaUgY9+Z8hyzG0xX8fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.0",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.0.tgz",
+      "integrity": "sha512-+nnvFEXIB08CZNVXpvW3B+zHW96QXvGUjNKJ8NJIPqAZi5Kd4WhYt2S3C234ReepG1qw2HOlEUbjYVHBowXObA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.8",
+        "@inquirer/type": "^4.0.7",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.0.tgz",
+      "integrity": "sha512-nnsP/IdJ8s83q7ZuObmgn12QM+uLCkab9E0Oordojbn62WUg1c+v9Ou/F/057pgh0ppX0W+Hj5bO/Dp5hsxQtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.0",
+        "@inquirer/external-editor": "^3.0.4",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.2.tgz",
+      "integrity": "sha512-OWIH1IyyWqEKIyqC9Xy+Bnga7NkGMovFdo4atYZMUOTRqf6rO2WCv9E/1MyzvOErDBCxs+9UFliRUDc50xs/jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.0",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.4.tgz",
+      "integrity": "sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
+      "integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.3.tgz",
+      "integrity": "sha512-F/BZHtyEzP+HO+IGVd4AjBRgvX/ywm42bx8S0+dENk2YclzE9tJ3X/15THwtT6ehApmKvdYDMsVTuyyDod0gOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.0",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.0.tgz",
+      "integrity": "sha512-ew+fSDijsQ/WhD4TV3XLb+if400cDuzTzHfGR8sTNBXkK9CYDWoGE8fhaO8GbT312pNv1AJEOsDxy/z/HVettA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.0",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.2.tgz",
+      "integrity": "sha512-nSdufycW8xynEVssFkNQEYIzTySilog0UlfOVRwh3pXzPSk4frXUT2jZWjHnKae6RU9PaoF9wfy1pGwewQuqGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^12.0.0",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.6.0.tgz",
+      "integrity": "sha512-WgBVDRy3IQ4v9XMCpQ1YDGpso2PcMUxYJzZdH4Nt4t0eoXhEPmOCh5iZbXbR4GTbdUB9VPWBbJB12rkjbaGDCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.2.2",
+        "@inquirer/confirm": "^6.2.0",
+        "@inquirer/editor": "^5.3.0",
+        "@inquirer/expand": "^5.1.2",
+        "@inquirer/input": "^5.1.3",
+        "@inquirer/number": "^4.2.0",
+        "@inquirer/password": "^5.1.2",
+        "@inquirer/rawlist": "^5.3.2",
+        "@inquirer/search": "^4.3.0",
+        "@inquirer/select": "^5.2.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.2.tgz",
+      "integrity": "sha512-oPSKrYK1X1bMkjXDzIKHUkJp195LFSfgbnVtXnjSKGFjrCbS6I+wyvfAZTwKE9BSt3HwWgfD7JfsXALBgCogzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.0",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.0.tgz",
+      "integrity": "sha512-HFxXE5w727ctSUcAwrDquftJGjMgu36OeV5SHEXMlr2j/ahzmRX9xSEeVolV8tzYnTf45cg6vGkdMMRdm3RPhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.0",
+        "@inquirer/figures": "^2.0.8",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.2.tgz",
+      "integrity": "sha512-RkI8dRHWt+bh04oLixvF1kFzKC7e5rqJoHKkzcqSHATebBXFC6GmrT8ddbVkgSzLV0HnHs2cPFuBINr8otij8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^12.0.0",
+        "@inquirer/figures": "^2.0.8",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1252,12 +2652,211 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@stryker-mutator/api": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-10.0.0.tgz",
+      "integrity": "sha512-ZtAJ0ZT3MVRCWJTBE2h90XB/6E+4lifHYtcTyNG6nU2nLekPgTo4gD5esjX6Okxo1b/JB4jJzyxYB54fwKAoJw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mutation-testing-metrics": "3.8.4",
+        "mutation-testing-report-schema": "3.8.4",
+        "tslib": "~2.8.0",
+        "typed-inject": "~5.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/core/-/core-10.0.0.tgz",
+      "integrity": "sha512-ZvMsRyaXQQ5e6Thcid9pkuODv6Fn9E3nrBQJUap+hcJuGJ4unm26afo3m6YKSjn8kinyxJ/3TXf0cTWRDaTxVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@inquirer/prompts": "^8.0.0",
+        "@stryker-mutator/api": "10.0.0",
+        "@stryker-mutator/instrumenter": "10.0.0",
+        "@stryker-mutator/util": "10.0.0",
+        "ajv": "~8.20.0",
+        "chalk": "~5.6.0",
+        "commander": "~14.0.0",
+        "diff-match-patch": "1.0.5",
+        "emoji-regex": "~10.6.0",
+        "execa": "~9.6.0",
+        "json-rpc-2.0": "^1.7.0",
+        "lodash.groupby": "~4.6.0",
+        "minimatch": "~10.2.4",
+        "mutation-server-protocol": "~0.4.0",
+        "mutation-testing-elements": "3.8.4",
+        "mutation-testing-metrics": "3.8.4",
+        "mutation-testing-report-schema": "3.8.4",
+        "npm-run-path": "~6.0.0",
+        "progress": "~2.0.3",
+        "rxjs": "~7.8.1",
+        "semver": "^7.6.3",
+        "source-map": "~0.7.4",
+        "tree-kill": "~1.2.2",
+        "tslib": "2.8.1",
+        "typed-inject": "~5.0.0",
+        "typed-rest-client": "~2.3.0"
+      },
+      "bin": {
+        "stryker": "bin/stryker.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/instrumenter/-/instrumenter-10.0.0.tgz",
+      "integrity": "sha512-B7Wmn1KlEWyFeOz6D6oGvQGRfi5Xw3VemG6dEKvFQp4qLvxD9Mf4kcZghfxffgnYwXd3bFgqXsJ+ZGlhdfIOrQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "~8.0.0",
+        "@babel/generator": "~8.0.0",
+        "@babel/parser": "~8.0.0",
+        "@babel/plugin-proposal-decorators": "~8.0.0",
+        "@babel/plugin-transform-explicit-resource-management": "^8.0.0",
+        "@babel/preset-react": "~8.0.0",
+        "@babel/preset-typescript": "~8.0.0",
+        "@babel/traverse": "~8.0.4",
+        "@stryker-mutator/api": "10.0.0",
+        "@stryker-mutator/util": "10.0.0",
+        "angular-html-parser": "~10.11.0",
+        "semver": "~7.8.0",
+        "tslib": "2.8.1",
+        "weapon-regex": "~2.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/parser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/typescript-checker": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/typescript-checker/-/typescript-checker-10.0.0.tgz",
+      "integrity": "sha512-GLvC0LVd8RJ5SxR3eFcgb7DFKmw07DYtPXs942z6Qh7l6p7YBnFyd7lPw7nvA9UKEYDd22embrFmLlyC1XJjXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stryker-mutator/api": "10.0.0",
+        "@stryker-mutator/util": "10.0.0",
+        "semver": "~7.8.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@stryker-mutator/core": "10.0.0",
+        "typescript": ">=3.6"
+      }
+    },
+    "node_modules/@stryker-mutator/util": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-10.0.0.tgz",
+      "integrity": "sha512-LzOpHiJaCp2ABQgnPMlrQQcsK43bd5Vo/2FGL78aN62yDoeRQ+4j3tzeuXxK5OAHdC3fUz6TDoy4IsoAuLAd3w==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@stryker-mutator/vitest-runner": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/vitest-runner/-/vitest-runner-10.0.0.tgz",
+      "integrity": "sha512-SHK2/vfvRUpiz7jXPnQMBnr6zLdm69DK03Mo5mPhaZWcRSygrKUqYsPqWsXsK+5ySHzlMTfCyFK5NQ/X9sJFFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stryker-mutator/api": "10.0.0",
+        "@stryker-mutator/util": "10.0.0",
+        "semver": "^7.7.4",
+        "tslib": "~2.8.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@stryker-mutator/core": "10.0.0",
+        "vitest": ">=2.0.0"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
@@ -1347,6 +2946,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/gensync": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.5.tgz",
+      "integrity": "sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.13.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
@@ -1355,6 +2968,71 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@typescript/legacy": {
+      "name": "@typescript/typescript6",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript6/-/typescript6-6.0.2.tgz",
+      "integrity": "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@typescript/old": "npm:typescript@^6"
+      },
+      "bin": {
+        "tsc6": "bin/tsc6"
+      }
+    },
+    "node_modules/@typescript/native": {
+      "name": "typescript",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/@typescript/old": {
+      "name": "typescript",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
@@ -1841,6 +3519,33 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/angular-html-parser": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/angular-html-parser/-/angular-html-parser-10.11.0.tgz",
+      "integrity": "sha512-3vERzJ65UFDr3C7uozLJwsNcQS3FS784dSh583oDgDTTZMgXe3/pdyXgKndxiP5R2lvYRfW6gSl145Hnyf2OFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1903,6 +3608,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.19.tgz",
+      "integrity": "sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -1912,6 +3640,105 @@
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -1923,12 +3750,67 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
@@ -1997,6 +3879,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2007,12 +3900,58 @@
         "node": ">=8"
       }
     },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.414",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.414.tgz",
+      "integrity": "sha512-aYlviXiaXBbzvKgyALpcMmqa3Np3sDr0XnZbEG62n2UpZFbEcjQ4EEMOLGzVPhwVnwTz0lvKY+GcARbunuHekw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/entities": {
       "version": "8.0.0",
@@ -2027,12 +3966,45 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
       "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -2076,6 +4048,16 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2086,6 +4068,33 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -2094,6 +4103,57 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
       }
     },
     "node_modules/fdir": {
@@ -2114,6 +4174,22 @@
         }
       }
     },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2129,6 +4205,95 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2137,6 +4302,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -2159,6 +4350,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -2169,12 +4398,65 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -2214,6 +4496,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2261,6 +4550,46 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-rpc-2.0": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/json-rpc-2.0/-/json-rpc-2.0-1.7.1.tgz",
+      "integrity": "sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/lightningcss": {
@@ -2536,6 +4865,13 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "11.5.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
@@ -2594,6 +4930,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -2609,6 +4955,76 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mutation-server-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mutation-server-protocol/-/mutation-server-protocol-0.4.1.tgz",
+      "integrity": "sha512-SBGK0j8hLDne7bktgThKI8kGvGTx3rY3LAeQTmOKZ5bVnL/7TorLMvcVF7dIPJCu5RNUWhkkuF53kurygYVt3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^4.1.12"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mutation-testing-elements": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/mutation-testing-elements/-/mutation-testing-elements-3.8.4.tgz",
+      "integrity": "sha512-5CF1SNa7at5ZH33vEr+21wNebTSrtNIVvnzaUlxortHajOrIPaSLczIWvg6sI/fsExekQ7jookwf2cHftkckqQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/mutation-testing-metrics": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/mutation-testing-metrics/-/mutation-testing-metrics-3.8.4.tgz",
+      "integrity": "sha512-DZcmndJBH6nrNs3tpiB3OcMVq9KkG2cHCpJSnDxSxPwi9qrafRmoec40xjhkbzOoX1n7/4UkDqg5tIj4A6nvCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mutation-testing-report-schema": "3.8.4"
+      }
+    },
+    "node_modules/mutation-testing-report-schema": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/mutation-testing-report-schema/-/mutation-testing-report-schema-3.8.4.tgz",
+      "integrity": "sha512-s4G71R6Lt/PpZ0cqeglIcgyBdzLM8E+SeCHZAPg1wkSsPtRBa4XfPzAozYKdiJk/TLbNEEb7En9t0/bveuPuxA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/nanoid": {
@@ -2630,6 +5046,59 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
@@ -2644,6 +5113,19 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
@@ -2655,6 +5137,16 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pathe": {
@@ -2728,6 +5220,32 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2736,6 +5254,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/react-is": {
@@ -2803,6 +5338,23 @@
         "@rolldown/binding-win32-x64-msvc": "1.2.5"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -2829,12 +5381,134 @@
         "node": ">=10"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -2859,6 +5533,19 @@
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -2983,6 +5670,60 @@
         "node": ">=20"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/typed-inject": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/typed-inject/-/typed-inject-5.0.0.tgz",
+      "integrity": "sha512-0Ql2ORqBORLMdAW89TQKZsb1PQkFGImFfVmncXWe7a+AA3+7dh7Se9exxZowH4kbnlvKEFkMxUYdHUpjYWFJaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typed-rest-client": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.3.1.tgz",
+      "integrity": "sha512-k4kX5Up6qA68D0Cby2AK+6+vM5k3qTxe+/3FqhnHRExjY5cfbOnzjQZbP/LXleF8hVoDvDqxlgk9KK83HoBZlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "6.15.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.13.8"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
@@ -3018,6 +5759,13 @@
         "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/undici": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
@@ -3034,6 +5782,50 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
     },
     "node_modules/vite": {
       "version": "8.2.2",
@@ -3216,6 +6008,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/weapon-regex": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/weapon-regex/-/weapon-regex-2.0.4.tgz",
+      "integrity": "sha512-ubuhY5Lo4phWcMsJqe8j62m9uhsuo/VpfK5XsSgYGRGDSt10hwVwOBTriPRd0dac+KYbGNXOrfXjM6xCp2NUKg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -3251,6 +6050,22 @@
         "node": "^22.14.0 || >=24.0.0"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3284,6 +6099,29 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,25 +3,39 @@
   "private": true,
   "description": "Frontend asset build for readout: esbuild bundles internal/assets/src/js -> static/readout.js (IIFE), Lightning CSS bundles internal/assets/src/css -> static/readout.css. The Go binary embeds the static/ artifacts and builds with NO Node toolchain.",
   "engines": {
-    "node": ">=24.15.0 <25"
+    "node": ">=24.19.0 <25"
   },
-  "packageManager": "npm@11.12.1",
+  "packageManager": "npm@11.17.0",
+  "overrides": {
+    "qs": "6.15.3"
+  },
   "type": "module",
   "scripts": {
     "build": "node scripts/build-assets.mjs",
     "check": "npm run lint && npm run typecheck && npm run typecheck:test && npm run test:coverage",
-    "lint": "biome check internal/assets/src scripts vitest.config.ts",
+    "lint": "biome check internal/assets/src scripts vitest.config.ts stryker.config.mjs",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "test:mutation": "npm run test:mutation:full",
+    "test:mutation:check": "node scripts/check-mutation-report.mjs",
+    "test:mutation:dry": "npm run test:mutation:guards && node scripts/run-mutation.mjs --mode=dry --concurrency=1",
+    "test:mutation:full": "npm run test:mutation:guards && npm run test:mutation:run && npm run test:mutation:check",
+    "test:mutation:guards": "node --test scripts/mutation-infrastructure.test.mjs",
+    "test:mutation:run": "node scripts/run-mutation.mjs --mode=full",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "typecheck:test": "tsc -p tsconfig.test.json --noEmit"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.5",
+    "@stryker-mutator/core": "10.0.0",
+    "@stryker-mutator/typescript-checker": "10.0.0",
+    "@stryker-mutator/vitest-runner": "10.0.0",
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "7.0.1",
     "@types/node": "24.13.3",
+    "@typescript/legacy": "npm:@typescript/typescript6@6.0.2",
+    "@typescript/native": "npm:typescript@7.0.2",
     "@vitest/coverage-v8": "4.1.11",
     "esbuild": "0.28.1",
     "jsdom": "30.0.1",

--- a/scripts/build-assets.mjs
+++ b/scripts/build-assets.mjs
@@ -23,9 +23,9 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as esbuild from 'esbuild';
 import { bundle as lightningBundle } from 'lightningcss';
+import { frontendJavaScriptBuildOptions } from './frontend-build-config.mjs';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
-const SRC_JS = join(repoRoot, 'internal/assets/src/js/readout.ts');
 const SRC_CSS = join(repoRoot, 'internal/assets/src/css/readout.css');
 const OUT_JS = join(repoRoot, 'internal/assets/static/readout.js');
 const OUT_CSS = join(repoRoot, 'internal/assets/static/readout.css');
@@ -36,17 +36,7 @@ function fail(msg) {
 
 // --- JS: esbuild -> classic IIFE ------------------------------------------
 async function buildJS() {
-  const result = await esbuild.build({
-    entryPoints: [SRC_JS],
-    bundle: true,
-    format: 'iife',
-    target: 'es2022',
-    minify: false,
-    sourcemap: false,
-    legalComments: 'none',
-    charset: 'utf8',
-    write: false,
-  });
+  const result = await esbuild.build(frontendJavaScriptBuildOptions(repoRoot));
   const out = result.outputFiles[0].text;
 
   // (strict-mode) the legacy bundle assumes 'use strict'; the IIFE wrapper must

--- a/scripts/check-mutation-report.mjs
+++ b/scripts/check-mutation-report.mjs
@@ -1,0 +1,290 @@
+// Fail the mutation quality gate on any unresolved or incomplete mutant. A
+// perfect Stryker score alone is insufficient because timed-out mutants count
+// as detected, so the report statuses are checked directly.
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import {
+  assertImportOnlyModuleSource,
+  assertMutationScopeMatchesRuntimeGraph,
+  assertTypeOnlyModuleSource,
+  verifyFullRunAttestation,
+} from './mutation-integrity.mjs';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const stagedCheckerHook = pathToFileURL(
+  join(repoRoot, '.mutation-stage', 'scripts', 'stryker-typescript-hook.mjs'),
+).href;
+const requiredMutatePatterns = [
+  'internal/assets/src/js/**/*.ts',
+  '!internal/assets/src/js/**/*.test.ts',
+  '!internal/assets/src/js/test/**',
+  '!internal/assets/src/js/types.ts',
+];
+const zeroMutantFiles = new Set(['internal/assets/src/js/readout.ts']);
+const statusOrder = [
+  'Killed',
+  'CompileError',
+  'Survived',
+  'NoCoverage',
+  'Timeout',
+  'RuntimeError',
+  'Ignored',
+  'Pending',
+];
+const allowedStatuses = new Set(['Killed', 'CompileError']);
+const schemaVersionPattern = /^[12](?:\.(?:0|[1-9]\d*)){0,2}$/u;
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function assertPosition(position, path) {
+  assert(isObject(position), `${path} must be an object`);
+  assert(Number.isInteger(position.line) && position.line >= 1, `${path}.line must be >= 1`);
+  assert(Number.isInteger(position.column) && position.column >= 1, `${path}.column must be >= 1`);
+}
+
+function assertThreshold(value, path) {
+  assert(Number.isInteger(value) && value >= 0 && value <= 100, `${path} must be 0..100`);
+}
+
+function parseReport(raw) {
+  let report;
+  try {
+    report = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`invalid JSON in mutation report: ${error.message}`, { cause: error });
+  }
+
+  assert(isObject(report), 'report must be an object');
+  assert(
+    typeof report.schemaVersion === 'string' && schemaVersionPattern.test(report.schemaVersion),
+    'schemaVersion is missing or unsupported',
+  );
+  assert(isObject(report.thresholds), 'thresholds must be an object');
+  assertThreshold(report.thresholds.high, 'thresholds.high');
+  assertThreshold(report.thresholds.low, 'thresholds.low');
+  assertThreshold(report.thresholds.break, 'thresholds.break');
+  assert(
+    report.thresholds.high === 100 &&
+      report.thresholds.low === 100 &&
+      report.thresholds.break === 100,
+    'mutation thresholds must all be 100',
+  );
+  assert(isObject(report.config), 'config must be an object');
+  assert(report.config.dryRunOnly === false, 'final mutation report must not be a dry run');
+  assert(
+    report.config.coverageAnalysis === 'perTest',
+    'final mutation report must use per-test coverage analysis',
+  );
+  assert(report.config.ignoreStatic === false, 'ignoreStatic must be false');
+  assert(report.config.incremental === false, 'final mutation report must be non-incremental');
+  assert(
+    Array.isArray(report.config.ignorePatterns) && report.config.ignorePatterns.length === 0,
+    'ignorePatterns must be empty',
+  );
+  assert(
+    Array.isArray(report.config.ignorers) && report.config.ignorers.length === 0,
+    'ignorers must be empty',
+  );
+  assert(
+    Array.isArray(report.config.testFiles) && report.config.testFiles.length === 0,
+    'testFiles must use complete Vitest discovery',
+  );
+  assert(report.config.testRunner === 'vitest', 'final mutation report must use Vitest');
+  assert(
+    isObject(report.config.vitest) &&
+      report.config.vitest.configFile === 'vitest.config.ts' &&
+      report.config.vitest.related === true,
+    'final mutation report must use the complete related Vitest configuration',
+  );
+  assert(
+    Array.isArray(report.config.checkers) &&
+      report.config.checkers.length === 1 &&
+      report.config.checkers[0] === 'typescript',
+    'final mutation report must use the TypeScript checker',
+  );
+  assert(
+    report.config.tsconfigFile === 'tsconfig.json',
+    'final mutation report must use the production TypeScript config',
+  );
+  assert(
+    isObject(report.config.typescriptChecker) &&
+      report.config.typescriptChecker.experimentalNativePreview === true,
+    'final mutation report must use the native TypeScript checker',
+  );
+  assert(
+    Array.isArray(report.config.checkerNodeArgs) &&
+      report.config.checkerNodeArgs.length === 2 &&
+      report.config.checkerNodeArgs[0] === '--import' &&
+      report.config.checkerNodeArgs[1] === stagedCheckerHook,
+    'final mutation report must use the attested TypeScript compatibility hook',
+  );
+  assert(report.config.inPlace === false, 'inPlace must be false');
+  assert(report.config.tempDirName === '.stryker-tmp', 'tempDirName must be .stryker-tmp');
+  assert(report.config.cleanTempDir === 'always', 'cleanTempDir must be always');
+  assert(report.config.force === false, 'force must be false');
+  assert(report.config.allowEmpty === false, 'allowEmpty must be false');
+  assert(report.config.disableBail === false, 'disableBail must be false');
+  assert(report.config.symlinkNodeModules === true, 'symlinkNodeModules must be true');
+  assert(
+    Array.isArray(report.config.reporters) &&
+      ['clear-text', 'json', 'html'].every(
+        (reporter, index) => report.config.reporters[index] === reporter,
+      ) &&
+      report.config.reporters.length === 3,
+    'final mutation report must use the complete reporter set',
+  );
+  assert(
+    Array.isArray(report.config.mutate) &&
+      report.config.mutate.length === requiredMutatePatterns.length &&
+      requiredMutatePatterns.every((pattern, index) => report.config.mutate[index] === pattern),
+    'final mutation report must use the complete production TypeScript scope',
+  );
+  assert(isObject(report.config.mutator), 'config.mutator must be an object');
+  assert(
+    Array.isArray(report.config.mutator.excludedMutations) &&
+      report.config.mutator.excludedMutations.length === 0,
+    'excludedMutations must be empty',
+  );
+  assert(isObject(report.files), 'files must be an object');
+
+  const files = Object.entries(report.files);
+  assert(files.length > 0, 'files must not be empty');
+  const expectedFiles = assertMutationScopeMatchesRuntimeGraph(repoRoot);
+  const typesFileName = 'internal/assets/src/js/types.ts';
+  assertTypeOnlyModuleSource(typesFileName, readFileSync(join(repoRoot, typesFileName), 'utf8'));
+  for (const fileName of expectedFiles) {
+    const source = readFileSync(join(repoRoot, fileName), 'utf8');
+    assert(
+      !/\bStryker\s+(?:disable|restore)\b/iu.test(source),
+      `${fileName} contains a Stryker suppression comment`,
+    );
+  }
+  const actualFiles = files.map(([fileName]) => fileName).sort();
+  for (const fileName of zeroMutantFiles) {
+    assertImportOnlyModuleSource(fileName, readFileSync(join(repoRoot, fileName), 'utf8'));
+  }
+  const missingFiles = expectedFiles.filter(
+    (fileName) => !actualFiles.includes(fileName) && !zeroMutantFiles.has(fileName),
+  );
+  const unexpectedFiles = actualFiles.filter((fileName) => !expectedFiles.includes(fileName));
+  assert(
+    missingFiles.length === 0 && unexpectedFiles.length === 0,
+    `report scope mismatch: missing=[${missingFiles.join(', ')}], ` +
+      `unexpected=[${unexpectedFiles.join(', ')}]`,
+  );
+
+  const seenIds = new Set();
+  let mutantCount = 0;
+  for (const [fileName, file] of files) {
+    assert(fileName.trim().length > 0, 'file name must not be empty');
+    assert(isObject(file), `${fileName} must be an object`);
+    assert(typeof file.language === 'string', `${fileName}.language must be a string`);
+    assert(typeof file.source === 'string', `${fileName}.source must be a string`);
+    assert(
+      file.source === readFileSync(join(repoRoot, fileName), 'utf8'),
+      `${fileName}.source does not match the current working tree`,
+    );
+    assert(Array.isArray(file.mutants), `${fileName}.mutants must be an array`);
+    if (zeroMutantFiles.has(fileName)) {
+      assert(file.mutants.length === 0, `${fileName} must remain import-only`);
+    } else {
+      assert(file.mutants.length > 0, `${fileName}.mutants must not be empty`);
+    }
+
+    for (const [index, mutant] of file.mutants.entries()) {
+      const path = `${fileName}.mutants[${index}]`;
+      assert(isObject(mutant), `${path} must be an object`);
+      assert(typeof mutant.id === 'string' && mutant.id.length > 0, `${path}.id is required`);
+      assert(!seenIds.has(mutant.id), `${path}.id duplicates mutant ${mutant.id}`);
+      seenIds.add(mutant.id);
+      assert(
+        typeof mutant.mutatorName === 'string' && mutant.mutatorName.length > 0,
+        `${path}.mutatorName is required`,
+      );
+      assert(statusOrder.includes(mutant.status), `${path}.status is unknown: ${mutant.status}`);
+      assert(isObject(mutant.location), `${path}.location must be an object`);
+      assertPosition(mutant.location.start, `${path}.location.start`);
+      assertPosition(mutant.location.end, `${path}.location.end`);
+      mutantCount += 1;
+    }
+  }
+  assert(mutantCount > 0, 'report must contain at least one mutant');
+
+  return { files, mutantCount, schemaVersion: report.schemaVersion };
+}
+
+function emptyCounts() {
+  return Object.fromEntries(statusOrder.map((status) => [status, 0]));
+}
+
+function summarize(files) {
+  const totalCounts = emptyCounts();
+  const fileCounts = [];
+
+  for (const [fileName, file] of files) {
+    const counts = emptyCounts();
+    for (const mutant of file.mutants) {
+      counts[mutant.status] += 1;
+      totalCounts[mutant.status] += 1;
+    }
+    fileCounts.push({ fileName, counts, total: file.mutants.length });
+  }
+
+  return {
+    fileCounts: fileCounts.sort((left, right) => left.fileName.localeCompare(right.fileName)),
+    totalCounts,
+  };
+}
+
+function printSummary({ fileCounts, totalCounts }, schemaVersion, mutantCount) {
+  console.log(
+    `Mutation report schema ${schemaVersion}: ${fileCounts.length} files, ${mutantCount} mutants`,
+  );
+  console.log('Statuses:');
+  for (const status of statusOrder) {
+    console.log(`  ${status.padEnd(12)} ${totalCounts[status]}`);
+  }
+  console.log('Files:');
+  for (const { fileName, counts, total } of fileCounts) {
+    const statuses = statusOrder
+      .filter((status) => counts[status] > 0)
+      .map((status) => `${status}=${counts[status]}`)
+      .join(' ');
+    console.log(`  ${fileName}: total=${total} ${statuses}`);
+  }
+}
+
+try {
+  const verifiedRun = verifyFullRunAttestation(repoRoot);
+  const { files, mutantCount, schemaVersion } = parseReport(
+    verifiedRun.reportBytes.toString('utf8'),
+  );
+  const summary = summarize(files);
+  for (const { fileName, counts } of summary.fileCounts) {
+    assert(counts.Killed > 0, `${fileName} has no behaviorally killed mutant`);
+  }
+  printSummary(summary, schemaVersion, mutantCount);
+
+  const failures = statusOrder.filter(
+    (status) => !allowedStatuses.has(status) && summary.totalCounts[status] > 0,
+  );
+  if (failures.length > 0) {
+    const details = failures.map((status) => `${status}=${summary.totalCounts[status]}`).join(', ');
+    throw new Error(`unresolved mutation statuses: ${details}`);
+  }
+  // Re-read the proof and inputs after the structural/source checks so a file
+  // changed concurrently with this checker cannot leave a passing stale result.
+  verifyFullRunAttestation(repoRoot);
+  console.log('Mutation report check passed.');
+} catch (error) {
+  console.error(`Mutation report check failed: ${error.message}`);
+  process.exitCode = 1;
+}

--- a/scripts/frontend-build-config.mjs
+++ b/scripts/frontend-build-config.mjs
@@ -1,0 +1,19 @@
+export const frontendJavaScriptEntryRelativePath = 'internal/assets/src/js/readout.ts';
+
+// Keep the production bundle recipe in one place so asset generation and the
+// mutation runtime-graph proof cannot silently drift apart.
+export function frontendJavaScriptBuildOptions(repoRoot, overrides = {}) {
+  return {
+    absWorkingDir: repoRoot,
+    entryPoints: [frontendJavaScriptEntryRelativePath],
+    bundle: true,
+    format: 'iife',
+    target: 'es2022',
+    minify: false,
+    sourcemap: false,
+    legalComments: 'none',
+    charset: 'utf8',
+    write: false,
+    ...overrides,
+  };
+}

--- a/scripts/mutation-child.mjs
+++ b/scripts/mutation-child.mjs
@@ -1,0 +1,110 @@
+// Keep a uniquely titled process-group leader alive for the entire Stryker run.
+// The two-phase IPC handshake prevents both unpersisted starts and successful
+// workload exit from being mistaken for permission to outlive the launcher.
+
+import { spawn } from 'node:child_process';
+
+const [compatibilityHook, strykerBin, ...strykerArgs] = process.argv.slice(2);
+if (!compatibilityHook || !strykerBin || typeof process.send !== 'function') {
+  throw new Error('mutation child must be started by the guarded launcher');
+}
+
+let state = 'awaiting-start';
+let workloadResult;
+let releaseTimeout;
+
+function terminateOwnProcessGroup(reason) {
+  if (state === 'released' || state === 'stopping') return;
+  state = 'stopping';
+  clearTimeout(startTimeout);
+  if (releaseTimeout) clearTimeout(releaseTimeout);
+  process.exitCode = 1;
+  console.error(`[mutation-child] ${reason}; terminating unmonitored process group`);
+
+  // The launcher creates this process as a detached group leader, so pid is
+  // also the PGID. Keep this leader alive through SIGTERM, then include it in a
+  // forced group kill so descendants cannot outlive the resource monitor.
+  try {
+    process.kill(-process.pid, 'SIGTERM');
+  } catch (error) {
+    if (error.code !== 'ESRCH') {
+      console.error(`[mutation-child] process-group SIGTERM failed: ${error.message}`);
+    }
+  }
+  setTimeout(() => {
+    try {
+      process.kill(-process.pid, 'SIGKILL');
+    } catch (error) {
+      if (error.code !== 'ESRCH') {
+        console.error(`[mutation-child] process-group SIGKILL failed: ${error.message}`);
+      }
+      process.exit(1);
+    }
+  }, 1_000);
+}
+
+function reportWorkloadResult(code, signal) {
+  if (state !== 'running') return;
+  state = 'awaiting-release';
+  workloadResult = { code, signal: signal ?? null };
+  releaseTimeout = setTimeout(
+    () => terminateOwnProcessGroup('launcher did not release the completed process group'),
+    30_000,
+  );
+  try {
+    process.send({ type: 'result', ...workloadResult }, (error) => {
+      if (error) terminateOwnProcessGroup(`could not report workload result: ${error.message}`);
+    });
+  } catch (error) {
+    terminateOwnProcessGroup(`could not report workload result: ${error.message}`);
+  }
+}
+
+const startTimeout = setTimeout(
+  () => terminateOwnProcessGroup('launcher did not complete the start handshake'),
+  30_000,
+);
+
+process.on('disconnect', () => {
+  if (state !== 'released') terminateOwnProcessGroup('launcher IPC disconnected unexpectedly');
+});
+
+for (const signal of ['SIGHUP', 'SIGINT', 'SIGTERM']) {
+  process.on(signal, () => terminateOwnProcessGroup(`received ${signal}`));
+}
+
+process.on('message', (message) => {
+  if (state === 'awaiting-start') {
+    if (message?.type !== 'start' || message.processGroupId !== process.pid) {
+      terminateOwnProcessGroup('received an invalid start handshake');
+      return;
+    }
+    state = 'running';
+    clearTimeout(startTimeout);
+
+    const stryker = spawn(
+      process.execPath,
+      ['--import', compatibilityHook, strykerBin, 'run', ...strykerArgs],
+      {
+        env: process.env,
+        stdio: 'inherit',
+      },
+    );
+    stryker.once('error', (error) => {
+      console.error(`[mutation-child] could not start Stryker: ${error.message}`);
+      reportWorkloadResult(1, null);
+    });
+    stryker.once('close', (code, signal) => reportWorkloadResult(code, signal));
+    return;
+  }
+
+  if (state === 'awaiting-release' && message?.type === 'release') {
+    state = 'released';
+    clearTimeout(releaseTimeout);
+    process.exitCode = workloadResult.signal ? 1 : (workloadResult.code ?? 1);
+    if (process.connected) process.disconnect();
+    return;
+  }
+
+  terminateOwnProcessGroup('received an invalid IPC state transition');
+});

--- a/scripts/mutation-cli.mjs
+++ b/scripts/mutation-cli.mjs
@@ -1,0 +1,98 @@
+const defaultMaximumConcurrency = 2;
+
+function optionValue(args, index, optionName) {
+  const argument = args[index];
+  const equalsIndex = argument.indexOf('=');
+  if (equalsIndex !== -1) {
+    const value = argument.slice(equalsIndex + 1);
+    if (value.length === 0) throw new Error(`${optionName} requires a value`);
+    return { value, consumed: 0 };
+  }
+
+  const value = args[index + 1];
+  if (value === undefined || value.startsWith('-')) {
+    throw new Error(`${optionName} requires a value`);
+  }
+  return { value, consumed: 1 };
+}
+
+/**
+ * Parse the launcher's deliberately small CLI instead of forwarding arbitrary
+ * Stryker options. The selected mode determines the only Stryker arguments the
+ * launcher constructs: a dry run gets --dryRunOnly; a full run never does.
+ */
+export function parseMutationCliArguments(
+  args,
+  { maximumConcurrency = defaultMaximumConcurrency } = {},
+) {
+  let mode;
+  let concurrency;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === '--mode' || argument.startsWith('--mode=')) {
+      if (mode !== undefined) throw new Error('--mode may be specified only once');
+      const parsed = optionValue(args, index, '--mode');
+      mode = parsed.value;
+      index += parsed.consumed;
+      continue;
+    }
+
+    if (argument === '--concurrency' || argument.startsWith('--concurrency=')) {
+      if (concurrency !== undefined) {
+        throw new Error('mutation concurrency may be specified only once');
+      }
+      const parsed = optionValue(args, index, '--concurrency');
+      concurrency = parsed.value;
+      index += parsed.consumed;
+      continue;
+    }
+
+    if (argument === '-c') {
+      if (concurrency !== undefined) {
+        throw new Error('mutation concurrency may be specified only once');
+      }
+      const parsed = optionValue(args, index, '-c');
+      concurrency = parsed.value;
+      index += parsed.consumed;
+      continue;
+    }
+
+    if (/^-c(?:=)?.+/u.test(argument)) {
+      if (concurrency !== undefined) {
+        throw new Error('mutation concurrency may be specified only once');
+      }
+      concurrency = argument.slice(2).replace(/^=/u, '');
+      continue;
+    }
+
+    if (argument.startsWith('-')) {
+      throw new Error(`unsupported mutation launcher option: ${argument}`);
+    }
+    throw new Error(`unexpected positional mutation argument: ${argument}`);
+  }
+
+  if (mode !== 'dry' && mode !== 'full') {
+    throw new Error('--mode must be exactly "dry" or "full"');
+  }
+
+  const parsedConcurrency =
+    concurrency === undefined ? (mode === 'dry' ? 1 : 2) : Number(concurrency);
+  if (
+    !Number.isInteger(parsedConcurrency) ||
+    parsedConcurrency < 1 ||
+    parsedConcurrency > maximumConcurrency
+  ) {
+    throw new Error(`mutation concurrency must be an integer from 1 to ${maximumConcurrency}`);
+  }
+
+  return {
+    concurrency: parsedConcurrency,
+    mode,
+    strykerArgs: [
+      ...(mode === 'dry' ? ['--dryRunOnly'] : []),
+      '--concurrency',
+      String(parsedConcurrency),
+    ],
+  };
+}

--- a/scripts/mutation-host.mjs
+++ b/scripts/mutation-host.mjs
@@ -1,0 +1,47 @@
+import { accessSync, constants, realpathSync, statSync } from 'node:fs';
+import { delimiter, isAbsolute, join, relative, resolve, sep } from 'node:path';
+
+function isInside(root, candidate) {
+  const pathFromRoot = relative(root, candidate);
+  return (
+    pathFromRoot === '' ||
+    (pathFromRoot !== '..' && !pathFromRoot.startsWith(`..${sep}`) && !isAbsolute(pathFromRoot))
+  );
+}
+
+export function resolveSafeHostExecutable(name, { repoRoot, searchPath = process.env.PATH } = {}) {
+  if (typeof searchPath !== 'string' || searchPath.length === 0) {
+    throw new Error(`cannot locate required host executable ${name}: PATH is empty`);
+  }
+  const resolvedRepoRoot = resolve(repoRoot);
+  const canonicalRepoRoot = realpathSync(resolvedRepoRoot);
+
+  for (const entry of searchPath.split(delimiter)) {
+    // Empty and relative entries resolve through the current directory, while
+    // repository descendants can contain attacker-controlled lookalikes. They
+    // are never eligible sources for resource-inspection commands.
+    if (entry.length === 0 || !isAbsolute(entry)) continue;
+    const directory = resolve(entry);
+    if (isInside(resolvedRepoRoot, directory)) continue;
+
+    let canonicalDirectory;
+    try {
+      canonicalDirectory = realpathSync(directory);
+      if (!statSync(canonicalDirectory).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    if (isInside(canonicalRepoRoot, canonicalDirectory)) continue;
+
+    const candidate = join(canonicalDirectory, name);
+    try {
+      accessSync(candidate, constants.X_OK);
+      if (!statSync(candidate).isFile()) continue;
+      const canonicalCandidate = realpathSync(candidate);
+      if (!isInside(canonicalRepoRoot, canonicalCandidate)) return canonicalCandidate;
+    } catch {
+      // Continue through the safe absolute PATH entries.
+    }
+  }
+  throw new Error(`cannot locate a safe executable ${name} in PATH`);
+}

--- a/scripts/mutation-infrastructure.test.mjs
+++ b/scripts/mutation-infrastructure.test.mjs
@@ -1,0 +1,893 @@
+import assert from 'node:assert/strict';
+import { spawn, spawnSync } from 'node:child_process';
+import { once } from 'node:events';
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { buildSync } from 'esbuild';
+import { frontendJavaScriptBuildOptions } from './frontend-build-config.mjs';
+import { parseMutationCliArguments } from './mutation-cli.mjs';
+import { resolveSafeHostExecutable } from './mutation-host.mjs';
+import {
+  assertImportOnlyModuleSource,
+  assertMutationRuntimeEligible,
+  assertMutationScopeMatchesRuntimeGraph,
+  assertTypeOnlyModuleSource,
+  createFullRunAttestation,
+  createMutationInputStage,
+  fullRunAttestationRelativePath,
+  invalidateFullMutationReport,
+  mutationHtmlReportRelativePath,
+  mutationLockRelativePath,
+  mutationLogRelativePath,
+  mutationRecoveryRelativePath,
+  mutationReportRelativePath,
+  mutationStagePath,
+  openMutationLogFile,
+  publishFullMutationReports,
+  removeMutationInputStage,
+  snapshotMutationInputs,
+  verifyFullRunAttestation,
+  writeFullRunAttestation,
+} from './mutation-integrity.mjs';
+import { acquireMutationLock } from './mutation-lock.mjs';
+
+const fixedFixtureInputs = [
+  '.mise.toml',
+  'internal/assets/static/readout.js',
+  'package-lock.json',
+  'package.json',
+  'scripts/build-assets.mjs',
+  'scripts/check-mutation-report.mjs',
+  'scripts/frontend-build-config.mjs',
+  'scripts/mutation-child.mjs',
+  'scripts/mutation-cli.mjs',
+  'scripts/mutation-infrastructure.test.mjs',
+  'scripts/mutation-host.mjs',
+  'scripts/mutation-integrity.mjs',
+  'scripts/mutation-lock.mjs',
+  'scripts/run-mutation.mjs',
+  'scripts/stryker-typescript-hook.mjs',
+  'stryker.config.mjs',
+  'tsconfig.json',
+  'tsconfig.test.json',
+  'vitest.config.ts',
+];
+
+function writeFixtureFile(repoRoot, fileName, contents = `${fileName}\n`) {
+  const path = join(repoRoot, fileName);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents);
+}
+
+function makeFixture(t) {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'readout-mutation-guard-'));
+  t.after(() => rmSync(repoRoot, { force: true, recursive: true }));
+  for (const fileName of fixedFixtureInputs) writeFixtureFile(repoRoot, fileName);
+  const nodeVersion = process.versions.node;
+  const nextNodeMajor = Number(nodeVersion.split('.')[0]) + 1;
+  writeFixtureFile(repoRoot, '.mise.toml', `[tools]\nnode = "${nodeVersion}"\n`);
+  writeFixtureFile(
+    repoRoot,
+    'package.json',
+    `${JSON.stringify({ engines: { node: `>=${nodeVersion} <${nextNodeMajor}` } })}\n`,
+  );
+  writeFixtureFile(repoRoot, 'tsconfig.json', '{}\n');
+  writeFixtureFile(repoRoot, 'tsconfig.test.json', '{"extends":"./tsconfig.json"}\n');
+  writeFixtureFile(repoRoot, 'internal/assets/src/js/runtime.ts', 'export const answer = 42;\n');
+  writeFixtureFile(
+    repoRoot,
+    'internal/assets/src/js/types.ts',
+    'export interface Answer { n: number }\n',
+  );
+  writeFixtureFile(repoRoot, 'internal/assets/src/js/readout.ts', "import './runtime.js';\n");
+  const bundle = buildSync(frontendJavaScriptBuildOptions(repoRoot)).outputFiles[0].text;
+  writeFixtureFile(repoRoot, 'internal/assets/static/readout.js', bundle);
+  writeFixtureFile(repoRoot, 'internal/assets/src/js/runtime.test.ts', 'void 0;\n');
+  writeFixtureFile(repoRoot, 'internal/assets/src/js/test/setup.ts', 'void 0;\n');
+  mkdirSync(join(repoRoot, 'node_modules'));
+  writeFixtureFile(
+    repoRoot,
+    'internal/web/testdata/prefs_golden/01_simple.json',
+    '{"payload":{}}\n',
+  );
+  return repoRoot;
+}
+
+function attestFixture(repoRoot) {
+  const startedAt = new Date(Date.now() - 2_000).toISOString();
+  const reportBytes = Buffer.from('{"fresh":true}\n');
+  const htmlReportBytes = Buffer.from('<!doctype html><title>fresh mutation report</title>\n');
+  writeFixtureFile(repoRoot, mutationReportRelativePath, reportBytes);
+  writeFixtureFile(repoRoot, mutationHtmlReportRelativePath, htmlReportBytes);
+  const completedAt = new Date().toISOString();
+  const inputs = snapshotMutationInputs(repoRoot);
+  writeFullRunAttestation(
+    repoRoot,
+    createFullRunAttestation({
+      completedAt,
+      executionInputs: inputs,
+      htmlReportBytes,
+      inputs,
+      repoRoot,
+      reportBytes,
+      runId: '00000000-0000-4000-8000-000000000000',
+      startedAt,
+    }),
+  );
+}
+
+async function waitUntil(predicate, description, timeoutMilliseconds = 5_000) {
+  const deadline = Date.now() + timeoutMilliseconds;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(`timed out waiting for ${description}`);
+    await new Promise((resolveWait) => setTimeout(resolveWait, 20));
+  }
+}
+
+function childResult(child, timeoutMilliseconds = 8_000) {
+  return new Promise((resolveResult, rejectResult) => {
+    const timeout = setTimeout(() => {
+      rejectResult(new Error(`child ${child.pid} did not exit within ${timeoutMilliseconds}ms`));
+    }, timeoutMilliseconds);
+    child.once('error', (error) => {
+      clearTimeout(timeout);
+      rejectResult(error);
+    });
+    child.once('close', (code, signal) => {
+      clearTimeout(timeout);
+      resolveResult({ code, signal });
+    });
+  });
+}
+
+function childExitResult(child, timeoutMilliseconds = 8_000) {
+  return new Promise((resolveResult, rejectResult) => {
+    const timeout = setTimeout(() => {
+      rejectResult(new Error(`child ${child.pid} did not exit within ${timeoutMilliseconds}ms`));
+    }, timeoutMilliseconds);
+    child.once('error', (error) => {
+      clearTimeout(timeout);
+      rejectResult(error);
+    });
+    child.once('exit', (code, signal) => {
+      clearTimeout(timeout);
+      resolveResult({ code, signal });
+    });
+  });
+}
+
+function processGroupExists(processGroupId) {
+  try {
+    process.kill(-processGroupId, 0);
+    return true;
+  } catch (error) {
+    if (error.code === 'ESRCH') return false;
+    throw error;
+  }
+}
+
+test('launcher accepts only its mode-aware CLI', () => {
+  assert.deepEqual(parseMutationCliArguments(['--mode=full', '-c1']), {
+    concurrency: 1,
+    mode: 'full',
+    strykerArgs: ['--concurrency', '1'],
+  });
+  assert.deepEqual(parseMutationCliArguments(['--mode', 'dry']), {
+    concurrency: 1,
+    mode: 'dry',
+    strykerArgs: ['--dryRunOnly', '--concurrency', '1'],
+  });
+
+  for (const args of [
+    ['--mode=full', '-c99'],
+    ['--mode=full', 'positional'],
+    ['--mode=full', '--unknown'],
+    ['--mode=full', '--reporters=json'],
+    ['--mode=full', '--dryRunOnly'],
+    ['--mode=full', '--mode=dry'],
+  ]) {
+    assert.throws(() => parseMutationCliArguments(args), Error, args.join(' '));
+  }
+});
+
+test('TypeScript AST guards type-only and side-effect-import-only modules', () => {
+  assert.doesNotThrow(() =>
+    assertTypeOnlyModuleSource(
+      'types.ts',
+      "import type { A } from './a.js';\nexport interface B { a: A }\ndeclare global { interface Window { b: B } }\n",
+    ),
+  );
+  assert.throws(() => assertTypeOnlyModuleSource('types.ts', 'export const runtime = 1;\n'));
+  assert.doesNotThrow(() =>
+    assertImportOnlyModuleSource('readout.ts', "import './a.js';\nimport './b.js';\n"),
+  );
+  assert.throws(() =>
+    assertImportOnlyModuleSource('readout.ts', "import { value } from './a.js';\n"),
+  );
+  assert.throws(() => assertImportOnlyModuleSource('readout.ts', "import './a.js';\nrun();\n"));
+});
+
+test('mutation stage is an exact input snapshot isolated from working-tree ABA', (t) => {
+  const repoRoot = makeFixture(t);
+  const testPath = 'internal/assets/src/js/runtime.test.ts';
+  const originalTest = readFileSync(join(repoRoot, testPath));
+  const expectedInputs = snapshotMutationInputs(repoRoot);
+  const { inputs: stagedInputs, stageRoot } = createMutationInputStage(repoRoot, expectedInputs);
+
+  assert.deepEqual(stagedInputs, expectedInputs);
+  assert.equal(lstatSync(join(stageRoot, 'node_modules')).isSymbolicLink(), true);
+  assert.equal(
+    realpathSync(join(stageRoot, 'node_modules')),
+    realpathSync(join(repoRoot, 'node_modules')),
+  );
+
+  // The old endpoint-only proof missed this transient working-tree change.
+  // The staged test bytes used by Stryker remain the captured bytes throughout.
+  writeFixtureFile(repoRoot, testPath, 'throw new Error("transient");\n');
+  writeFixtureFile(repoRoot, testPath, originalTest);
+  assert.deepEqual(snapshotMutationInputs(repoRoot), expectedInputs);
+  assert.deepEqual(readFileSync(join(stageRoot, testPath)), originalTest);
+  assert.deepEqual(snapshotMutationInputs(stageRoot), expectedInputs);
+
+  removeMutationInputStage(repoRoot);
+  assert.equal(existsSync(stageRoot), false);
+});
+
+test('mutation staging rejects a changed source and removes its partial stage', (t) => {
+  const repoRoot = makeFixture(t);
+  const expectedInputs = snapshotMutationInputs(repoRoot);
+  writeFixtureFile(repoRoot, 'vitest.config.ts', 'export default { changed: true };\n');
+
+  assert.throws(
+    () => createMutationInputStage(repoRoot, expectedInputs),
+    /mutation input changed while staging: vitest\.config\.ts/u,
+  );
+  assert.equal(existsSync(mutationStagePath(repoRoot)), false);
+});
+
+test('stage cleanup unlinks an exact-path symlink without traversing its target', (t) => {
+  const repoRoot = makeFixture(t);
+  const externalRoot = mkdtempSync(join(tmpdir(), 'readout-stage-target-'));
+  t.after(() => rmSync(externalRoot, { force: true, recursive: true }));
+  const sentinelPath = join(externalRoot, 'sentinel');
+  writeFileSync(sentinelPath, 'keep\n');
+  symlinkSync(externalRoot, mutationStagePath(repoRoot), 'dir');
+
+  removeMutationInputStage(repoRoot);
+  assert.equal(existsSync(mutationStagePath(repoRoot)), false);
+  assert.equal(readFileSync(sentinelPath, 'utf8'), 'keep\n');
+});
+
+test('runtime graph guard rejects runtime code hidden under an excluded path', (t) => {
+  const repoRoot = makeFixture(t);
+  assert.doesNotThrow(() => assertMutationScopeMatchesRuntimeGraph(repoRoot));
+
+  writeFixtureFile(
+    repoRoot,
+    'internal/assets/src/js/test/hidden.ts',
+    'export const hiddenRuntime = true;\n',
+  );
+  writeFixtureFile(
+    repoRoot,
+    'internal/assets/src/js/readout.ts',
+    "import './runtime.js';\nimport './test/hidden.js';\n",
+  );
+  assert.throws(
+    () => assertMutationScopeMatchesRuntimeGraph(repoRoot),
+    /excluded-from-mutation=\[internal\/assets\/src\/js\/test\/hidden\.ts\]/u,
+  );
+
+  writeFixtureFile(repoRoot, 'internal/assets/src/outside.ts', 'export const outside = true;\n');
+  writeFixtureFile(
+    repoRoot,
+    'internal/assets/src/js/readout.ts',
+    "import './runtime.js';\nimport '../outside.js';\n",
+  );
+  assert.throws(
+    () => assertMutationScopeMatchesRuntimeGraph(repoRoot),
+    /project inputs outside the mutation root: \[internal\/assets\/src\/outside\.ts\]/u,
+  );
+
+  writeFixtureFile(repoRoot, 'internal/assets/src/outside.js', 'export const outside = true;\n');
+  writeFixtureFile(
+    repoRoot,
+    'internal/assets/src/js/readout.ts',
+    "import './runtime.js';\nimport '../outside.js';\n",
+  );
+  assert.throws(
+    () => assertMutationScopeMatchesRuntimeGraph(repoRoot),
+    /project inputs outside the mutation root: \[internal\/assets\/src\/outside\.js\]/u,
+  );
+
+  writeFixtureFile(repoRoot, 'internal/assets/src/outside.json', '{"outside":true}\n');
+  writeFixtureFile(
+    repoRoot,
+    'internal/assets/src/js/readout.ts',
+    "import outside from '../outside.json';\nvoid outside;\n",
+  );
+  assert.throws(
+    () => assertMutationScopeMatchesRuntimeGraph(repoRoot),
+    /project inputs outside the mutation root: \[internal\/assets\/src\/outside\.json\]/u,
+  );
+
+  writeFixtureFile(repoRoot, 'internal/assets/src/js/readout.ts', "import './runtime.js';\n");
+  writeFixtureFile(repoRoot, 'internal/assets/static/readout.js', 'stale bundle\n');
+  assert.throws(
+    () => assertMutationScopeMatchesRuntimeGraph(repoRoot),
+    /shipped frontend bundle is stale/u,
+  );
+});
+
+test('shared frontend build recipe is independent of the caller working directory', (t) => {
+  const repoRoot = makeFixture(t);
+  const callerRoot = mkdtempSync(join(tmpdir(), 'readout-build-caller-'));
+  t.after(() => rmSync(callerRoot, { force: true, recursive: true }));
+  const moduleUrl = new URL('./frontend-build-config.mjs', import.meta.url).href;
+  const esbuildUrl = new URL('../node_modules/esbuild/lib/main.js', import.meta.url).href;
+  const script = `
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+const { buildSync } = await import(${JSON.stringify(esbuildUrl)});
+const { frontendJavaScriptBuildOptions } = await import(${JSON.stringify(moduleUrl)});
+const repoRoot = ${JSON.stringify(repoRoot)};
+const built = buildSync(frontendJavaScriptBuildOptions(repoRoot)).outputFiles[0].text;
+const shipped = readFileSync(join(repoRoot, 'internal/assets/static/readout.js'), 'utf8');
+if (built !== shipped) throw new Error('shared frontend build changed with caller cwd');
+`;
+  const result = spawnSync(process.execPath, ['--input-type=module', '--eval', script], {
+    cwd: callerRoot,
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test('mutation artifacts never traverse a symlinked reports directory', (t) => {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'readout-report-root-'));
+  const externalRoot = mkdtempSync(join(tmpdir(), 'readout-report-external-'));
+  t.after(() => rmSync(repoRoot, { force: true, recursive: true }));
+  t.after(() => rmSync(externalRoot, { force: true, recursive: true }));
+  mkdirSync(join(repoRoot, 'reports'));
+  for (const fileName of ['full-run.json', 'mutation.json', 'index.html']) {
+    writeFileSync(join(externalRoot, fileName), `keep ${fileName}\n`);
+  }
+  symlinkSync(externalRoot, join(repoRoot, 'reports', 'mutation'), 'dir');
+
+  assert.throws(
+    () => invalidateFullMutationReport(repoRoot),
+    /mutation artifact directory must be a real directory/u,
+  );
+  for (const fileName of ['full-run.json', 'mutation.json', 'index.html']) {
+    assert.equal(readFileSync(join(externalRoot, fileName), 'utf8'), `keep ${fileName}\n`);
+  }
+});
+
+test('latest mutation log replaces links without truncating their targets', (t) => {
+  const repoRoot = makeFixture(t);
+  const externalRoot = mkdtempSync(join(tmpdir(), 'readout-log-target-'));
+  t.after(() => rmSync(externalRoot, { force: true, recursive: true }));
+  mkdirSync(join(repoRoot, 'reports', 'mutation'), { recursive: true });
+  const sentinelPath = join(externalRoot, 'sentinel.log');
+  const logPath = join(repoRoot, mutationLogRelativePath);
+  writeFileSync(sentinelPath, 'keep external bytes\n');
+
+  symlinkSync(sentinelPath, logPath);
+  let opened = openMutationLogFile(repoRoot);
+  closeSync(opened.descriptor);
+  assert.equal(opened.logPath, logPath);
+  assert.equal(readFileSync(sentinelPath, 'utf8'), 'keep external bytes\n');
+  assert.equal(lstatSync(logPath).isSymbolicLink(), false);
+
+  rmSync(logPath);
+  linkSync(sentinelPath, logPath);
+  opened = openMutationLogFile(repoRoot);
+  closeSync(opened.descriptor);
+  assert.equal(readFileSync(sentinelPath, 'utf8'), 'keep external bytes\n');
+  assert.equal(readFileSync(logPath, 'utf8'), '');
+});
+
+test('full report publication is explicit, atomic per file, and refuses overwrite', (t) => {
+  const repoRoot = makeFixture(t);
+  const reportBytes = Buffer.from('{"stage":true}\n');
+  const htmlReportBytes = Buffer.from('<!doctype html><title>stage</title>\n');
+
+  publishFullMutationReports(repoRoot, { htmlReportBytes, reportBytes });
+  assert.deepEqual(readFileSync(join(repoRoot, mutationReportRelativePath)), reportBytes);
+  assert.deepEqual(readFileSync(join(repoRoot, mutationHtmlReportRelativePath)), htmlReportBytes);
+  assert.equal(existsSync(join(repoRoot, fullRunAttestationRelativePath)), false);
+  assert.throws(
+    () => publishFullMutationReports(repoRoot, { htmlReportBytes, reportBytes }),
+    /refusing to overwrite an existing full-run artifact/u,
+  );
+  assert.deepEqual(readFileSync(join(repoRoot, mutationReportRelativePath)), reportBytes);
+});
+
+test('checker provenance rejects a stale unattested report', (t) => {
+  const repoRoot = makeFixture(t);
+  writeFixtureFile(repoRoot, mutationReportRelativePath, '{"stale":true}\n');
+  assert.throws(
+    () => verifyFullRunAttestation(repoRoot),
+    /cannot read a valid full-run attestation/u,
+  );
+});
+
+test('a full attempt invalidates every prior candidate report', (t) => {
+  const repoRoot = makeFixture(t);
+  for (const fileName of [
+    mutationReportRelativePath,
+    mutationHtmlReportRelativePath,
+    fullRunAttestationRelativePath,
+  ]) {
+    writeFixtureFile(repoRoot, fileName, 'stale\n');
+  }
+  invalidateFullMutationReport(repoRoot);
+  for (const fileName of [
+    mutationReportRelativePath,
+    mutationHtmlReportRelativePath,
+    fullRunAttestationRelativePath,
+  ]) {
+    assert.equal(existsSync(join(repoRoot, fileName)), false, fileName);
+  }
+});
+
+test('full-attempt invalidation removes proof before a malformed report path can fail', (t) => {
+  const repoRoot = makeFixture(t);
+  attestFixture(repoRoot);
+  const reportPath = join(repoRoot, mutationReportRelativePath);
+  rmSync(reportPath);
+  mkdirSync(reportPath);
+  writeFileSync(join(reportPath, 'cannot-unlink-as-a-file'), 'blocked\n');
+
+  assert.throws(() => invalidateFullMutationReport(repoRoot));
+  assert.equal(existsSync(join(repoRoot, fullRunAttestationRelativePath)), false);
+});
+
+test('checker provenance rejects a report changed after a successful full run', (t) => {
+  const repoRoot = makeFixture(t);
+  attestFixture(repoRoot);
+  writeFixtureFile(repoRoot, mutationReportRelativePath, '{"replaced":true}\n');
+  assert.throws(() => verifyFullRunAttestation(repoRoot), /report digest does not match/u);
+});
+
+test('checker provenance requires the attested HTML report', (t) => {
+  const repoRoot = makeFixture(t);
+  attestFixture(repoRoot);
+  rmSync(join(repoRoot, mutationHtmlReportRelativePath));
+  assert.throws(() => verifyFullRunAttestation(repoRoot), /ENOENT/u);
+});
+
+test('checker provenance binds the staged execution digest and requires stage cleanup', (t) => {
+  const repoRoot = makeFixture(t);
+  attestFixture(repoRoot);
+  const attestationPath = join(repoRoot, fullRunAttestationRelativePath);
+  const attestation = JSON.parse(readFileSync(attestationPath, 'utf8'));
+  attestation.execution.inputsSha256 = '0'.repeat(64);
+  writeFileSync(attestationPath, `${JSON.stringify(attestation)}\n`);
+  assert.throws(
+    () => verifyFullRunAttestation(repoRoot),
+    /execution inputs do not match the attested working-tree inputs/u,
+  );
+
+  attestFixture(repoRoot);
+  mkdirSync(mutationStagePath(repoRoot));
+  assert.throws(() => verifyFullRunAttestation(repoRoot), /mutation stage still exists/u);
+});
+
+test('checker provenance rejects changed or stale HTML reports', (t) => {
+  const repoRoot = makeFixture(t);
+  attestFixture(repoRoot);
+  writeFixtureFile(repoRoot, mutationHtmlReportRelativePath, '<html>replaced</html>\n');
+  assert.throws(() => verifyFullRunAttestation(repoRoot), /HTML report digest does not match/u);
+
+  attestFixture(repoRoot);
+  const staleTime = new Date(Date.now() - 60_000);
+  utimesSync(join(repoRoot, mutationHtmlReportRelativePath), staleTime, staleTime);
+  assert.throws(() => verifyFullRunAttestation(repoRoot), /HTML report timestamp falls outside/u);
+});
+
+test('checker provenance rejects a tampered frontend test', (t) => {
+  const repoRoot = makeFixture(t);
+  attestFixture(repoRoot);
+  writeFixtureFile(repoRoot, 'internal/assets/src/js/runtime.test.ts', 'throw new Error();\n');
+  assert.throws(
+    () => verifyFullRunAttestation(repoRoot),
+    /attested mutation inputs changed.*runtime\.test\.ts/u,
+  );
+});
+
+test('checker provenance rejects changed external Vitest test data', (t) => {
+  const repoRoot = makeFixture(t);
+  attestFixture(repoRoot);
+  writeFixtureFile(
+    repoRoot,
+    'internal/web/testdata/prefs_golden/01_simple.json',
+    '{"payload":{"changed":true}}\n',
+  );
+  assert.throws(
+    () => verifyFullRunAttestation(repoRoot),
+    /attested mutation inputs changed.*prefs_golden\/01_simple\.json/u,
+  );
+});
+
+test('checker provenance discovers newly added external Vitest test data', (t) => {
+  const repoRoot = makeFixture(t);
+  attestFixture(repoRoot);
+  writeFixtureFile(
+    repoRoot,
+    'internal/web/testdata/prefs_golden/02_new_case.json',
+    '{"payload":{"new":true}}\n',
+  );
+  assert.throws(
+    () => verifyFullRunAttestation(repoRoot),
+    /attested mutation inputs changed: added=\[internal\/web\/testdata\/prefs_golden\/02_new_case\.json\]/u,
+  );
+});
+
+test('runtime must match the exact mise pin and package engine', (t) => {
+  const repoRoot = makeFixture(t);
+  const nodeVersion = process.versions.node;
+  const major = Number(nodeVersion.split('.')[0]);
+
+  assert.doesNotThrow(() => assertMutationRuntimeEligible(repoRoot));
+  writeFixtureFile(repoRoot, '.mise.toml', '[tools]\nnode = "0.0.1"\n');
+  assert.throws(
+    () => assertMutationRuntimeEligible(repoRoot),
+    /does not match the exact mise pin/u,
+  );
+
+  writeFixtureFile(repoRoot, '.mise.toml', `[tools]\nnode = "${nodeVersion}"\n`);
+  writeFixtureFile(
+    repoRoot,
+    'package.json',
+    `${JSON.stringify({ engines: { node: `<${major}` } })}\n`,
+  );
+  assert.throws(
+    () => assertMutationRuntimeEligible(repoRoot),
+    /does not satisfy package\.json engines\.node/u,
+  );
+});
+
+test('checker provenance rejects a changed mise configuration', (t) => {
+  const repoRoot = makeFixture(t);
+  attestFixture(repoRoot);
+  writeFixtureFile(
+    repoRoot,
+    '.mise.toml',
+    `[tools]\nnode = "${process.versions.node}" # semantically unchanged\n`,
+  );
+  assert.throws(
+    () => verifyFullRunAttestation(repoRoot),
+    /attested mutation inputs changed.*\.mise\.toml/u,
+  );
+});
+
+test('checker provenance rejects a different runtime identity', (t) => {
+  const repoRoot = makeFixture(t);
+  for (const field of ['node', 'platform', 'arch']) {
+    attestFixture(repoRoot);
+    const attestationPath = join(repoRoot, fullRunAttestationRelativePath);
+    const attestation = JSON.parse(readFileSync(attestationPath, 'utf8'));
+    attestation.runtime[field] = `hostile-${field}`;
+    writeFileSync(attestationPath, `${JSON.stringify(attestation)}\n`);
+
+    assert.throws(
+      () => verifyFullRunAttestation(repoRoot),
+      new RegExp(`attestation\\.runtime\\.${field} does not match`, 'u'),
+      field,
+    );
+  }
+});
+
+test('host executable lookup ignores relative and repository-local PATH entries', (t) => {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'readout-host-path-repo-'));
+  const safeRoot = mkdtempSync(join(tmpdir(), 'readout-host-path-safe-'));
+  t.after(() => rmSync(repoRoot, { force: true, recursive: true }));
+  t.after(() => rmSync(safeRoot, { force: true, recursive: true }));
+  const unsafeBin = join(repoRoot, 'bin');
+  mkdirSync(unsafeBin);
+  for (const path of [join(unsafeBin, 'ps'), join(safeRoot, 'ps')]) {
+    writeFileSync(path, '#!/bin/sh\nexit 0\n');
+    chmodSync(path, 0o755);
+  }
+
+  assert.equal(
+    resolveSafeHostExecutable('ps', {
+      repoRoot,
+      searchPath: ['.', 'bin', unsafeBin, safeRoot].join(delimiter),
+    }),
+    realpathSync(join(safeRoot, 'ps')),
+  );
+  assert.throws(
+    () =>
+      resolveSafeHostExecutable('ps', {
+        repoRoot,
+        searchPath: ['.', 'bin', unsafeBin].join(delimiter),
+      }),
+    /cannot locate a safe executable/u,
+  );
+});
+
+test('concurrent stale-lock recovery publishes exactly one new owner', async (t) => {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'readout-lock-race-'));
+  t.after(() => rmSync(fixtureRoot, { force: true, recursive: true }));
+  const lockPath = join(fixtureRoot, mutationLockRelativePath);
+  const recoveryPath = join(fixtureRoot, mutationRecoveryRelativePath);
+  writeFixtureFile(
+    fixtureRoot,
+    mutationLockRelativePath,
+    `${JSON.stringify({ version: 3, pid: 999_999_999, token: 'stale-token-000000000000' })}\n`,
+  );
+  const workerPath = join(fixtureRoot, 'lock-worker.mjs');
+  writeFixtureFile(
+    fixtureRoot,
+    'lock-worker.mjs',
+    `
+import { existsSync, writeFileSync } from 'node:fs';
+const [moduleUrl, configJson] = process.argv.slice(2);
+const config = JSON.parse(configJson);
+const { acquireMutationLock, releaseOwnedMutationLock } = await import(moduleUrl);
+const waitArray = new Int32Array(new SharedArrayBuffer(4));
+const waitForFile = (path) => {
+  while (!existsSync(path)) Atomics.wait(waitArray, 0, 0, 10);
+};
+writeFileSync(config.readyPath, 'ready');
+waitForFile(config.goPath);
+try {
+  const token = acquireMutationLock({
+    isOwnerAlive: () => false,
+    lockPath: config.lockPath,
+    reclaim: () => {
+      writeFileSync(config.reclaimPath, 'claimed', { flag: 'wx' });
+      waitForFile(config.releaseRecoveryPath);
+    },
+    record: { version: 3, pid: process.pid, token: config.token },
+    recoveryPath: config.recoveryPath,
+  });
+  writeFileSync(config.acquiredPath, token);
+  waitForFile(config.releaseOwnerPath);
+  releaseOwnedMutationLock(config.lockPath, token);
+} catch (error) {
+  writeFileSync(config.errorPath, error.message);
+  process.exitCode = 2;
+}
+`,
+  );
+  const shared = {
+    goPath: join(fixtureRoot, 'go'),
+    lockPath,
+    recoveryPath,
+    releaseOwnerPath: join(fixtureRoot, 'release-owner'),
+    releaseRecoveryPath: join(fixtureRoot, 'release-recovery'),
+  };
+  const moduleUrl = new URL('./mutation-lock.mjs', import.meta.url).href;
+  const workers = ['a', 'b'].map((id) => {
+    const config = {
+      ...shared,
+      acquiredPath: join(fixtureRoot, `acquired-${id}`),
+      errorPath: join(fixtureRoot, `error-${id}`),
+      readyPath: join(fixtureRoot, `ready-${id}`),
+      reclaimPath: join(fixtureRoot, `reclaim-${id}`),
+      token: `owner-${id}-0000000000000000`,
+    };
+    return {
+      id,
+      process: spawn(process.execPath, [workerPath, moduleUrl, JSON.stringify(config)]),
+    };
+  });
+  t.after(() => {
+    for (const worker of workers) {
+      if (worker.process.exitCode === null) worker.process.kill('SIGKILL');
+    }
+  });
+  const results = workers.map(({ process: child }) => childResult(child));
+  await waitUntil(
+    () => workers.every(({ id }) => existsSync(join(fixtureRoot, `ready-${id}`))),
+    'both lock contenders',
+  );
+  writeFileSync(shared.goPath, 'go');
+  await waitUntil(
+    () => workers.filter(({ id }) => existsSync(join(fixtureRoot, `reclaim-${id}`))).length === 1,
+    'one atomic recovery claimant',
+  );
+  await waitUntil(
+    () => workers.filter(({ id }) => existsSync(join(fixtureRoot, `error-${id}`))).length === 1,
+    'the losing recovery contender to fail closed',
+  );
+  assert.equal(existsSync(recoveryPath), true);
+
+  writeFileSync(shared.releaseRecoveryPath, 'release');
+  await waitUntil(
+    () => workers.filter(({ id }) => existsSync(join(fixtureRoot, `acquired-${id}`))).length === 1,
+    'one published lock owner',
+  );
+  const owner = workers.find(({ id }) => existsSync(join(fixtureRoot, `acquired-${id}`)));
+  assert.equal(
+    JSON.parse(readFileSync(lockPath, 'utf8')).token,
+    `owner-${owner.id}-0000000000000000`,
+  );
+  writeFileSync(shared.releaseOwnerPath, 'release');
+  const exits = await Promise.all(results);
+  assert.deepEqual(exits.map(({ code }) => code).sort(), [0, 2]);
+  assert.equal(existsSync(lockPath), false);
+  assert.equal(existsSync(recoveryPath), false);
+});
+
+test('stale recovery never deletes a late publisher and abandoned recovery fails closed', (t) => {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'readout-lock-late-publisher-'));
+  t.after(() => rmSync(fixtureRoot, { force: true, recursive: true }));
+  const lockPath = join(fixtureRoot, '.guard.lock');
+  const recoveryPath = join(fixtureRoot, '.guard.recovery');
+  mkdirSync(fixtureRoot, { recursive: true });
+  writeFileSync(
+    lockPath,
+    `${JSON.stringify({ version: 3, pid: 999_999_999, token: 'stale-0000000000000000' })}\n`,
+  );
+  const lateCandidatePath = join(fixtureRoot, 'late.candidate');
+  const lateRecord = { version: 3, pid: process.pid, token: 'late-00000000000000000' };
+  writeFileSync(lateCandidatePath, `${JSON.stringify(lateRecord)}\n`);
+
+  assert.throws(
+    () =>
+      acquireMutationLock({
+        afterStaleUnlinked: () => linkSync(lateCandidatePath, lockPath),
+        isOwnerAlive: () => false,
+        lockPath,
+        reclaim: () => {},
+        record: { version: 3, pid: process.pid, token: 'self-00000000000000000' },
+        recoveryPath,
+      }),
+    /another launcher acquired the mutation lock during recovery/u,
+  );
+  assert.deepEqual(JSON.parse(readFileSync(lockPath, 'utf8')), lateRecord);
+  assert.equal(existsSync(recoveryPath), false);
+
+  linkSync(lockPath, recoveryPath);
+  assert.throws(
+    () =>
+      acquireMutationLock({
+        isOwnerAlive: () => false,
+        lockPath,
+        reclaim: () => {},
+        record: { version: 3, pid: process.pid, token: 'next-00000000000000000' },
+        recoveryPath,
+      }),
+    /recovery is in progress or abandoned/u,
+  );
+  assert.deepEqual(JSON.parse(readFileSync(lockPath, 'utf8')), lateRecord);
+});
+
+test('mutation child kills its entire group after unexpected launcher disconnect', async (t) => {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'readout-child-orphan-'));
+  t.after(() => rmSync(fixtureRoot, { force: true, recursive: true }));
+  writeFixtureFile(fixtureRoot, 'hook.mjs', 'export {};\n');
+  writeFixtureFile(
+    fixtureRoot,
+    'stubborn-worker.mjs',
+    `
+import { writeFileSync } from 'node:fs';
+process.on('SIGTERM', () => {});
+writeFileSync(process.argv[2], String(process.pid));
+setInterval(() => {}, 1_000);
+`,
+  );
+  writeFixtureFile(
+    fixtureRoot,
+    'fake-stryker.mjs',
+    `
+import { spawn } from 'node:child_process';
+import { existsSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+process.on('SIGTERM', () => {});
+const readyPath = process.argv.at(-1);
+const workerReadyPath = readyPath + '.worker';
+const worker = spawn(
+  process.execPath,
+  [fileURLToPath(new URL('./stubborn-worker.mjs', import.meta.url)), workerReadyPath],
+  { stdio: 'ignore' },
+);
+while (!existsSync(workerReadyPath)) await new Promise((resolve) => setTimeout(resolve, 10));
+writeFileSync(readyPath, JSON.stringify({ stryker: process.pid, worker: worker.pid }));
+process.exit(0);
+`,
+  );
+  const readyPath = join(fixtureRoot, 'ready.json');
+  const mutationChildPath = fileURLToPath(new URL('./mutation-child.mjs', import.meta.url));
+  const child = spawn(
+    process.execPath,
+    [
+      mutationChildPath,
+      join(fixtureRoot, 'hook.mjs'),
+      join(fixtureRoot, 'fake-stryker.mjs'),
+      readyPath,
+    ],
+    { detached: true, stdio: ['ignore', 'ignore', 'pipe', 'ipc'] },
+  );
+  let childStderr = '';
+  child.stderr.on('data', (chunk) => {
+    childStderr += chunk;
+  });
+  const processGroupId = child.pid;
+  assert.ok(processGroupId && processGroupId > 1);
+  t.after(() => {
+    if (!processGroupExists(processGroupId)) return;
+    try {
+      process.kill(-processGroupId, 'SIGKILL');
+    } catch (error) {
+      if (error.code !== 'ESRCH') throw error;
+    }
+  });
+  const result = childExitResult(child);
+  const resultMessage = once(child, 'message');
+  await once(child, 'spawn');
+  child.send({ type: 'start', processGroupId });
+  await waitUntil(() => existsSync(readyPath), 'stubborn mutation workload');
+  const workload = JSON.parse(readFileSync(readyPath, 'utf8'));
+  assert.deepEqual((await resultMessage)[0], { type: 'result', code: 0, signal: null });
+
+  child.disconnect();
+  let exit;
+  try {
+    exit = await result;
+  } catch (error) {
+    throw new Error(`${error.message}; mutation-child stderr: ${childStderr}`, { cause: error });
+  }
+  child.stderr.destroy();
+  assert.equal(exit.signal, 'SIGKILL');
+  await waitUntil(() => !processGroupExists(processGroupId), 'orphaned mutation group exit');
+  for (const pid of [workload.stryker, workload.worker]) {
+    assert.throws(
+      () => process.kill(pid, 0),
+      (error) => error.code === 'ESRCH',
+    );
+  }
+});
+
+test('mutation child preserves a normal successful disconnect', async (t) => {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'readout-child-success-'));
+  t.after(() => rmSync(fixtureRoot, { force: true, recursive: true }));
+  writeFixtureFile(fixtureRoot, 'hook.mjs', 'export {};\n');
+  writeFixtureFile(fixtureRoot, 'fake-stryker.mjs', 'process.exit(0);\n');
+  const child = spawn(
+    process.execPath,
+    [
+      fileURLToPath(new URL('./mutation-child.mjs', import.meta.url)),
+      join(fixtureRoot, 'hook.mjs'),
+      join(fixtureRoot, 'fake-stryker.mjs'),
+    ],
+    { detached: true, stdio: ['ignore', 'ignore', 'ignore', 'ipc'] },
+  );
+  const processGroupId = child.pid;
+  assert.ok(processGroupId && processGroupId > 1);
+  t.after(() => {
+    if (!processGroupExists(processGroupId)) return;
+    try {
+      process.kill(-processGroupId, 'SIGKILL');
+    } catch (error) {
+      if (error.code !== 'ESRCH') throw error;
+    }
+  });
+  const result = childResult(child);
+  const resultMessage = once(child, 'message');
+  await once(child, 'spawn');
+  child.send({ type: 'start', processGroupId });
+  assert.deepEqual((await resultMessage)[0], { type: 'result', code: 0, signal: null });
+  child.send({ type: 'release' });
+  assert.deepEqual(await result, { code: 0, signal: null });
+  assert.equal(processGroupExists(processGroupId), false);
+});

--- a/scripts/mutation-integrity.mjs
+++ b/scripts/mutation-integrity.mjs
@@ -1,0 +1,759 @@
+import { createHash, randomUUID } from 'node:crypto';
+import {
+  closeSync,
+  existsSync,
+  globSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import ts from '@typescript/legacy';
+import { buildSync } from 'esbuild';
+import { frontendJavaScriptBuildOptions } from './frontend-build-config.mjs';
+
+export const mutationReportRelativePath = 'reports/mutation/mutation.json';
+export const mutationHtmlReportRelativePath = 'reports/mutation/index.html';
+export const fullRunAttestationRelativePath = 'reports/mutation/full-run.json';
+export const mutationLockRelativePath = 'reports/mutation/.guard.lock';
+export const mutationRecoveryRelativePath = 'reports/mutation/.guard.recovery';
+export const mutationLogRelativePath = 'reports/mutation/latest.log';
+export const mutationStageRelativePath = '.mutation-stage';
+
+const fixedMutationInputs = [
+  '.mise.toml',
+  'internal/assets/static/readout.js',
+  'package-lock.json',
+  'package.json',
+  'scripts/build-assets.mjs',
+  'scripts/check-mutation-report.mjs',
+  'scripts/frontend-build-config.mjs',
+  'scripts/mutation-child.mjs',
+  'scripts/mutation-cli.mjs',
+  'scripts/mutation-infrastructure.test.mjs',
+  'scripts/mutation-host.mjs',
+  'scripts/mutation-integrity.mjs',
+  'scripts/mutation-lock.mjs',
+  'scripts/run-mutation.mjs',
+  'scripts/stryker-typescript-hook.mjs',
+  'stryker.config.mjs',
+  'tsconfig.json',
+  'tsconfig.test.json',
+  'vitest.config.ts',
+];
+const mutationTestDataPatterns = [
+  // prefs.test.ts enumerates this shared Go/TypeScript codec corpus at module load.
+  'internal/web/testdata/prefs_golden/**/*.json',
+];
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function sortedUnique(values) {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}
+
+function assertSafeRelativePath(fileName, context) {
+  if (
+    typeof fileName !== 'string' ||
+    fileName.length === 0 ||
+    isAbsolute(fileName) ||
+    fileName.includes('\\') ||
+    fileName.includes('\0') ||
+    fileName.split('/').some((part) => part.length === 0 || part === '.' || part === '..')
+  ) {
+    throw new Error(`${context} contains an unsafe path: ${fileName}`);
+  }
+}
+
+function pathEntryExists(path) {
+  try {
+    lstatSync(path);
+    return true;
+  } catch (error) {
+    if (error.code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+function ensurePlainDirectory(path, label) {
+  try {
+    const stats = lstatSync(path);
+    if (stats.isSymbolicLink() || !stats.isDirectory()) {
+      throw new Error(`${label} must be a real directory, not a symlink or file: ${path}`);
+    }
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error;
+    mkdirSync(path, { mode: 0o700 });
+    const stats = lstatSync(path);
+    if (stats.isSymbolicLink() || !stats.isDirectory()) {
+      throw new Error(`${label} could not be created as a real directory: ${path}`);
+    }
+  }
+}
+
+export function ensureMutationArtifactDirectory(repoRoot) {
+  const resolvedRepoRoot = resolve(repoRoot);
+  const reportsRoot = join(resolvedRepoRoot, 'reports');
+  const artifactRoot = join(reportsRoot, 'mutation');
+  if (resolve(artifactRoot) !== artifactRoot) {
+    throw new Error(`refusing unexpected mutation artifact path: ${artifactRoot}`);
+  }
+  // Create and validate one component at a time. Recursive mkdir/rm through an
+  // existing symlink could otherwise escape the repository.
+  ensurePlainDirectory(reportsRoot, 'mutation reports parent');
+  ensurePlainDirectory(artifactRoot, 'mutation artifact directory');
+  return artifactRoot;
+}
+
+export function openMutationLogFile(repoRoot) {
+  const artifactRoot = ensureMutationArtifactDirectory(repoRoot);
+  const logPath = join(artifactRoot, 'latest.log');
+  const candidatePath = `${logPath}.${process.pid}.${randomUUID()}.candidate`;
+  let descriptor;
+  try {
+    descriptor = openSync(candidatePath, 'wx', 0o600);
+    // Renaming a fresh inode over latest.log replaces a symlink or hard link
+    // itself without opening or truncating its external target.
+    renameSync(candidatePath, logPath);
+    return { descriptor, logPath };
+  } catch (error) {
+    if (descriptor !== undefined) closeSync(descriptor);
+    rmSync(candidatePath, { force: true });
+    throw error;
+  }
+}
+
+export function mutationStagePath(repoRoot) {
+  const resolvedRepoRoot = resolve(repoRoot);
+  const stageRoot = resolve(resolvedRepoRoot, mutationStageRelativePath);
+  if (stageRoot !== join(resolvedRepoRoot, mutationStageRelativePath)) {
+    throw new Error(`refusing unexpected mutation stage path: ${stageRoot}`);
+  }
+  return stageRoot;
+}
+
+export function collectMutationRuntimePaths(repoRoot) {
+  return globSync('internal/assets/src/js/**/*.ts', { cwd: repoRoot })
+    .filter(
+      (fileName) =>
+        !fileName.endsWith('.test.ts') &&
+        fileName !== 'internal/assets/src/js/types.ts' &&
+        !fileName.startsWith('internal/assets/src/js/test/'),
+    )
+    .sort();
+}
+
+function buildBundledRuntime(repoRoot) {
+  let result;
+  try {
+    result = buildSync(
+      frontendJavaScriptBuildOptions(repoRoot, {
+        metafile: true,
+        logLevel: 'silent',
+      }),
+    );
+  } catch (error) {
+    throw new Error(`cannot derive the shipped frontend module graph: ${error.message}`, {
+      cause: error,
+    });
+  }
+  if (result.metafile === undefined) {
+    throw new Error('esbuild did not return a frontend module graph');
+  }
+  const bundledInputs = Object.keys(result.metafile.inputs);
+  const outsideMutationRoot = bundledInputs.filter(
+    (fileName) =>
+      !fileName.startsWith('internal/assets/src/js/') && !fileName.startsWith('node_modules/'),
+  );
+  if (outsideMutationRoot.length > 0) {
+    throw new Error(
+      `shipped frontend graph contains project inputs outside the mutation root: ` +
+        `[${outsideMutationRoot.sort().join(', ')}]`,
+    );
+  }
+  const projectInputs = bundledInputs
+    .filter((fileName) => fileName.startsWith('internal/assets/src/js/'))
+    .sort();
+  const nonTypeScript = projectInputs.filter((fileName) => !fileName.endsWith('.ts'));
+  if (nonTypeScript.length > 0) {
+    throw new Error(
+      `shipped frontend graph contains non-TypeScript inputs: [${nonTypeScript.join(', ')}]`,
+    );
+  }
+  if (!Array.isArray(result.outputFiles) || result.outputFiles.length !== 1) {
+    throw new Error('esbuild did not return exactly one shipped frontend output');
+  }
+  return { output: result.outputFiles[0].text, paths: projectInputs };
+}
+
+export function collectBundledRuntimePaths(repoRoot) {
+  return buildBundledRuntime(repoRoot).paths;
+}
+
+export function assertMutationScopeMatchesRuntimeGraph(repoRoot) {
+  const mutationPaths = collectMutationRuntimePaths(repoRoot);
+  const { output, paths: runtimePaths } = buildBundledRuntime(repoRoot);
+  const missingFromGraph = mutationPaths.filter((fileName) => !runtimePaths.includes(fileName));
+  const excludedFromMutation = runtimePaths.filter((fileName) => !mutationPaths.includes(fileName));
+  if (missingFromGraph.length > 0 || excludedFromMutation.length > 0) {
+    throw new Error(
+      `mutation candidates do not equal the shipped frontend graph: ` +
+        `missing-from-graph=[${missingFromGraph.join(', ')}], ` +
+        `excluded-from-mutation=[${excludedFromMutation.join(', ')}]`,
+    );
+  }
+  const shippedPath = join(repoRoot, 'internal/assets/static/readout.js');
+  if (output !== readFileSync(shippedPath, 'utf8')) {
+    throw new Error('shipped frontend bundle is stale relative to its attested build recipe');
+  }
+  return mutationPaths;
+}
+
+export function collectMutationInputPaths(repoRoot) {
+  const runtimeSources = globSync('internal/assets/src/js/**/*.ts', { cwd: repoRoot }).filter(
+    (fileName) =>
+      !fileName.endsWith('.test.ts') && !fileName.startsWith('internal/assets/src/js/test/'),
+  );
+  const frontendTests = [
+    ...globSync('internal/assets/src/js/**/*.test.ts', { cwd: repoRoot }),
+    ...globSync('internal/assets/src/js/test/**/*.ts', { cwd: repoRoot }),
+  ];
+  const frontendTestData = mutationTestDataPatterns.flatMap((pattern) => {
+    const matches = globSync(pattern, { cwd: repoRoot });
+    if (matches.length === 0) {
+      throw new Error(`mutation test-data pattern matched no files: ${pattern}`);
+    }
+    return matches;
+  });
+  const paths = sortedUnique([
+    ...runtimeSources,
+    ...frontendTests,
+    ...frontendTestData,
+    ...fixedMutationInputs,
+  ]);
+
+  for (const fileName of paths) {
+    if (!existsSync(join(repoRoot, fileName))) {
+      throw new Error(`mutation input is missing: ${fileName}`);
+    }
+  }
+  return paths;
+}
+
+export function currentMutationRuntime() {
+  return {
+    node: process.version,
+    platform: process.platform,
+    arch: process.arch,
+  };
+}
+
+function parseExactVersion(value, fieldName) {
+  if (
+    typeof value !== 'string' ||
+    !/^v?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u.test(value)
+  ) {
+    throw new Error(`${fieldName} must be an exact numeric version`);
+  }
+  return value.replace(/^v/u, '').split('.').map(Number);
+}
+
+function compareVersions(left, right) {
+  for (let index = 0; index < 3; index += 1) {
+    if (left[index] !== right[index]) return left[index] < right[index] ? -1 : 1;
+  }
+  return 0;
+}
+
+function satisfiesSimpleNodeRange(version, range) {
+  if (typeof range !== 'string' || range.trim().length === 0) return false;
+  const parsedVersion = parseExactVersion(version, 'Node version');
+  const comparators = range.trim().split(/\s+/u);
+  return comparators.every((comparator) => {
+    const match = /^(>=|<=|>|<|=)?(\d+(?:\.\d+){0,2})$/u.exec(comparator);
+    if (!match) {
+      throw new Error(`package.json engines.node uses an unsupported range: ${range}`);
+    }
+    const boundaryParts = match[2].split('.').map(Number);
+    while (boundaryParts.length < 3) boundaryParts.push(0);
+    const comparison = compareVersions(parsedVersion, boundaryParts);
+    switch (match[1] ?? '=') {
+      case '>=':
+        return comparison >= 0;
+      case '<=':
+        return comparison <= 0;
+      case '>':
+        return comparison > 0;
+      case '<':
+        return comparison < 0;
+      default:
+        return comparison === 0;
+    }
+  });
+}
+
+function readMiseNodePin(repoRoot) {
+  const source = readFileSync(join(repoRoot, '.mise.toml'), 'utf8');
+  let section = '';
+  const pins = [];
+  for (const rawLine of source.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith('#')) continue;
+    const sectionMatch = /^\[([^\]]+)\](?:\s*#.*)?$/u.exec(line);
+    if (sectionMatch) {
+      section = sectionMatch[1];
+      continue;
+    }
+    if (section !== 'tools' || !/^node\s*=/u.test(line)) continue;
+    const pinMatch = /^node\s*=\s*"([^"]+)"(?:\s*#.*)?$/u.exec(line);
+    if (!pinMatch) throw new Error('.mise.toml [tools].node must be an exact quoted version');
+    pins.push(pinMatch[1]);
+  }
+  if (pins.length !== 1) {
+    throw new Error(`.mise.toml must contain exactly one [tools].node pin, found ${pins.length}`);
+  }
+  parseExactVersion(pins[0], '.mise.toml [tools].node');
+  return pins[0];
+}
+
+export function assertMutationRuntimeEligible(repoRoot, runtime = currentMutationRuntime()) {
+  const pin = readMiseNodePin(repoRoot);
+  const actual = runtime.node?.replace(/^v/u, '');
+  parseExactVersion(actual, 'runtime Node version');
+  if (actual !== pin) {
+    throw new Error(`runtime Node ${actual} does not match the exact mise pin ${pin}`);
+  }
+
+  let packageJson;
+  try {
+    packageJson = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'));
+  } catch (error) {
+    throw new Error(`cannot read package.json Node engine: ${error.message}`, { cause: error });
+  }
+  const engine = packageJson?.engines?.node;
+  if (!satisfiesSimpleNodeRange(actual, engine)) {
+    throw new Error(`runtime Node ${actual} does not satisfy package.json engines.node ${engine}`);
+  }
+  return { engine, pin };
+}
+
+function inputSetDigest(files) {
+  return sha256(
+    Object.entries(files)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([fileName, digest]) => `${fileName}\0${digest}\n`)
+      .join(''),
+  );
+}
+
+export function snapshotMutationInputs(repoRoot) {
+  const files = Object.fromEntries(
+    collectMutationInputPaths(repoRoot).map((fileName) => [
+      fileName,
+      sha256(readFileSync(join(repoRoot, fileName))),
+    ]),
+  );
+  return { files, sha256: inputSetDigest(files) };
+}
+
+export function assertMutationInputsEqual(expected, actual, context = 'mutation inputs') {
+  const expectedNames = Object.keys(expected.files).sort();
+  const actualNames = Object.keys(actual.files).sort();
+  const added = actualNames.filter((fileName) => !expectedNames.includes(fileName));
+  const removed = expectedNames.filter((fileName) => !actualNames.includes(fileName));
+  const changed = expectedNames.filter(
+    (fileName) =>
+      actual.files[fileName] !== undefined && actual.files[fileName] !== expected.files[fileName],
+  );
+  if (
+    expected.sha256 !== actual.sha256 ||
+    added.length > 0 ||
+    removed.length > 0 ||
+    changed.length > 0
+  ) {
+    throw new Error(
+      `${context} changed: added=[${added.join(', ')}], removed=[${removed.join(', ')}], ` +
+        `changed=[${changed.join(', ')}]`,
+    );
+  }
+}
+
+function parseIsoTimestamp(value, fieldName) {
+  if (typeof value !== 'string') throw new Error(`${fieldName} must be an ISO timestamp`);
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds) || new Date(milliseconds).toISOString() !== value) {
+    throw new Error(`${fieldName} must be an ISO timestamp`);
+  }
+  return milliseconds;
+}
+
+function assertDigest(value, fieldName) {
+  if (typeof value !== 'string' || !/^[a-f0-9]{64}$/u.test(value)) {
+    throw new Error(`${fieldName} must be a SHA-256 digest`);
+  }
+}
+
+function assertAttestedInputSnapshot(value) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('attestation.inputs must be an object');
+  }
+  if (value.files === null || typeof value.files !== 'object' || Array.isArray(value.files)) {
+    throw new Error('attestation.inputs.files must be an object');
+  }
+  for (const [fileName, digest] of Object.entries(value.files)) {
+    assertSafeRelativePath(fileName, 'attestation');
+    assertDigest(digest, `attestation.inputs.files[${JSON.stringify(fileName)}]`);
+  }
+  assertDigest(value.sha256, 'attestation.inputs.sha256');
+  if (inputSetDigest(value.files) !== value.sha256) {
+    throw new Error('attestation input-set digest is inconsistent');
+  }
+}
+
+export function removeMutationInputStage(repoRoot) {
+  const stageRoot = mutationStagePath(repoRoot);
+  if (!pathEntryExists(stageRoot)) return;
+  if (lstatSync(stageRoot).isSymbolicLink()) {
+    unlinkSync(stageRoot);
+    return;
+  }
+  rmSync(stageRoot, { recursive: true, force: true });
+}
+
+export function createMutationInputStage(repoRoot, expectedInputs) {
+  assertAttestedInputSnapshot(expectedInputs);
+  const stageRoot = mutationStagePath(repoRoot);
+  if (pathEntryExists(stageRoot)) {
+    throw new Error(`mutation stage already exists: ${stageRoot}`);
+  }
+  const nodeModulesPath = join(repoRoot, 'node_modules');
+  if (!existsSync(nodeModulesPath) || !statSync(nodeModulesPath).isDirectory()) {
+    throw new Error('node_modules is missing; run npm ci before staging mutation inputs');
+  }
+
+  mkdirSync(stageRoot, { mode: 0o700 });
+  try {
+    for (const fileName of Object.keys(expectedInputs.files).sort()) {
+      assertSafeRelativePath(fileName, 'mutation input snapshot');
+      const sourcePath = join(repoRoot, fileName);
+      const sourceBytes = readFileSync(sourcePath);
+      if (sha256(sourceBytes) !== expectedInputs.files[fileName]) {
+        throw new Error(`mutation input changed while staging: ${fileName}`);
+      }
+      const targetPath = join(stageRoot, fileName);
+      mkdirSync(dirname(targetPath), { recursive: true });
+      writeFileSync(targetPath, sourceBytes, {
+        flag: 'wx',
+        mode: statSync(sourcePath).mode & 0o777,
+      });
+    }
+    symlinkSync(nodeModulesPath, join(stageRoot, 'node_modules'), 'dir');
+    const stagedInputs = snapshotMutationInputs(stageRoot);
+    assertMutationInputsEqual(expectedInputs, stagedInputs, 'staged mutation inputs');
+    return { inputs: stagedInputs, stageRoot };
+  } catch (error) {
+    removeMutationInputStage(repoRoot);
+    throw error;
+  }
+}
+
+export function invalidateFullMutationReport(repoRoot) {
+  ensureMutationArtifactDirectory(repoRoot);
+  const resolvedRepoRoot = resolve(repoRoot);
+  for (const relativePath of [
+    // Remove the proof first. If a malformed report path makes a later unlink
+    // fail, no previously attested result can remain usable.
+    fullRunAttestationRelativePath,
+    mutationReportRelativePath,
+    mutationHtmlReportRelativePath,
+  ]) {
+    rmSync(join(resolvedRepoRoot, relativePath), { force: true });
+  }
+}
+
+export function publishFullMutationReports(repoRoot, { htmlReportBytes, reportBytes }) {
+  ensureMutationArtifactDirectory(repoRoot);
+  if (reportBytes.length === 0 || htmlReportBytes.length === 0) {
+    throw new Error('full mutation JSON and HTML reports must both be non-empty');
+  }
+  const resolvedRepoRoot = resolve(repoRoot);
+  const reportPath = join(resolvedRepoRoot, mutationReportRelativePath);
+  const htmlReportPath = join(resolvedRepoRoot, mutationHtmlReportRelativePath);
+  const attestationPath = join(resolvedRepoRoot, fullRunAttestationRelativePath);
+  for (const targetPath of [reportPath, htmlReportPath, attestationPath]) {
+    if (pathEntryExists(targetPath)) {
+      throw new Error(`refusing to overwrite an existing full-run artifact: ${targetPath}`);
+    }
+  }
+
+  const nonce = `${process.pid}.${randomUUID()}`;
+  const candidates = [
+    {
+      bytes: reportBytes,
+      candidatePath: `${reportPath}.${nonce}.candidate`,
+      targetPath: reportPath,
+    },
+    {
+      bytes: htmlReportBytes,
+      candidatePath: `${htmlReportPath}.${nonce}.candidate`,
+      targetPath: htmlReportPath,
+    },
+  ];
+  try {
+    for (const { bytes, candidatePath } of candidates) {
+      writeFileSync(candidatePath, bytes, { flag: 'wx', mode: 0o600 });
+    }
+    for (const { candidatePath, targetPath } of candidates) renameSync(candidatePath, targetPath);
+  } catch (error) {
+    for (const { candidatePath, targetPath } of candidates) {
+      rmSync(candidatePath, { force: true });
+      rmSync(targetPath, { force: true });
+    }
+    throw error;
+  } finally {
+    for (const { candidatePath } of candidates) rmSync(candidatePath, { force: true });
+  }
+}
+
+export function createFullRunAttestation({
+  completedAt,
+  executionInputs,
+  htmlReportBytes,
+  inputs,
+  repoRoot,
+  reportBytes,
+  runId,
+  startedAt,
+}) {
+  assertMutationRuntimeEligible(repoRoot);
+  assertAttestedInputSnapshot(inputs);
+  assertAttestedInputSnapshot(executionInputs);
+  assertMutationInputsEqual(inputs, executionInputs, 'staged execution inputs');
+  if (reportBytes.length === 0 || htmlReportBytes.length === 0) {
+    throw new Error('full mutation JSON and HTML reports must both be non-empty');
+  }
+  return {
+    schemaVersion: 4,
+    runId,
+    mode: 'full',
+    successful: true,
+    startedAt,
+    completedAt,
+    runtime: currentMutationRuntime(),
+    execution: {
+      cwd: mutationStageRelativePath,
+      inputsSha256: executionInputs.sha256,
+    },
+    report: {
+      path: mutationReportRelativePath,
+      sha256: sha256(reportBytes),
+    },
+    htmlReport: {
+      path: mutationHtmlReportRelativePath,
+      sha256: sha256(htmlReportBytes),
+    },
+    inputs,
+  };
+}
+
+function assertRuntimeMetadata(value) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('attestation.runtime must be an object');
+  }
+  const current = currentMutationRuntime();
+  for (const field of ['node', 'platform', 'arch']) {
+    if (typeof value[field] !== 'string' || value[field] !== current[field]) {
+      throw new Error(
+        `attestation.runtime.${field} does not match this process: ` +
+          `${JSON.stringify(value[field])} != ${JSON.stringify(current[field])}`,
+      );
+    }
+  }
+}
+
+export function writeFullRunAttestation(repoRoot, attestation) {
+  ensureMutationArtifactDirectory(repoRoot);
+  const attestationPath = join(resolve(repoRoot), fullRunAttestationRelativePath);
+  const candidatePath = `${attestationPath}.${process.pid}.${randomUUID()}.candidate`;
+  writeFileSync(candidatePath, `${JSON.stringify(attestation, null, 2)}\n`, {
+    encoding: 'utf8',
+    flag: 'wx',
+    mode: 0o600,
+  });
+  try {
+    renameSync(candidatePath, attestationPath);
+  } finally {
+    rmSync(candidatePath, { force: true });
+  }
+}
+
+export function verifyFullRunAttestation(repoRoot) {
+  ensureMutationArtifactDirectory(repoRoot);
+  if (existsSync(join(repoRoot, mutationLockRelativePath))) {
+    throw new Error('mutation guard lock still exists; the full run did not finish cleanly');
+  }
+  if (existsSync(join(repoRoot, mutationRecoveryRelativePath))) {
+    throw new Error('mutation recovery claim still exists; the full run did not finish cleanly');
+  }
+  if (pathEntryExists(mutationStagePath(repoRoot))) {
+    throw new Error('mutation stage still exists; the full run did not finish cleanly');
+  }
+
+  const attestationPath = join(repoRoot, fullRunAttestationRelativePath);
+  let attestation;
+  try {
+    attestation = JSON.parse(readFileSync(attestationPath, 'utf8'));
+  } catch (error) {
+    throw new Error(`cannot read a valid full-run attestation: ${error.message}`, { cause: error });
+  }
+  if (attestation === null || typeof attestation !== 'object' || Array.isArray(attestation)) {
+    throw new Error('full-run attestation must be an object');
+  }
+  if (attestation.schemaVersion !== 4) throw new Error('unsupported full-run attestation schema');
+  if (attestation.mode !== 'full' || attestation.successful !== true) {
+    throw new Error('attestation is not from a successful full mutation run');
+  }
+  assertRuntimeMetadata(attestation.runtime);
+  assertMutationRuntimeEligible(repoRoot, attestation.runtime);
+  if (
+    attestation.execution === null ||
+    typeof attestation.execution !== 'object' ||
+    Array.isArray(attestation.execution) ||
+    attestation.execution.cwd !== mutationStageRelativePath
+  ) {
+    throw new Error('attestation execution root is invalid');
+  }
+  assertDigest(attestation.execution.inputsSha256, 'attestation.execution.inputsSha256');
+  if (typeof attestation.runId !== 'string' || attestation.runId.length < 16) {
+    throw new Error('attestation.runId is invalid');
+  }
+  const startedAt = parseIsoTimestamp(attestation.startedAt, 'attestation.startedAt');
+  const completedAt = parseIsoTimestamp(attestation.completedAt, 'attestation.completedAt');
+  if (completedAt < startedAt || completedAt > Date.now() + 60_000) {
+    throw new Error('attestation timestamps are inconsistent');
+  }
+  if (
+    attestation.report === null ||
+    typeof attestation.report !== 'object' ||
+    Array.isArray(attestation.report) ||
+    attestation.report.path !== mutationReportRelativePath
+  ) {
+    throw new Error('attestation report path is invalid');
+  }
+  assertDigest(attestation.report.sha256, 'attestation.report.sha256');
+  if (
+    attestation.htmlReport === null ||
+    typeof attestation.htmlReport !== 'object' ||
+    Array.isArray(attestation.htmlReport) ||
+    attestation.htmlReport.path !== mutationHtmlReportRelativePath
+  ) {
+    throw new Error('attestation HTML report path is invalid');
+  }
+  assertDigest(attestation.htmlReport.sha256, 'attestation.htmlReport.sha256');
+  assertAttestedInputSnapshot(attestation.inputs);
+  if (attestation.execution.inputsSha256 !== attestation.inputs.sha256) {
+    throw new Error('attestation execution inputs do not match the attested working-tree inputs');
+  }
+
+  const reportPath = join(repoRoot, mutationReportRelativePath);
+  const reportBytes = readFileSync(reportPath);
+  if (sha256(reportBytes) !== attestation.report.sha256) {
+    throw new Error('mutation report digest does not match the successful full run');
+  }
+  const reportModifiedAt = statSync(reportPath).mtimeMs;
+  if (reportModifiedAt < startedAt - 1_000 || reportModifiedAt > completedAt + 1_000) {
+    throw new Error('mutation report timestamp falls outside the attested full run');
+  }
+
+  const htmlReportPath = join(repoRoot, mutationHtmlReportRelativePath);
+  const htmlReportBytes = readFileSync(htmlReportPath);
+  if (htmlReportBytes.length === 0 || sha256(htmlReportBytes) !== attestation.htmlReport.sha256) {
+    throw new Error('mutation HTML report digest does not match the successful full run');
+  }
+  const htmlReportModifiedAt = statSync(htmlReportPath).mtimeMs;
+  if (htmlReportModifiedAt < startedAt - 1_000 || htmlReportModifiedAt > completedAt + 1_000) {
+    throw new Error('mutation HTML report timestamp falls outside the attested full run');
+  }
+
+  const currentInputs = snapshotMutationInputs(repoRoot);
+  assertMutationInputsEqual(attestation.inputs, currentInputs, 'attested mutation inputs');
+  return { attestation, htmlReportBytes, reportBytes };
+}
+
+function parseTypeScript(fileName, source) {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  if (sourceFile.parseDiagnostics.length > 0) {
+    const diagnostic = sourceFile.parseDiagnostics[0];
+    throw new Error(
+      `${fileName} cannot be parsed: ${ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')}`,
+    );
+  }
+  return sourceFile;
+}
+
+function hasDeclareModifier(statement) {
+  return (
+    statement.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.DeclareKeyword) ?? false
+  );
+}
+
+function isTypeOnlyStatement(statement) {
+  if (ts.isInterfaceDeclaration(statement) || ts.isTypeAliasDeclaration(statement)) return true;
+  if (ts.isImportDeclaration(statement)) return statement.importClause?.isTypeOnly === true;
+  if (ts.isExportDeclaration(statement)) return statement.isTypeOnly;
+  if (ts.isModuleDeclaration(statement) && hasDeclareModifier(statement)) {
+    if (statement.body === undefined) return true;
+    if (ts.isModuleBlock(statement.body)) {
+      return statement.body.statements.every(isTypeOnlyStatement);
+    }
+    return isTypeOnlyStatement(statement.body);
+  }
+  return false;
+}
+
+function statementLocation(sourceFile, statement) {
+  const location = sourceFile.getLineAndCharacterOfPosition(statement.getStart(sourceFile));
+  return `${sourceFile.fileName}:${location.line + 1}:${location.character + 1}`;
+}
+
+export function assertTypeOnlyModuleSource(fileName, source) {
+  const sourceFile = parseTypeScript(fileName, source);
+  for (const statement of sourceFile.statements) {
+    if (!isTypeOnlyStatement(statement)) {
+      throw new Error(
+        `${fileName} is no longer type-only: ${ts.SyntaxKind[statement.kind]} at ` +
+          statementLocation(sourceFile, statement),
+      );
+    }
+  }
+}
+
+export function assertImportOnlyModuleSource(fileName, source) {
+  const sourceFile = parseTypeScript(fileName, source);
+  if (sourceFile.statements.length === 0) {
+    throw new Error(`${fileName} must contain at least one side-effect import`);
+  }
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement) || statement.importClause !== undefined) {
+      throw new Error(
+        `${fileName} is no longer side-effect-import-only: ${ts.SyntaxKind[statement.kind]} at ` +
+          statementLocation(sourceFile, statement),
+      );
+    }
+  }
+}

--- a/scripts/mutation-lock.mjs
+++ b/scripts/mutation-lock.mjs
@@ -1,0 +1,152 @@
+import { randomUUID } from 'node:crypto';
+import {
+  existsSync,
+  linkSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
+
+export function parseMutationLockRecord(content) {
+  try {
+    const parsed = JSON.parse(content);
+    if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed;
+  } catch {
+    const legacyOwner = Number.parseInt(content.trim(), 10);
+    if (Number.isInteger(legacyOwner) && legacyOwner > 0) {
+      return { version: 1, pid: legacyOwner };
+    }
+  }
+  return {};
+}
+
+function sameFile(leftPath, rightPath) {
+  const left = statSync(leftPath, { bigint: true });
+  const right = statSync(rightPath, { bigint: true });
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function readLock(path) {
+  return parseMutationLockRecord(readFileSync(path, 'utf8'));
+}
+
+function writeCandidate(path, record) {
+  writeFileSync(path, `${JSON.stringify(record)}\n`, {
+    encoding: 'utf8',
+    flag: 'wx',
+    mode: 0o600,
+  });
+}
+
+export function acquireMutationLock({
+  afterStaleUnlinked = () => {},
+  isOwnerAlive,
+  lockPath,
+  record,
+  reclaim,
+  recoveryPath,
+}) {
+  if (typeof record?.token !== 'string' || record.token.length < 16) {
+    throw new Error('new mutation lock record must have a strong ownership token');
+  }
+  mkdirSync(dirname(lockPath), { recursive: true });
+  const candidatePath = `${lockPath}.${process.pid}.${randomUUID()}.candidate`;
+  writeCandidate(candidatePath, record);
+  try {
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      // A recovery hard link is a filesystem-level claim on the stale lock's
+      // inode. Never publish a new owner while a prior recovery is incomplete.
+      if (existsSync(recoveryPath)) {
+        throw new Error(
+          `mutation lock recovery is in progress or abandoned at ${recoveryPath}; ` +
+            'refusing to start',
+        );
+      }
+
+      try {
+        linkSync(candidatePath, lockPath);
+        return record.token;
+      } catch (error) {
+        if (error.code !== 'EEXIST') throw error;
+      }
+
+      try {
+        // The fixed destination makes recovery ownership atomic: exactly one
+        // contender can hard-link the currently published lock inode here.
+        linkSync(lockPath, recoveryPath);
+      } catch (error) {
+        if (error.code === 'ENOENT') continue;
+        if (error.code === 'EEXIST') {
+          throw new Error(`another launcher owns mutation lock recovery at ${recoveryPath}`);
+        }
+        throw error;
+      }
+
+      try {
+        // Read only the claimed inode. The lock may have changed between the
+        // failed publication and recovery claim, so earlier observations are
+        // deliberately ignored.
+        const claimedRecord = readLock(recoveryPath);
+        const owner =
+          Number.isInteger(claimedRecord.pid) && claimedRecord.pid > 0
+            ? claimedRecord.pid
+            : undefined;
+        if (owner && isOwnerAlive(owner)) {
+          throw new Error(`another mutation guard is already running (pid ${owner})`);
+        }
+
+        reclaim(claimedRecord);
+        if (!sameFile(lockPath, recoveryPath)) {
+          throw new Error('mutation lock changed during stale recovery; refusing to unlink it');
+        }
+        rmSync(lockPath);
+        afterStaleUnlinked();
+
+        try {
+          // Publish the new owner before releasing the recovery claim. A
+          // contender that raced an earlier claim check may win this link, but
+          // this launcher will never delete or overlap that new owner.
+          linkSync(candidatePath, lockPath);
+          return record.token;
+        } catch (error) {
+          if (error.code !== 'EEXIST') throw error;
+          throw new Error('another launcher acquired the mutation lock during recovery');
+        }
+      } finally {
+        rmSync(recoveryPath, { force: true });
+      }
+    }
+  } finally {
+    rmSync(candidatePath, { force: true });
+  }
+  throw new Error('could not acquire mutation guard lock');
+}
+
+export function updateOwnedMutationLock(lockPath, token, transform) {
+  const current = readLock(lockPath);
+  if (current.token !== token || current.pid !== process.pid) {
+    throw new Error('mutation guard lock ownership changed unexpectedly');
+  }
+  const candidatePath = `${lockPath}.${process.pid}.${randomUUID()}.update`;
+  writeCandidate(candidatePath, transform(current));
+  try {
+    renameSync(candidatePath, lockPath);
+  } finally {
+    rmSync(candidatePath, { force: true });
+  }
+}
+
+export function releaseOwnedMutationLock(lockPath, token) {
+  let current;
+  try {
+    current = readLock(lockPath);
+  } catch (error) {
+    if (error.code === 'ENOENT') return;
+    throw error;
+  }
+  if (current.token === token) rmSync(lockPath);
+}

--- a/scripts/run-mutation.mjs
+++ b/scripts/run-mutation.mjs
@@ -1,0 +1,788 @@
+// Resource-monitored Stryker launcher. Stryker owns its worker pool; this wrapper
+// samples its process group and stops a run after a configured limit is observed.
+
+import { execFileSync, spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import {
+  createWriteStream,
+  existsSync,
+  lstatSync,
+  readFileSync,
+  rmSync,
+  statfsSync,
+  statSync,
+  unlinkSync,
+} from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { parseMutationCliArguments } from './mutation-cli.mjs';
+import { resolveSafeHostExecutable } from './mutation-host.mjs';
+import {
+  assertMutationInputsEqual,
+  assertMutationRuntimeEligible,
+  assertMutationScopeMatchesRuntimeGraph,
+  createFullRunAttestation,
+  createMutationInputStage,
+  ensureMutationArtifactDirectory,
+  fullRunAttestationRelativePath,
+  invalidateFullMutationReport,
+  mutationHtmlReportRelativePath,
+  mutationReportRelativePath,
+  mutationStagePath,
+  openMutationLogFile,
+  publishFullMutationReports,
+  removeMutationInputStage,
+  snapshotMutationInputs,
+  writeFullRunAttestation,
+} from './mutation-integrity.mjs';
+import {
+  acquireMutationLock,
+  releaseOwnedMutationLock,
+  updateOwnedMutationLock,
+} from './mutation-lock.mjs';
+
+const GIB = 1024 ** 3;
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const installedStrykerBin = join(repoRoot, 'node_modules', '.bin', 'stryker');
+const stageRoot = mutationStagePath(repoRoot);
+const strykerBin = join(stageRoot, 'node_modules', '.bin', 'stryker');
+const compatibilityHook = pathToFileURL(
+  join(stageRoot, 'scripts', 'stryker-typescript-hook.mjs'),
+).href;
+const sourceMutationChild = join(repoRoot, 'scripts', 'mutation-child.mjs');
+const mutationChild = join(stageRoot, 'scripts', 'mutation-child.mjs');
+const legacyTempDir = join(repoRoot, '.stryker-tmp');
+const reportDir = join(repoRoot, 'reports', 'mutation');
+const stagedReportPath = join(stageRoot, mutationReportRelativePath);
+const stagedHtmlReportPath = join(stageRoot, mutationHtmlReportRelativePath);
+const attestationPath = join(repoRoot, fullRunAttestationRelativePath);
+const logPath = join(reportDir, 'latest.log');
+const lockPath = join(reportDir, '.guard.lock');
+const recoveryPath = join(reportDir, '.guard.recovery');
+const guardEnvironment = 'READOUT_MUTATION_GUARD';
+const modeEnvironment = 'READOUT_MUTATION_MODE';
+const runIdEnvironment = 'READOUT_MUTATION_RUN_ID';
+const supportedPlatforms = new Set(['darwin', 'linux']);
+const { concurrency, mode, strykerArgs } = parseMutationCliArguments(process.argv.slice(2));
+const fullRun = mode === 'full';
+const runId = randomUUID();
+const childMarker = `readout-mutation-${runId}`;
+
+if (!supportedPlatforms.has(process.platform)) {
+  throw new Error('the mutation resource guard supports only POSIX macOS and Linux hosts');
+}
+assertMutationRuntimeEligible(repoRoot);
+const duBin = resolveSafeHostExecutable('du', { repoRoot });
+const psBin = resolveSafeHostExecutable('ps', { repoRoot });
+
+const minimumFreeBytes = readLimit('MUTATION_MIN_FREE_GIB', 30, 'minimum') * GIB;
+const maximumGeneratedBytes = readLimit('MUTATION_MAX_GENERATED_GIB', 2, 'maximum') * GIB;
+const maximumRssKiB = (readLimit('MUTATION_MAX_RSS_GIB', 8, 'maximum') * GIB) / 1024;
+const pollMilliseconds = readLimit('MUTATION_MONITOR_SECONDS', 15, 'maximum') * 1000;
+const heartbeatMilliseconds = readLimit('MUTATION_HEARTBEAT_MINUTES', 5, 'maximum') * 60_000;
+const maximumRunMilliseconds = readLimit('MUTATION_MAX_MINUTES', 60, 'maximum') * 60_000;
+
+function readLimit(name, fallback, direction) {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${name} must be a positive number, got ${JSON.stringify(raw)}`);
+  }
+  if (direction === 'minimum' && value < fallback) {
+    throw new Error(`${name} cannot lower the safety floor below ${fallback}`);
+  }
+  if (direction === 'maximum' && value > fallback) {
+    throw new Error(`${name} cannot raise the safety ceiling above ${fallback}`);
+  }
+  return value;
+}
+
+function freeBytes() {
+  const stats = statfsSync(repoRoot);
+  return stats.bavail * stats.bsize;
+}
+
+function directoryBytes(path) {
+  if (!existsSync(path)) return 0;
+  const output = execFileSync(duBin, ['-sk', path], { encoding: 'utf8' }).trim();
+  const kibibytes = Number.parseInt(output.split(/\s+/u)[0], 10);
+  if (!Number.isFinite(kibibytes)) throw new Error(`could not parse du output for ${path}`);
+  return kibibytes * 1024;
+}
+
+function processGroupRssKiB(processGroupId) {
+  return processTable()
+    .filter(({ pgid }) => pgid === processGroupId)
+    .reduce((total, { rssKiB }) => total + rssKiB, 0);
+}
+
+function gibibytes(bytes) {
+  return (bytes / GIB).toFixed(2);
+}
+
+function mutationInputBytes(inputs) {
+  return Object.keys(inputs.files).reduce(
+    (total, fileName) => total + statSync(join(repoRoot, fileName)).size,
+    0,
+  );
+}
+
+function cleanLegacyTempDir() {
+  const resolvedTempDir = resolve(legacyTempDir);
+  if (resolvedTempDir !== join(repoRoot, '.stryker-tmp')) {
+    throw new Error(`refusing to clean unexpected temp path: ${resolvedTempDir}`);
+  }
+  try {
+    if (lstatSync(resolvedTempDir).isSymbolicLink()) {
+      unlinkSync(resolvedTempDir);
+      return;
+    }
+  } catch (error) {
+    if (error.code === 'ENOENT') return;
+    throw error;
+  }
+  rmSync(resolvedTempDir, { recursive: true, force: true });
+}
+
+function cleanMutationWorkspace() {
+  const failures = [];
+  for (const cleanup of [() => removeMutationInputStage(repoRoot), () => cleanLegacyTempDir()]) {
+    try {
+      cleanup();
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  if (failures.length > 0) {
+    throw new Error(failures.map((error) => error.message).join('; '), {
+      cause: failures[0],
+    });
+  }
+}
+
+function processExists(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error.code === 'ESRCH') return false;
+    throw error;
+  }
+}
+
+function processGroupExists(processGroupId) {
+  try {
+    process.kill(-processGroupId, 0);
+    return true;
+  } catch (error) {
+    if (error.code === 'ESRCH') return false;
+    throw error;
+  }
+}
+
+function processTable() {
+  const output = execFileSync(psBin, ['-axo', 'pgid=,pid=,rss=,command='], {
+    encoding: 'utf8',
+  });
+  if (output.trim().length === 0) return [];
+  return output
+    .trimEnd()
+    .split('\n')
+    .map((line) => /^\s*(\d+)\s+(\d+)\s+(\d+)\s+(.*)$/u.exec(line))
+    .filter((match) => match !== null)
+    .map((match) => ({
+      command: match[4].trim(),
+      pgid: Number(match[1]),
+      pid: Number(match[2]),
+      rssKiB: Number(match[3]),
+    }));
+}
+
+function processGroupProcesses(processGroupId) {
+  return processTable().filter(({ pgid }) => pgid === processGroupId);
+}
+
+function currentProcessGroupId() {
+  const current = processTable().find(({ pid }) => pid === process.pid);
+  if (!current || !Number.isInteger(current.pgid) || current.pgid <= 0) {
+    throw new Error('could not determine launcher PGID from ps output');
+  }
+  return current.pgid;
+}
+
+function probeHostUtilities() {
+  // These options are shared by the BSD ps/du on macOS and procps/coreutils on
+  // Linux. Probe them before publishing a lock or invalidating a full report.
+  directoryBytes(sourceMutationChild);
+  currentProcessGroupId();
+}
+
+const waitArray = new Int32Array(new SharedArrayBuffer(4));
+function waitForProcessGroupExit(processGroupId, timeoutMilliseconds) {
+  const deadline = Date.now() + timeoutMilliseconds;
+  while (processGroupExists(processGroupId)) {
+    if (Date.now() >= deadline) return false;
+    Atomics.wait(waitArray, 0, 0, Math.min(100, deadline - Date.now()));
+  }
+  return true;
+}
+
+async function waitForProcessGroupExitAsync(processGroupId, timeoutMilliseconds) {
+  const deadline = Date.now() + timeoutMilliseconds;
+  while (processGroupExists(processGroupId)) {
+    if (Date.now() >= deadline) return false;
+    await new Promise((resolveWait) => setTimeout(resolveWait, 50));
+  }
+  return true;
+}
+
+function reclaimOrphanedProcessGroup(record) {
+  if (!Number.isInteger(record.pgid) || record.pgid <= 0) {
+    const identity =
+      (record.version === 2 || record.version === 3) &&
+      record.pgid === null &&
+      typeof record.marker === 'string' &&
+      /^readout-mutation-[a-f0-9-]{36}$/u.test(record.marker)
+        ? `marker ${record.marker}`
+        : 'an unverifiable identity';
+    throw new Error(
+      `stale mutation lock has no persisted child PGID (${identity}); ` +
+        'refusing automatic cleanup',
+    );
+  }
+  if (!processGroupExists(record.pgid)) return;
+  if (record.pgid <= 1 || record.pgid === currentProcessGroupId()) {
+    throw new Error(`refusing to signal unsafe stale process group ${record.pgid}`);
+  }
+  if (
+    typeof record.marker !== 'string' ||
+    !/^readout-mutation-[a-f0-9-]{36}$/u.test(record.marker)
+  ) {
+    throw new Error(`stale mutation lock has no verifiable identity for PGID ${record.pgid}`);
+  }
+  const processes = processGroupProcesses(record.pgid);
+  const verifiedLeader = processes.some(
+    ({ command, pgid, pid }) => pid === pgid && pid === record.pgid && command === record.marker,
+  );
+  if (!verifiedLeader) {
+    throw new Error(`refusing to signal unverified stale process group ${record.pgid}`);
+  }
+
+  console.warn(`[mutation-monitor] reclaiming orphaned mutation process group ${record.pgid}`);
+  try {
+    process.kill(-record.pgid, 'SIGTERM');
+  } catch (error) {
+    if (error.code !== 'ESRCH') throw error;
+  }
+  if (waitForProcessGroupExit(record.pgid, 5_000)) return;
+  try {
+    process.kill(-record.pgid, 'SIGKILL');
+  } catch (error) {
+    if (error.code !== 'ESRCH') throw error;
+  }
+  if (!waitForProcessGroupExit(record.pgid, 10_000)) {
+    throw new Error(`orphaned mutation process group ${record.pgid} did not exit after SIGKILL`);
+  }
+}
+
+function persistChildProcessGroup(token, processGroupId) {
+  updateOwnedMutationLock(lockPath, token, (record) => ({ ...record, pgid: processGroupId }));
+}
+
+function acquireLock() {
+  const token = randomUUID();
+  const record = {
+    version: 3,
+    pid: process.pid,
+    pgid: null,
+    marker: childMarker,
+    mode,
+    runId,
+    startedAt: new Date().toISOString(),
+    token,
+  };
+  return acquireMutationLock({
+    isOwnerAlive: processExists,
+    lockPath,
+    reclaim: reclaimOrphanedProcessGroup,
+    record,
+    recoveryPath,
+  });
+}
+
+if (!existsSync(installedStrykerBin)) {
+  throw new Error('Stryker is not installed; run npm ci first');
+}
+probeHostUtilities();
+ensureMutationArtifactDirectory(repoRoot);
+
+const lockToken = acquireLock();
+let lockReleased = false;
+let retainLock = false;
+function releaseOwnedLock() {
+  if (lockReleased) return;
+  releaseOwnedMutationLock(lockPath, lockToken);
+  lockReleased = true;
+}
+
+const startedAt = Date.now();
+const startedAtIso = new Date(startedAt).toISOString();
+let startingFreeBytes;
+let startingInputs;
+let stagedInputs;
+let logStream;
+try {
+  // A full attempt cannot inherit a prior report or proof. Dry runs use only a
+  // text reporter and intentionally leave the last full result untouched.
+  if (fullRun) invalidateFullMutationReport(repoRoot);
+  assertMutationScopeMatchesRuntimeGraph(repoRoot);
+  startingInputs = snapshotMutationInputs(repoRoot);
+  // acquireLock() has already waited for any verified orphaned process group,
+  // so it is now safe to remove the deterministic stage and legacy sandbox.
+  cleanMutationWorkspace();
+  const preStageFreeBytes = freeBytes();
+  const existingGeneratedBytes = directoryBytes(reportDir);
+  const stagedSourceBytes = mutationInputBytes(startingInputs);
+  if (preStageFreeBytes - stagedSourceBytes < minimumFreeBytes) {
+    throw new Error(
+      `mutation run refused: staging ${gibibytes(stagedSourceBytes)} GiB from ` +
+        `${gibibytes(preStageFreeBytes)} GiB free would cross the ` +
+        `${gibibytes(minimumFreeBytes)} GiB minimum`,
+    );
+  }
+  if (existingGeneratedBytes + stagedSourceBytes > maximumGeneratedBytes) {
+    throw new Error(
+      `mutation run refused: reports plus staged inputs would use at least ` +
+        `${gibibytes(existingGeneratedBytes + stagedSourceBytes)} GiB, ` +
+        `maximum is ${gibibytes(maximumGeneratedBytes)} GiB`,
+    );
+  }
+  ({ inputs: stagedInputs } = createMutationInputStage(repoRoot, startingInputs));
+  assertMutationScopeMatchesRuntimeGraph(stageRoot);
+  startingFreeBytes = freeBytes();
+  const stagedGeneratedBytes = directoryBytes(stageRoot) + directoryBytes(reportDir);
+  if (startingFreeBytes < minimumFreeBytes) {
+    throw new Error(
+      `mutation run refused after staging: ${gibibytes(startingFreeBytes)} GiB free, ` +
+        `minimum is ${gibibytes(minimumFreeBytes)} GiB`,
+    );
+  }
+  if (stagedGeneratedBytes > maximumGeneratedBytes) {
+    throw new Error(
+      `mutation run refused after staging: mutation data is ` +
+        `${gibibytes(stagedGeneratedBytes)} GiB, ` +
+        `maximum is ${gibibytes(maximumGeneratedBytes)} GiB`,
+    );
+  }
+  const { descriptor: logDescriptor } = openMutationLogFile(repoRoot);
+  logStream = createWriteStream(logPath, { autoClose: true, fd: logDescriptor });
+} catch (error) {
+  try {
+    cleanMutationWorkspace();
+  } catch (cleanupFailure) {
+    console.error(`[mutation-monitor] initialization cleanup failed: ${cleanupFailure.message}`);
+  }
+  retainLock = fullRun && existsSync(attestationPath);
+  if (retainLock) {
+    console.error(
+      `[mutation-monitor] old attestation could not be invalidated; retaining ${lockPath}`,
+    );
+  } else {
+    releaseOwnedLock();
+  }
+  throw error;
+}
+
+console.log(
+  `[mutation-monitor] ${mode} start (concurrency=${concurrency}): ` +
+    `${gibibytes(startingFreeBytes)} GiB free; ` +
+    `limits generated=${gibibytes(maximumGeneratedBytes)} GiB, ` +
+    `rss=${gibibytes(maximumRssKiB * 1024)} GiB, ` +
+    `runtime=${Math.round(maximumRunMilliseconds / 60_000)}m; log=${logPath}`,
+);
+
+const child = spawn(
+  process.execPath,
+  [`--title=${childMarker}`, mutationChild, compatibilityHook, strykerBin, ...strykerArgs],
+  {
+    cwd: stageRoot,
+    detached: true,
+    env: {
+      ...process.env,
+      [guardEnvironment]: '1',
+      [modeEnvironment]: mode,
+      [runIdEnvironment]: runId,
+    },
+    stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+  },
+);
+child.stdout.pipe(logStream, { end: false });
+child.stderr.pipe(logStream, { end: false });
+
+const processGroupId = child.pid;
+if (!processGroupId) {
+  logStream.destroy();
+  let startupCleanupError;
+  try {
+    cleanMutationWorkspace();
+  } catch (error) {
+    startupCleanupError = error;
+  }
+  try {
+    releaseOwnedLock();
+  } catch (error) {
+    startupCleanupError ??= error;
+  }
+  if (startupCleanupError) throw startupCleanupError;
+  throw new Error('could not obtain the mutation child process-group ID');
+}
+try {
+  persistChildProcessGroup(lockToken, processGroupId);
+} catch (error) {
+  let childStopped = false;
+  let cleanupError;
+  try {
+    if (child.connected) child.disconnect();
+  } catch (disconnectError) {
+    cleanupError = disconnectError;
+  }
+  try {
+    process.kill(-processGroupId, 'SIGKILL');
+  } catch (killError) {
+    if (killError.code !== 'ESRCH') cleanupError ??= killError;
+  }
+  try {
+    // Yield to libuv while waiting so it can reap this direct child. A blocking
+    // poll can leave a killed child visible as a zombie and falsely claim that
+    // the group is still live.
+    childStopped = await waitForProcessGroupExitAsync(processGroupId, 5_000);
+  } catch (waitError) {
+    cleanupError ??= waitError;
+  }
+  logStream.destroy();
+  if (childStopped) {
+    try {
+      cleanMutationWorkspace();
+    } catch (stageCleanupError) {
+      cleanupError ??= stageCleanupError;
+    }
+    releaseOwnedLock();
+  } else {
+    // The child never receives the start handshake before its PGID is durably
+    // recorded. If synchronous cleanup cannot prove that paused group is gone,
+    // retain the lock. A persisted PGID can be verified by the next launcher;
+    // a pre-persistence lock deliberately fails closed for manual inspection.
+    const cleanupDetail = cleanupError ? ` (${cleanupError.message})` : '';
+    throw new Error(
+      `mutation child startup failed and process group ${processGroupId} could not be ` +
+        `confirmed stopped; recovery lock retained at ${lockPath}${cleanupDetail}`,
+      { cause: error },
+    );
+  }
+  throw error;
+}
+let childResult;
+let stopping = false;
+let killTimer;
+let latestSample;
+let finalized = false;
+let finalizing = false;
+let childClosed = false;
+let cleanupError;
+
+function signalProcessGroup(signal) {
+  if (!processGroupId) return;
+  try {
+    process.kill(-processGroupId, signal);
+  } catch (error) {
+    if (error.code !== 'ESRCH') throw error;
+  }
+}
+
+function stopProcessGroup(reason) {
+  if (stopping) return;
+  stopping = true;
+  console.error(`[mutation-monitor] stopping: ${reason}`);
+  signalProcessGroup('SIGTERM');
+  killTimer = setTimeout(() => signalProcessGroup('SIGKILL'), 15_000);
+}
+
+function sampleResources() {
+  const free = freeBytes();
+  const generated = directoryBytes(stageRoot) + directoryBytes(reportDir);
+  const rssKiB = processGroupId ? processGroupRssKiB(processGroupId) : 0;
+  latestSample = { free, generated, rssKiB };
+  return latestSample;
+}
+
+function inspectResources() {
+  try {
+    const sample = sampleResources();
+    if (sample.free < minimumFreeBytes) {
+      stopProcessGroup(`free disk fell to ${gibibytes(sample.free)} GiB`);
+    } else if (sample.generated > maximumGeneratedBytes) {
+      stopProcessGroup(`mutation data grew to ${gibibytes(sample.generated)} GiB`);
+    } else if (sample.rssKiB > maximumRssKiB) {
+      stopProcessGroup(`mutation processes reached ${gibibytes(sample.rssKiB * 1024)} GiB RSS`);
+    }
+  } catch (error) {
+    stopProcessGroup(`resource inspection failed: ${error.message}`);
+  }
+}
+
+function heartbeat() {
+  try {
+    const sample = latestSample ?? sampleResources();
+    const elapsedMinutes = Math.floor((Date.now() - startedAt) / 60_000);
+    console.log(
+      `[mutation-monitor] running ${elapsedMinutes}m: free=${gibibytes(sample.free)} GiB, ` +
+        `generated=${gibibytes(sample.generated)} GiB, ` +
+        `rss=${gibibytes(sample.rssKiB * 1024)} GiB`,
+    );
+  } catch (error) {
+    stopProcessGroup(`heartbeat inspection failed: ${error.message}`);
+  }
+}
+
+const monitor = setInterval(inspectResources, pollMilliseconds);
+const heartbeatTimer = setInterval(heartbeat, heartbeatMilliseconds);
+const wallClockTimer = setTimeout(
+  () => stopProcessGroup(`runtime reached ${Math.round(maximumRunMilliseconds / 60_000)} minutes`),
+  maximumRunMilliseconds,
+);
+
+function finalizeWhenProcessGroupStops() {
+  if (finalized || finalizing || childResult === undefined || !childClosed) return;
+  if (processGroupId && processGroupExists(processGroupId)) return;
+  finalizing = true;
+  clearInterval(monitor);
+  clearInterval(heartbeatTimer);
+  clearInterval(groupWatcher);
+  clearTimeout(wallClockTimer);
+  if (killTimer) clearTimeout(killTimer);
+
+  const complete = () => {
+    if (finalized) return;
+    if (killTimer) clearTimeout(killTimer);
+    let finalizationFailed = cleanupError !== undefined;
+    let finalFreeText = 'unknown';
+    try {
+      const finalSample = sampleResources();
+      finalFreeText = `${gibibytes(finalSample.free)} GiB`;
+      if (finalSample.free < minimumFreeBytes) {
+        throw new Error(`free disk fell to ${gibibytes(finalSample.free)} GiB before publication`);
+      }
+      if (finalSample.generated > maximumGeneratedBytes) {
+        throw new Error(
+          `mutation data grew to ${gibibytes(finalSample.generated)} GiB before publication`,
+        );
+      }
+    } catch (error) {
+      finalizationFailed = true;
+      console.error(`[mutation-monitor] final resource inspection failed: ${error.message}`);
+    }
+    let currentInputs;
+    let finalStagedInputs;
+    let reportBytes;
+    let htmlReportBytes;
+    let attestationWritten = false;
+    const childSucceeded = !stopping && !childResult.signal && childResult.code === 0;
+    if (childSucceeded) {
+      try {
+        finalStagedInputs = snapshotMutationInputs(stageRoot);
+        assertMutationInputsEqual(
+          stagedInputs,
+          finalStagedInputs,
+          'staged mutation inputs during run',
+        );
+        if (fullRun) {
+          currentInputs = snapshotMutationInputs(repoRoot);
+          assertMutationInputsEqual(
+            startingInputs,
+            currentInputs,
+            'working-tree mutation inputs during full run',
+          );
+          reportBytes = readFileSync(stagedReportPath);
+          htmlReportBytes = readFileSync(stagedHtmlReportPath);
+        }
+      } catch (error) {
+        finalizationFailed = true;
+        console.error(`[mutation-monitor] staged result validation failed: ${error.message}`);
+      }
+    }
+
+    try {
+      // The process-group check above is the authorization boundary for both
+      // successful cleanup and crash-recovery cleanup on the next launcher.
+      cleanMutationWorkspace();
+    } catch (error) {
+      finalizationFailed = true;
+      console.error(`[mutation-monitor] stage cleanup failed: ${error.message}`);
+    }
+
+    if (fullRun && childSucceeded && !finalizationFailed) {
+      try {
+        publishFullMutationReports(repoRoot, { htmlReportBytes, reportBytes });
+        const completedAt = new Date().toISOString();
+        writeFullRunAttestation(
+          repoRoot,
+          createFullRunAttestation({
+            completedAt,
+            executionInputs: finalStagedInputs,
+            htmlReportBytes,
+            inputs: currentInputs,
+            repoRoot,
+            reportBytes,
+            runId,
+            startedAt: startedAtIso,
+          }),
+        );
+        attestationWritten = true;
+      } catch (error) {
+        finalizationFailed = true;
+        console.error(`[mutation-monitor] full-run publication failed: ${error.message}`);
+      }
+    }
+    if (fullRun && (!childSucceeded || finalizationFailed || !attestationWritten)) {
+      try {
+        invalidateFullMutationReport(repoRoot);
+      } catch (error) {
+        finalizationFailed = true;
+        retainLock = existsSync(attestationPath);
+        console.error(`[mutation-monitor] full-run artifact invalidation failed: ${error.message}`);
+      }
+    }
+    if (!retainLock) {
+      try {
+        releaseOwnedLock();
+      } catch (error) {
+        finalizationFailed = true;
+        console.error(`[mutation-monitor] lock release failed: ${error.message}`);
+        if (fullRun) {
+          try {
+            invalidateFullMutationReport(repoRoot);
+          } catch (invalidationError) {
+            retainLock = existsSync(attestationPath);
+            console.error(
+              `[mutation-monitor] post-release-failure invalidation failed: ` +
+                invalidationError.message,
+            );
+          }
+        }
+      }
+    } else {
+      console.error(`[mutation-monitor] retaining recovery lock at ${lockPath}`);
+    }
+    const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);
+    finalized = true;
+    console.log(
+      `[mutation-monitor] end after ${elapsedSeconds}s: ${finalFreeText} free; ` + `log=${logPath}`,
+    );
+    if (stopping) process.exitCode = 75;
+    else if (finalizationFailed || childResult.signal) process.exitCode = 1;
+    else process.exitCode = childResult.code ?? 1;
+  };
+
+  if (logStream.destroyed || logStream.closed) {
+    complete();
+  } else {
+    logStream.once('close', complete);
+    logStream.end();
+  }
+}
+
+const groupWatcher = setInterval(finalizeWhenProcessGroupStops, 250);
+
+for (const signal of ['SIGHUP', 'SIGINT', 'SIGTERM']) {
+  process.on(signal, () => stopProcessGroup(`launcher received ${signal}`));
+}
+
+logStream.on('error', (error) => {
+  cleanupError ??= error;
+  if (!finalizing) stopProcessGroup(`log write failed: ${error.message}`);
+});
+
+child.on('error', (error) => {
+  childResult = { code: 1, signal: undefined };
+  stopProcessGroup(`could not start Stryker: ${error.message}`);
+  finalizeWhenProcessGroupStops();
+});
+
+child.on('message', (message) => {
+  const validCode =
+    message?.code === null || (Number.isInteger(message?.code) && message.code >= 0);
+  const validSignal = message?.signal === null || typeof message?.signal === 'string';
+  if (
+    message?.type !== 'result' ||
+    !validCode ||
+    !validSignal ||
+    (message.code === null && message.signal === null) ||
+    childResult !== undefined
+  ) {
+    stopProcessGroup('mutation child sent an invalid or duplicate result');
+    return;
+  }
+  childResult = { code: message.code, signal: message.signal ?? undefined };
+
+  try {
+    const groupProcesses = processGroupProcesses(processGroupId);
+    const verifiedLeader = groupProcesses.some(
+      ({ command, pgid, pid }) =>
+        pid === processGroupId && pgid === processGroupId && command === childMarker,
+    );
+    const descendants = groupProcesses.filter(({ pid }) => pid !== processGroupId);
+    if (!verifiedLeader || descendants.length > 0) {
+      stopProcessGroup(
+        `workload exited with ${descendants.length} descendant process(es) still in its group`,
+      );
+      return;
+    }
+    child.send({ type: 'release' }, (error) => {
+      if (error) stopProcessGroup(`could not release mutation child: ${error.message}`);
+    });
+  } catch (error) {
+    stopProcessGroup(`could not verify completed mutation process group: ${error.message}`);
+  }
+});
+
+child.on('exit', (code, signal) => {
+  childResult = { code, signal };
+  if (processGroupId && processGroupExists(processGroupId)) {
+    stopProcessGroup('Stryker leader exited while worker processes were still running');
+  }
+  finalizeWhenProcessGroupStops();
+});
+
+child.on('close', (code, signal) => {
+  childClosed = true;
+  childResult ??= { code, signal };
+  finalizeWhenProcessGroupStops();
+});
+
+process.on('exit', () => {
+  if (!finalized) {
+    try {
+      signalProcessGroup('SIGKILL');
+    } catch {
+      // A persisted PGID can be verified by the next launcher. If persistence
+      // itself failed, the marker-bearing lock intentionally remains fail-closed.
+    }
+    // Do not remove the lock or sandbox while a group may still be alive. This
+    // also makes an uncatchable SIGKILL recoverable by the next launcher.
+  } else if (!lockReleased && !retainLock) {
+    try {
+      releaseOwnedLock();
+    } catch {
+      // The next launcher can reclaim the dead owner's lock.
+    }
+  }
+});
+
+try {
+  child.send({ type: 'start', processGroupId }, (error) => {
+    if (error) stopProcessGroup(`could not send mutation start handshake: ${error.message}`);
+  });
+} catch (error) {
+  stopProcessGroup(`could not send mutation start handshake: ${error.message}`);
+}

--- a/scripts/stryker-typescript-hook.mjs
+++ b/scripts/stryker-typescript-hook.mjs
@@ -1,0 +1,18 @@
+// Stryker 10 still uses the TypeScript 6 API while preparing its sandbox and
+// bootstrapping the experimental native TypeScript 7 checker. Redirect only
+// those tooling imports; Vitest and the readout project keep resolving TS 7.
+
+import { registerHooks } from 'node:module';
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (
+      specifier === 'typescript' &&
+      (context.parentURL?.includes('/node_modules/@stryker-mutator/core/') ||
+        context.parentURL?.includes('/node_modules/@stryker-mutator/typescript-checker/'))
+    ) {
+      return nextResolve('@typescript/legacy', context);
+    }
+    return nextResolve(specifier, context);
+  },
+});

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -1,0 +1,57 @@
+if (process.env.READOUT_MUTATION_GUARD !== '1') {
+    throw new Error('Run Stryker through the guarded npm mutation scripts');
+}
+const mutationMode = process.env.READOUT_MUTATION_MODE;
+if (mutationMode !== 'dry' && mutationMode !== 'full') {
+    throw new Error('The guarded launcher must select dry or full mutation mode');
+}
+const fullRun = mutationMode === 'full';
+
+/** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
+export default {
+    $schema: './node_modules/@stryker-mutator/core/schema/stryker-schema.json',
+    mutate: [
+        'internal/assets/src/js/**/*.ts',
+        '!internal/assets/src/js/**/*.test.ts',
+        '!internal/assets/src/js/test/**',
+        '!internal/assets/src/js/types.ts',
+    ],
+    testRunner: 'vitest',
+    vitest: {
+        configFile: 'vitest.config.ts',
+        related: true,
+    },
+    checkers: ['typescript'],
+    coverageAnalysis: 'perTest',
+    tsconfigFile: 'tsconfig.json',
+    typescriptChecker: {
+        experimentalNativePreview: true,
+    },
+    checkerNodeArgs: [
+        '--import',
+        new URL('./scripts/stryker-typescript-hook.mjs', import.meta.url).href,
+    ],
+    concurrency: 2,
+    inPlace: false,
+    tempDirName: '.stryker-tmp',
+    cleanTempDir: 'always',
+    incremental: false,
+    ignoreStatic: false,
+    logLevel: 'warn',
+    fileLogLevel: 'off',
+    reporters: fullRun ? ['clear-text', 'json', 'html'] : ['clear-text'],
+    jsonReporter: {
+        fileName: 'reports/mutation/mutation.json',
+    },
+    htmlReporter: {
+        fileName: 'reports/mutation/index.html',
+    },
+    thresholds: {
+        high: 100,
+        low: 100,
+        break: 100,
+    },
+    mutator: {
+        excludedMutations: [],
+    },
+};


### PR DESCRIPTION
## Summary

- harden frontend runtime contracts across live updates, preferences, filtering, palette navigation, refresh, and malformed state
- strengthen Vitest unit and DOM coverage around races, timers, virtualization, and cross-language Go/TypeScript behavior
- add guarded StrykerJS mutation testing with bounded resources and attested local reports
- run the fast mutation-infrastructure guards in the regular frontend CI job

## Verification

- make ci
- npm run check: 588 tests, 99.43% statements, 96.72% branches
- npm run test:mutation:guards: 28 passed
- npm run test:mutation:check: 4,173 mutants; 0 survived, uncovered, timed out, runtime-error, ignored, or pending
- npm audit --audit-level=high: 0 vulnerabilities
- make e2e: 118 passed, 92 expected matrix skips