### PR TITLE
chart: usable as a subchart, gates on both helm majors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,21 +115,29 @@ jobs:
           npm run build
           git diff --exit-code -- internal/assets/static
 
-  # Helm chart gate. Users run helm 3, so CI pins helm 3 (local dev runs helm 4;
-  # both must pass). Validates: lint, default + every example render through
-  # kubeconform -strict (core types from the upstream schema, the three CR kinds
-  # from the schemas vendored in chart/ci/schemas/ -- never -ignore-missing-schemas),
-  # then the template safety-gate and values.schema.json matrix as exit-code
-  # asserts, and the golden NetworkPolicy renders (scripts/chart-golden.sh).
+  # Helm chart gate, run against BOTH helm majors: users are on either, and the
+  # schema engine (the if/then branches in particular) is the part most likely
+  # to differ between them. Validates: lint, default + every example render
+  # through kubeconform -strict (core types from the upstream schema, the three
+  # CR kinds from the schemas vendored in chart/ci/schemas/ -- never
+  # -ignore-missing-schemas), the template safety-gate and values.schema.json
+  # matrix as exit-code asserts, the golden NetworkPolicy renders
+  # (scripts/chart-golden.sh), the chart rendered as a DEPENDENCY of an umbrella
+  # parent (scripts/chart-umbrella.sh), and the image-metadata invariant that
+  # the release workflow re-checks. Release packaging stays pinned to helm 3.
   chart:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        helm-version: [v3.21.0, v4.2.1]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
-          version: v3.21.0
+          version: ${{ matrix.helm-version }}
       - name: Install kubeconform
         run: |
           curl -fsSL -o kubeconform.tar.gz \
@@ -148,6 +156,15 @@ jobs:
         run: bash scripts/chart-gate-matrix.sh chart
       - name: Gate - golden NetworkPolicy renders
         run: bash scripts/chart-golden.sh chart
+      - name: Gate - renders as a subchart of an umbrella parent
+        run: bash scripts/chart-umbrella.sh chart
+      - name: Gate - chart image metadata agrees with appVersion
+        run: bash scripts/chart-metadata-check.sh chart
+      # helm 3's `install --dry-run=client` still reaches for a cluster, so the
+      # NOTES premise/mitigation the README documents is asserted on helm 4 only.
+      - name: Gate - subchart NOTES caveat holds (helm 4)
+        if: matrix.helm-version == 'v4.2.1'
+        run: bash scripts/chart-subchart-notes.sh chart
 
   # Real install smoke on kind. The chart job only RENDERS, so anything that
   # depends on the app running inside a pod -- bind address vs. kubelet probes,

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -27,16 +27,24 @@ jobs:
         run: |
           printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
           printf '%s' "$GHCR_TOKEN" | helm registry login ghcr.io -u "$GHCR_USERNAME" --password-stdin
-      - name: Guard - tag, chart metadata, and app image agree
+      # The tag pins the CHART version only. appVersion is independent by
+      # design -- a chart-only patch moves one and not the other -- so the app
+      # image is guarded by the metadata invariant plus its existence in the
+      # registry, not by tying it to the tag.
+      - name: Guard - tag matches the chart version
         run: |
           VERSION="${GITHUB_REF_NAME#chart-v}"
           CHART=$(awk '$1 == "version:" {print $2}' chart/Chart.yaml | tr -d '"')
-          APP=$(grep '^appVersion:' chart/Chart.yaml | awk '{print $2}' | tr -d '"')
           test -n "$VERSION"
           test -n "$CHART"
-          test -n "$APP"
           test "$VERSION" = "$CHART"
-          test "$VERSION" = "$APP"
+      # Re-run of the CI gate: a tag can be pushed at a commit CI never passed.
+      - name: Guard - chart image metadata agrees with appVersion
+        run: bash scripts/chart-metadata-check.sh chart
+      - name: Guard - the app image exists in the registry
+        run: |
+          APP=$(grep '^appVersion:' chart/Chart.yaml | awk '{print $2}' | tr -d '"')
+          test -n "$APP"
           docker manifest inspect "ghcr.io/kbelokon/readout:${APP}" > /dev/null
       - name: Package and push chart
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,19 @@ additionally runs vet, `govulncheck`, frontend, Playwright, and chart jobs. Run 
 before sending a patch. Use `mise run doctor` to print the active tool versions
 when debugging local setup.
 
+The chart gates run against **both Helm majors** in CI. `.mise.toml` can pin only
+one, so it pins the helm 3 the release packaging uses; to reproduce the helm 4
+leg locally, install it alongside:
+
+```sh
+mise install helm@4.2.1
+mise exec helm@4.2.1 -- bash scripts/chart-gate-matrix.sh chart
+```
+
+Every `scripts/chart-*.sh` also honours a `HELM` variable holding a path to the
+executable, for a Helm installed outside mise. `scripts/chart-subchart-notes.sh`
+is helm 4 only: helm 3's `install --dry-run=client` still reaches for a cluster.
+
 The frontend has a separate fast gate:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ docker run --rm -p 8080:8080 -v "$PWD/readout.yaml:/readout.yaml" \
 **On Kubernetes**, with the Helm chart (the supported install path):
 
 ```sh
-helm install readout oci://ghcr.io/kbelokon/charts/readout --version 0.13.0
+helm install readout oci://ghcr.io/kbelokon/charts/readout --version 0.13.1
 ```
 
 See [`chart/README.md`](chart/README.md) for values, RBAC presets, ingress/Gateway options, and upgrade notes.
@@ -338,7 +338,7 @@ The three defaults were kept as shipped after the run: `maxConnections: 512` (~6
 If you want raw manifests instead of a Helm release — to commit them to git, pipe them into another tool, or just read them — render the chart locally:
 
 ```sh
-helm template readout oci://ghcr.io/kbelokon/charts/readout --version 0.13.0 > readout-manifests.yaml
+helm template readout oci://ghcr.io/kbelokon/charts/readout --version 0.13.1 > readout-manifests.yaml
 ```
 
 readout deploys on its own host (its own domain or subdomain); it builds root-absolute URLs everywhere and does not support being served under a subpath. The chart's `image.tag` / `appVersion` track the app release they target; the chart's own version moves independently.

--- a/chart/AGENTS.md
+++ b/chart/AGENTS.md
@@ -5,7 +5,7 @@ is a strictly read-only Kubernetes web viewer. It serves on its own host
 (subdomain or root domain) — no subpath. Follow this flow top to bottom; each
 step is concrete commands, not theory.
 
-Chart source (OCI): `oci://ghcr.io/kbelokon/charts/readout` (version `0.13.0`).
+Chart source (OCI): `oci://ghcr.io/kbelokon/charts/readout` (version `0.13.1`).
 
 ## 1. Detect cluster routing options
 
@@ -83,7 +83,7 @@ Chart values (renders manifests, runs the safety gates):
 
 ```sh
 helm template readout oci://ghcr.io/kbelokon/charts/readout \
-  --version 0.13.0 -f values.yaml
+  --version 0.13.1 -f values.yaml
 ```
 
 Raw app config (faithful to startup):
@@ -102,9 +102,9 @@ Dry-run first, then apply:
 
 ```sh
 helm upgrade --install readout oci://ghcr.io/kbelokon/charts/readout \
-  --version 0.13.0 -f values.yaml --dry-run
+  --version 0.13.1 -f values.yaml --dry-run
 helm upgrade --install readout oci://ghcr.io/kbelokon/charts/readout \
-  --version 0.13.0 -f values.yaml
+  --version 0.13.1 -f values.yaml
 ```
 
 **Upgrading a user from chart ≤ 0.6:** identity (selectors/names) changed, so
@@ -112,7 +112,7 @@ helm upgrade --install readout oci://ghcr.io/kbelokon/charts/readout \
 
 ```sh
 helm uninstall readout
-helm install readout oci://ghcr.io/kbelokon/charts/readout --version 0.13.0 -f values.yaml
+helm install readout oci://ghcr.io/kbelokon/charts/readout --version 0.13.1 -f values.yaml
 ```
 
 ## 6. Verify

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: readout
 description: Strictly read-only Kubernetes web viewer in Go
 type: application
-version: 0.13.0
+version: 0.13.1
 appVersion: 0.13.0
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/kbelokon/readout
@@ -31,13 +31,7 @@ annotations:
     - name: readout
       image: ghcr.io/kbelokon/readout:0.13.0
   artifacthub.io/changes: |
-    - kind: security
-      description: "Open the app port and the metrics port to separate NetworkPolicy peer lists (networkPolicy.ingress.from and the new networkPolicy.ingress.metricsFrom) so a metrics scraper never reaches the dashboard and the ingress controller never reaches metrics. Peers listed in `from` no longer receive the metrics port; move scrapers to `metricsFrom`."
     - kind: fixed
-      description: "Default config.listenAddress to 0.0.0.0 so a default (auth.mode none) install becomes Ready in a pod instead of binding loopback."
-    - kind: fixed
-      description: "Keep the helm-test pod out of every chart selector and admit it through the NetworkPolicy so `helm test` works with networkPolicy.enabled."
+      description: "Accept the two top-level keys a parent chart owns (`global`, and `enabled` for `condition: <name>.enabled`) so the chart can be used as a dependency of an umbrella chart. Every other unknown key stays rejected. Chart-only release: the application is unchanged at 0.13.0."
     - kind: added
-      description: "Fail the render when metrics.port equals config.port or when metricsFrom is set without metrics.enabled; warn in NOTES when no peer can reach the metrics port; document the full egress destination list."
-    - kind: changed
-      description: "Update the default readout image to v0.13.0 (released in lockstep with the chart; no application changes)."
+      description: "Document using the chart as a subchart, including that Helm does not print a subchart's NOTES unless you install with --render-subchart-notes -- this chart's safety warnings live there."

--- a/chart/README.md
+++ b/chart/README.md
@@ -47,10 +47,11 @@ Four things are worth knowing.
 - **`global` is accepted and ignored.** Helm copies the parent's `global` table
   into every subchart's values, even when the parent sets none, so the schema
   declares it. This chart version reads nothing from it: `global.imageRegistry`,
-  `global.imagePullSecrets`, `global.commonLabels` and friends have no meaning
-  here. Use the chart's own values instead — `readout.image.repository` (and
-  `readout.testFramework.image.repository` when `testFramework.enabled`) point
-  the images at a mirror.
+  `global.imagePullSecrets`, `global.commonLabels` and `global.commonAnnotations`
+  have no meaning here. Use the chart's own values instead —
+  `readout.image.repository` (and `readout.testFramework.image.repository` when
+  `testFramework.enabled`) point the images at a mirror, and
+  `readout.commonLabels` / `readout.commonAnnotations` carry shared metadata.
 - **`condition: readout.enabled` works.** The schema accepts the `enabled` key
   Helm places in the child's namespace for it. The chart implements no
   standalone on/off switch — installed directly, `enabled` does nothing.

--- a/chart/README.md
+++ b/chart/README.md
@@ -14,14 +14,14 @@ support subpath deployment, and `publicUrl` is validated as origin-only (scheme
 The chart is published as an OCI artifact:
 
 ```sh
-helm install readout oci://ghcr.io/kbelokon/charts/readout --version 0.13.0
+helm install readout oci://ghcr.io/kbelokon/charts/readout --version 0.13.1
 ```
 
 Or, with your own values:
 
 ```sh
 helm upgrade --install readout oci://ghcr.io/kbelokon/charts/readout \
-  --version 0.13.0 -f my-values.yaml
+  --version 0.13.1 -f my-values.yaml
 ```
 
 The smallest honest install (single replica, no auth, no exposure — reach it
@@ -29,6 +29,43 @@ with `kubectl port-forward`) is in [`examples/minimal.yaml`](examples/minimal.ya
 
 The image tag defaults to the chart's `appVersion`. Set `image.tag` to override,
 or `image.digest` to pin by digest — a digest always wins and the tag is ignored.
+
+## As a subchart
+
+The chart works as a dependency of an umbrella chart:
+
+```yaml
+# the parent's Chart.yaml
+dependencies:
+  - name: readout
+    version: 0.13.1
+    repository: oci://ghcr.io/kbelokon/charts
+```
+
+Four things are worth knowing.
+
+- **`global` is accepted and ignored.** Helm copies the parent's `global` table
+  into every subchart's values, even when the parent sets none, so the schema
+  declares it. This chart version reads nothing from it: `global.imageRegistry`,
+  `global.imagePullSecrets`, `global.commonLabels` and friends have no meaning
+  here. Use the chart's own values instead — `readout.image.repository` (and
+  `readout.testFramework.image.repository` when `testFramework.enabled`) point
+  the images at a mirror.
+- **`condition: readout.enabled` works.** The schema accepts the `enabled` key
+  Helm places in the child's namespace for it. The chart implements no
+  standalone on/off switch — installed directly, `enabled` does nothing.
+- **Every other unknown key is still rejected.** The root schema is closed, in
+  an umbrella exactly as standalone, so a typo in the parent's `readout:` block
+  fails the render with the offending key named. That is the schema working, not
+  the dependency being broken.
+- **NOTES are not printed by default — pass `--render-subchart-notes`.** This
+  chart warns rather than blocks (see [Safety gates](#safety-gates-and-the-env-boundary)),
+  and those warnings live in NOTES, which Helm suppresses for subcharts:
+
+  ```sh
+  helm upgrade --install platform . --render-subchart-notes
+  ```
+
 
 ## Upgrading from ≤ 0.6 (breaking)
 
@@ -44,7 +81,7 @@ migration is a clean reinstall with **no data loss**:
 
 ```sh
 helm uninstall readout
-helm install readout oci://ghcr.io/kbelokon/charts/readout --version 0.13.0 -f my-values.yaml
+helm install readout oci://ghcr.io/kbelokon/charts/readout --version 0.13.1 -f my-values.yaml
 ```
 
 Fresh installs of 0.7 are unaffected.
@@ -189,6 +226,13 @@ quietly missing feature. Every gate sees **chart values only**: config
 delivered through `env`/`envFrom` (opaque references the chart cannot read)
 bypasses them entirely, backstopped by the **app's own startup checks** and
 `readout config validate` (see [Validating before install](#validating-before-install)).
+
+**These warnings are only as good as their delivery.** They are printed by
+`helm install`/`helm upgrade`; `helm template` never prints NOTES at all, and
+neither do GitOps controllers that do not surface release notes. Installed as a
+subchart they are suppressed unless you pass `--render-subchart-notes` (see
+[As a subchart](#as-a-subchart)). On those paths, read this section instead of
+expecting the install to tell you.
 
 Warnings (install proceeds, NOTES warns):
 
@@ -345,7 +389,7 @@ Two complementary checks:
 - **Chart values** — render the manifests and let the gates run:
 
   ```sh
-  helm template readout oci://ghcr.io/kbelokon/charts/readout --version 0.13.0 -f my-values.yaml
+  helm template readout oci://ghcr.io/kbelokon/charts/readout --version 0.13.1 -f my-values.yaml
   ```
 
 - **Raw app config** — validate a `readout.yaml` exactly as startup would:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4,6 +4,14 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "global": {
+      "type": "object",
+      "description": "Helm copies the parent chart's global table into every subchart's values, even when the parent sets none. Declared so this chart can be used as a dependency; this chart version accepts it and reads nothing from it."
+    },
+    "enabled": {
+      "type": "boolean",
+      "description": "Consumed by a parent chart's dependency condition (condition: <name>.enabled). This chart implements no standalone on/off switch."
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/scripts/chart-gate-matrix.sh
+++ b/scripts/chart-gate-matrix.sh
@@ -3,9 +3,14 @@
 # inputs they must reject and accept the inputs they must accept. Each case
 # checks the exit code of `helm template` -- or, for expect_grep /
 # expect_no_grep, the presence or absence of a line of its rendered output -- so
-# it works identically on helm 3 (CI) and helm 4 (local). A wrong exit code, a
+# CI runs it on helm 3 and helm 4 alike (the chart job matrix). A wrong exit code, a
 # missing rendered line, or a line that must not render, exits non-zero.
 set -uo pipefail
+
+# Helm binary to drive: CI's chart job runs this on both majors. Locally,
+# `mise exec helm@<version> -- ...` is enough; HELM takes a path to an
+# executable installed outside mise.
+HELM="${HELM:-helm}"
 
 CHART_DIR="${1:-chart}"
 fail=0
@@ -14,7 +19,7 @@ fail=0
 # that MUST exit non-zero (a gate or schema rejection).
 expect_fail() {
   local desc="$1"; shift
-  if helm template readout "$CHART_DIR" "$@" >/dev/null 2>&1; then
+  if "$HELM" template readout "$CHART_DIR" "$@" >/dev/null 2>&1; then
     echo "FAIL (expected non-zero, got zero): $desc"
     fail=1
   else
@@ -25,7 +30,7 @@ expect_fail() {
 # expect_pass <description> -- the call MUST exit zero.
 expect_pass() {
   local desc="$1"; shift
-  if helm template readout "$CHART_DIR" "$@" >/dev/null 2>&1; then
+  if "$HELM" template readout "$CHART_DIR" "$@" >/dev/null 2>&1; then
     echo "ok (accepted): $desc"
   else
     echo "FAIL (expected zero, got non-zero): $desc"
@@ -38,7 +43,7 @@ expect_pass() {
 # regex. Use it to pin a rendered VALUE, not just an exit code.
 expect_grep() {
   local desc="$1" pattern="$2"; shift 2
-  if helm template readout "$CHART_DIR" "$@" 2>/dev/null | grep -q -E "$pattern"; then
+  if "$HELM" template readout "$CHART_DIR" "$@" 2>/dev/null | grep -q -E "$pattern"; then
     echo "ok (rendered): $desc"
   else
     echo "FAIL (pattern not rendered: $pattern): $desc"
@@ -52,7 +57,7 @@ expect_grep() {
 expect_no_grep() {
   local desc="$1" pattern="$2"; shift 2
   local out
-  if ! out="$(helm template readout "$CHART_DIR" "$@" 2>/dev/null)" || [ -z "$out" ]; then
+  if ! out="$("$HELM" template readout "$CHART_DIR" "$@" 2>/dev/null)" || [ -z "$out" ]; then
     echo "FAIL (render failed or empty): $desc"
     fail=1
   elif grep -q -E "$pattern" <<<"$out"; then
@@ -107,7 +112,8 @@ expect_pass "oidc multi-replica with name-only env husk renders (warns, never bl
   --set 'env[0].name=READOUT_SESSION_SECRET'
 
 # Schema conditional (if/then) branches -- the constructs most likely to
-# diverge between the helm 3 and helm 4 schema engines, so probe them on both.
+# diverge between the helm 3 and helm 4 schema engines; the chart job matrix
+# runs this file on both.
 expect_fail "schema rejects ingress.enabled with zero hosts" \
   --set ingress.enabled=true
 expect_fail "schema rejects existingSecret with empty key" \
@@ -147,5 +153,20 @@ expect_no_grep "helm-test pod carries no app.kubernetes.io/name" \
 # explicit all-interfaces bind by default.
 expect_grep "default config binds all interfaces (loopback is unreachable in a pod)" \
   '^\s*listenAddress: "?0\.0\.0\.0"?$' -s templates/configmap.yaml
+
+# Schema: the two top-level keys a PARENT chart owns are accepted. Helm copies
+# its `global` table into every subchart's values (even when the parent sets
+# none), and `condition: <name>.enabled` puts `enabled` in the child namespace.
+# A chart whose root schema rejects them cannot be used as a dependency at all.
+# The real subchart path is exercised by scripts/chart-umbrella.sh; these two
+# only pin the schema itself.
+expect_pass "schema accepts a parent-injected global block" \
+  --set-json 'global={"imageRegistry":"mirror.example.com"}'
+expect_pass "schema accepts a parent-injected enabled flag" \
+  --set enabled=true
+# ...while every OTHER unknown top-level key stays rejected, in an umbrella's
+# child namespace exactly as standalone.
+expect_fail "schema still rejects an unknown top-level key" \
+  --set replicaCounttypo=3
 
 exit "$fail"

--- a/scripts/chart-golden.sh
+++ b/scripts/chart-golden.sh
@@ -3,11 +3,16 @@
 # exact shape matters (WHICH peers get WHICH port), so an exit-code assert is
 # not enough: each case under chart/ci/golden/ pairs <case>.values.yaml with
 # the expected render <case>.yaml of templates/networkpolicy.yaml, and any
-# drift fails with a diff. Runs identically on helm 3 (CI) and helm 4 (local).
+# drift fails with a diff. CI runs it on helm 3 and helm 4 alike (chart job matrix).
 #
 #   scripts/chart-golden.sh [chart-dir]        # assert
 #   UPDATE=1 scripts/chart-golden.sh [chart-dir]  # rewrite expected files
 set -uo pipefail
+
+# Helm binary to drive: CI's chart job runs this on both majors. Locally,
+# `mise exec helm@<version> -- ...` is enough; HELM takes a path to an
+# executable installed outside mise.
+HELM="${HELM:-helm}"
 
 CHART_DIR="${1:-chart}"
 GOLDEN_DIR="$CHART_DIR/ci/golden"
@@ -22,7 +27,7 @@ normalize() {
 }
 
 render() {
-  helm template readout "$CHART_DIR" -s "$TEMPLATE" -f "$1" | normalize
+  "$HELM" template readout "$CHART_DIR" -s "$TEMPLATE" -f "$1" | normalize
 }
 
 for values in "$GOLDEN_DIR"/*.values.yaml; do

--- a/scripts/chart-kubeconform.sh
+++ b/scripts/chart-kubeconform.sh
@@ -8,6 +8,11 @@
 # We never pass -ignore-missing-schemas: an unknown kind must fail, not skip.
 set -euo pipefail
 
+# Helm binary to drive: CI's chart job runs this on both majors. Locally,
+# `mise exec helm@<version> -- ...` is enough; HELM takes a path to an
+# executable installed outside mise.
+HELM="${HELM:-helm}"
+
 CHART_DIR="${1:-chart}"
 SCHEMA_LOCATION="${CHART_DIR}/ci/schemas/{{ .Group }}/{{ .ResourceKind }}_{{ .ResourceAPIVersion }}.json"
 
@@ -18,11 +23,11 @@ validate() {
 }
 
 echo "==> default render"
-helm template readout "$CHART_DIR" | validate
+"$HELM" template readout "$CHART_DIR" | validate
 
 for f in "$CHART_DIR"/examples/*.yaml; do
   echo "==> example: $f"
-  helm template readout "$CHART_DIR" -f "$f" | validate
+  "$HELM" template readout "$CHART_DIR" -f "$f" | validate
 done
 
 # The NetworkPolicy renders only under networkPolicy.enabled, which no example
@@ -31,7 +36,7 @@ done
 # kubeconform pins the object's SHAPE.
 for f in "$CHART_DIR"/ci/golden/*.values.yaml; do
   echo "==> golden values: $f"
-  helm template readout "$CHART_DIR" -f "$f" | validate
+  "$HELM" template readout "$CHART_DIR" -f "$f" | validate
 done
 
 echo "OK"

--- a/scripts/chart-metadata-check.sh
+++ b/scripts/chart-metadata-check.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Assert that every place naming the application image agrees with appVersion:
+#
+#   appVersion  ==  artifacthub.io/images[name=readout] tag  ==  default render
+#
+# Chart.version is deliberately NOT part of that equality. A chart-only patch
+# moves the chart while the application stands still, and the Artifact Hub
+# annotation is the one place carrying a hardcoded tag that nothing else pins --
+# so it is exactly what drifts silently once the two versions separate.
+#
+# Run from CI on every PR (early, fixable with a commit) and again from the
+# release workflow (a tag can be pushed at a commit CI never passed).
+set -uo pipefail
+
+CHART_DIR="${1:-chart}"
+# Helm binary to drive: CI's chart job runs this on both majors. Locally,
+# `mise exec helm@<version> -- ...` is enough; HELM takes a path to an
+# executable installed outside mise.
+HELM="${HELM:-helm}"
+YQ="${YQ:-yq}"
+
+# Mike Farah's yq, not the Python wrapper of the same name: the expressions
+# below are its dialect, and the wrapper would parse them differently.
+if ! "$YQ" --version 2>/dev/null | grep -q 'github.com/mikefarah/yq'; then
+  echo "FAIL: need Mike Farah's yq v4 on PATH (got: $("$YQ" --version 2>&1 || echo none))"
+  exit 1
+fi
+
+fail=0
+die() { echo "FAIL: $1"; fail=1; }
+
+version="$("$YQ" -r '.version' "$CHART_DIR/Chart.yaml")"
+appversion="$("$YQ" -r '.appVersion' "$CHART_DIR/Chart.yaml")"
+[ -n "$version" ] && [ "$version" != "null" ] || die "Chart.yaml has no version"
+[ -n "$appversion" ] && [ "$appversion" != "null" ] || die "Chart.yaml has no appVersion"
+
+# Exactly one readout entry in the annotation: a second one, or none, means the
+# equality below would be silently checking the wrong thing.
+entries="$("$YQ" -r '.annotations."artifacthub.io/images"' "$CHART_DIR/Chart.yaml" \
+  | "$YQ" -r '[.[] | select(.name == "readout")] | length')"
+[ "$entries" = "1" ] || die "artifacthub.io/images must hold exactly one entry named readout (found $entries)"
+
+annotated="$("$YQ" -r '.annotations."artifacthub.io/images"' "$CHART_DIR/Chart.yaml" \
+  | "$YQ" -r '.[] | select(.name == "readout") | .image')"
+
+# Select the container by NAME: extraContainers makes the ordering a user's
+# choice, so an index would pin something this chart does not own.
+rendered="$("$HELM" template readout "$CHART_DIR" -s templates/deployment.yaml \
+  | "$YQ" -r '.spec.template.spec.containers[] | select(.name == "readout") | .image')"
+[ -n "$rendered" ] && [ "$rendered" != "null" ] || die "could not read the rendered readout image"
+
+expected="ghcr.io/kbelokon/readout:${appversion}"
+[ "$annotated" = "$expected" ] || die "artifacthub.io/images is $annotated, expected $expected"
+[ "$rendered" = "$expected" ] || die "the default render is $rendered, expected $expected"
+
+if [ "$fail" = 0 ]; then
+  echo "ok: appVersion $appversion == annotation == default render (chart version $version, free to differ)"
+fi
+exit "$fail"

--- a/scripts/chart-metadata-check.sh
+++ b/scripts/chart-metadata-check.sh
@@ -19,12 +19,14 @@ CHART_DIR="${1:-chart}"
 HELM="${HELM:-helm}"
 YQ="${YQ:-yq}"
 
-# Mike Farah's yq, not the Python wrapper of the same name: the expressions
-# below are its dialect, and the wrapper would parse them differently.
-if ! "$YQ" --version 2>/dev/null | grep -q 'github.com/mikefarah/yq'; then
-  echo "FAIL: need Mike Farah's yq v4 on PATH (got: $("$YQ" --version 2>&1 || echo none))"
-  exit 1
-fi
+# Mike Farah's yq v4, not the Python wrapper of the same name and not a future
+# major: the expressions below are that dialect, and another one would parse
+# them differently -- silently, since a wrong parse still prints something.
+yq_version="$("$YQ" --version 2>&1)" || yq_version="none"
+case "$yq_version" in
+  *github.com/mikefarah/yq*version\ v4.*) ;;
+  *) echo "FAIL: need Mike Farah's yq v4 on PATH (got: $yq_version)"; exit 1 ;;
+esac
 
 fail=0
 die() { echo "FAIL: $1"; fail=1; }

--- a/scripts/chart-subchart-notes.sh
+++ b/scripts/chart-subchart-notes.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Assert the premise and the mitigation of the chart README's subchart caveat.
+#
+# This chart's safety model is "warn, never block": exposing a no-auth instance,
+# or enabling a NetworkPolicy with no egress, RENDERS and warns through NOTES.
+# Helm does not print a subchart's NOTES unless the installer asks for them, so
+# an umbrella install silently drops every one of those warnings. The README
+# tells operators to install with --render-subchart-notes; this file is what
+# keeps that instruction from quietly becoming wrong.
+#
+# HELM 4 ONLY: helm 3's `install --dry-run=client` still reaches for a cluster,
+# so the workflow calls this script from the helm 4 matrix leg alone rather than
+# hiding a skip in here.
+set -uo pipefail
+
+CHART_DIR="${1:-chart}"
+# Helm binary to drive: CI's chart job runs this on both majors. Locally,
+# `mise exec helm@<version> -- ...` is enough; HELM takes a path to an
+# executable installed outside mise.
+HELM="${HELM:-helm}"
+
+# A marker owned by THIS repository (chart/templates/NOTES.txt), not by Helm:
+# rewording the warning is a deliberate act that must update this file too.
+MARKER='WARNING: auth.mode is "none"'
+
+fail=0
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+mkdir -p "$work/charts"
+cp -R "$CHART_DIR" "$work/charts/readout"
+cat > "$work/Chart.yaml" <<'EOF'
+apiVersion: v2
+name: wrapper
+version: 0.1.0
+dependencies:
+  - name: readout
+EOF
+printf '{}\n' > "$work/values.yaml"
+
+# Both outputs are captured from a SUCCESSFUL install and required to be
+# non-empty first, so a broken install can never read as "the warning is absent".
+if ! default_out="$("$HELM" install w "$work" --dry-run=client 2>&1)" || [ -z "$default_out" ]; then
+  echo "FAIL (dry-run install failed): default output"
+  fail=1
+elif grep -qF "$MARKER" <<<"$default_out"; then
+  echo "FAIL (subchart NOTES appeared by default -- the README caveat is stale): Helm default suppresses subchart safety NOTES (README premise)"
+  fail=1
+else
+  echo "ok (suppressed): Helm default suppresses subchart safety NOTES (README premise)"
+fi
+
+if ! flagged_out="$("$HELM" install w "$work" --dry-run=client --render-subchart-notes 2>&1)" || [ -z "$flagged_out" ]; then
+  echo "FAIL (dry-run install failed): --render-subchart-notes output"
+  fail=1
+elif grep -qF "$MARKER" <<<"$flagged_out"; then
+  echo "ok (surfaced): --render-subchart-notes surfaces subchart safety warning (documented mitigation)"
+else
+  echo "FAIL (the documented mitigation no longer surfaces the warning): --render-subchart-notes surfaces subchart safety warning (documented mitigation)"
+  fail=1
+fi
+
+exit "$fail"

--- a/scripts/chart-umbrella.sh
+++ b/scripts/chart-umbrella.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Render the chart AS A DEPENDENCY of a throwaway parent chart. Helm coalesces
+# the parent's `global` table into every subchart's values unconditionally --
+# even when the parent sets none -- and `condition: <name>.enabled` lands
+# `enabled` in the child's own namespace. A root schema with
+# additionalProperties:false must therefore declare both, or the chart cannot be
+# a dependency at all: the render aborts before a single object is produced.
+#
+# The parent is built UNPACKED (the chart is copied into charts/), so no
+# `helm dependency build`, no registry and no network are involved, and the
+# dependency carries no version constraint to keep in step with Chart.yaml.
+set -uo pipefail
+
+CHART_DIR="${1:-chart}"
+
+# Helm binary to drive: CI's chart job runs this on both majors. Locally,
+# `mise exec helm@<version> -- ...` is enough; HELM takes a path to an
+# executable installed outside mise.
+HELM="${HELM:-helm}"
+
+fail=0
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# expect_render <description> -- the parent in $work MUST render, and its output
+# MUST contain the subchart's Deployment. A zero exit with an empty render (the
+# `condition` never matched, say) is a FAIL, not a pass.
+expect_render() {
+  local desc="$1" out
+  if ! out="$("$HELM" template w "$work" 2>&1)"; then
+    echo "FAIL (render failed): $desc"
+    printf '%s\n' "$out" | sed 's/^/    /' | head -5
+    fail=1
+  elif ! grep -q '^kind: Deployment$' <<<"$out"; then
+    echo "FAIL (rendered nothing from the subchart): $desc"
+    fail=1
+  else
+    echo "ok (rendered as a subchart): $desc"
+  fi
+}
+
+mkdir -p "$work/charts"
+cp -R "$CHART_DIR" "$work/charts/readout"
+
+# Case 1: a plain dependency. The parent declares no `global` of its own; Helm
+# injects the key regardless, which is the whole point of the case.
+cat > "$work/Chart.yaml" <<'EOF'
+apiVersion: v2
+name: wrapper
+version: 0.1.0
+dependencies:
+  - name: readout
+EOF
+cat > "$work/values.yaml" <<'EOF'
+global:
+  sentinel: from-the-parent
+EOF
+expect_render "plain dependency with a parent global block"
+
+# Case 2: the dependency is gated by a Helm `condition`, whose value path sits
+# inside the subchart's OWN namespace -- so `enabled` reaches the child too.
+cat > "$work/Chart.yaml" <<'EOF'
+apiVersion: v2
+name: wrapper
+version: 0.1.0
+dependencies:
+  - name: readout
+    condition: readout.enabled
+EOF
+cat > "$work/values.yaml" <<'EOF'
+global:
+  sentinel: from-the-parent
+readout:
+  enabled: true
+EOF
+expect_render "dependency gated by condition: readout.enabled"
+
+# The strict root schema still does its job through the parent: a typo in the
+# umbrella's own values must be rejected, exactly as it is standalone.
+if "$HELM" template w "$work" --set readout.replicaCounttypo=3 >/dev/null 2>&1; then
+  echo "FAIL (expected non-zero, got zero): parent-side typo in child values is rejected"
+  fail=1
+else
+  echo "ok (rejected): parent-side typo in child values"
+fi
+
+exit "$fail"

--- a/scripts/chart-umbrella.sh
+++ b/scripts/chart-umbrella.sh
@@ -42,8 +42,10 @@ expect_render() {
 mkdir -p "$work/charts"
 cp -R "$CHART_DIR" "$work/charts/readout"
 
-# Case 1: a plain dependency. The parent declares no `global` of its own; Helm
-# injects the key regardless, which is the whole point of the case.
+# Case 1: a plain dependency whose parent sets NO global of its own. Helm
+# coalesces the key in regardless -- that unconditional injection is what a
+# closed root schema has to survive, and it is the case an umbrella author
+# hits without ever writing the word `global`.
 cat > "$work/Chart.yaml" <<'EOF'
 apiVersion: v2
 name: wrapper
@@ -51,11 +53,8 @@ version: 0.1.0
 dependencies:
   - name: readout
 EOF
-cat > "$work/values.yaml" <<'EOF'
-global:
-  sentinel: from-the-parent
-EOF
-expect_render "plain dependency with a parent global block"
+printf '{}\n' > "$work/values.yaml"
+expect_render "plain dependency, parent sets no global at all"
 
 # Case 2: the dependency is gated by a Helm `condition`, whose value path sits
 # inside the subchart's OWN namespace -- so `enabled` reaches the child too.


### PR DESCRIPTION
The chart's closed root schema rejected the `global` table Helm propagates into every subchart and the `enabled` value a parent's dependency `condition` owns, so readout could not be used as a dependency of an umbrella chart at all.

Alongside the fix: the chart gates now run on both helm majors (nothing ran helm 4 before, despite three comments claiming otherwise), the release guard no longer ties the tag to `appVersion` so a chart-only patch is possible, and the README documents the subchart path including that Helm suppresses a subchart's NOTES.