### PR TITLE
chart: imagePullSecrets on both pods, no SA token in the test pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ docker run --rm -p 8080:8080 -v "$PWD/readout.yaml:/readout.yaml" \
 **On Kubernetes**, with the Helm chart (the supported install path):
 
 ```sh
-helm install readout oci://ghcr.io/kbelokon/charts/readout --version 0.13.1
+helm install readout oci://ghcr.io/kbelokon/charts/readout --version 0.14.0
 ```
 
 See [`chart/README.md`](chart/README.md) for values, RBAC presets, ingress/Gateway options, and upgrade notes.
@@ -338,7 +338,7 @@ The three defaults were kept as shipped after the run: `maxConnections: 512` (~6
 If you want raw manifests instead of a Helm release — to commit them to git, pipe them into another tool, or just read them — render the chart locally:
 
 ```sh
-helm template readout oci://ghcr.io/kbelokon/charts/readout --version 0.13.1 > readout-manifests.yaml
+helm template readout oci://ghcr.io/kbelokon/charts/readout --version 0.14.0 > readout-manifests.yaml
 ```
 
 readout deploys on its own host (its own domain or subdomain); it builds root-absolute URLs everywhere and does not support being served under a subpath. The chart's `image.tag` / `appVersion` track the app release they target; the chart's own version moves independently.

--- a/chart/AGENTS.md
+++ b/chart/AGENTS.md
@@ -5,7 +5,7 @@ is a strictly read-only Kubernetes web viewer. It serves on its own host
 (subdomain or root domain) — no subpath. Follow this flow top to bottom; each
 step is concrete commands, not theory.
 
-Chart source (OCI): `oci://ghcr.io/kbelokon/charts/readout` (version `0.13.1`).
+Chart source (OCI): `oci://ghcr.io/kbelokon/charts/readout` (version `0.14.0`).
 
 ## 1. Detect cluster routing options
 
@@ -83,7 +83,7 @@ Chart values (renders manifests, runs the safety gates):
 
 ```sh
 helm template readout oci://ghcr.io/kbelokon/charts/readout \
-  --version 0.13.1 -f values.yaml
+  --version 0.14.0 -f values.yaml
 ```
 
 Raw app config (faithful to startup):
@@ -102,9 +102,9 @@ Dry-run first, then apply:
 
 ```sh
 helm upgrade --install readout oci://ghcr.io/kbelokon/charts/readout \
-  --version 0.13.1 -f values.yaml --dry-run
+  --version 0.14.0 -f values.yaml --dry-run
 helm upgrade --install readout oci://ghcr.io/kbelokon/charts/readout \
-  --version 0.13.1 -f values.yaml
+  --version 0.14.0 -f values.yaml
 ```
 
 **Upgrading a user from chart ≤ 0.6:** identity (selectors/names) changed, so
@@ -112,7 +112,7 @@ helm upgrade --install readout oci://ghcr.io/kbelokon/charts/readout \
 
 ```sh
 helm uninstall readout
-helm install readout oci://ghcr.io/kbelokon/charts/readout --version 0.13.1 -f values.yaml
+helm install readout oci://ghcr.io/kbelokon/charts/readout --version 0.14.0 -f values.yaml
 ```
 
 ## 6. Verify

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: readout
 description: Strictly read-only Kubernetes web viewer in Go
 type: application
-version: 0.13.1
+version: 0.14.0
 appVersion: 0.13.0
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/kbelokon/readout
@@ -31,7 +31,7 @@ annotations:
     - name: readout
       image: ghcr.io/kbelokon/readout:0.13.0
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "Accept the two top-level keys a parent chart owns (`global`, and `enabled` for `condition: <name>.enabled`) so the chart can be used as a dependency of an umbrella chart. Every other unknown key stays rejected. Chart-only release: the application is unchanged at 0.13.0."
     - kind: added
-      description: "Document using the chart as a subchart, including that Helm does not print a subchart's NOTES unless you install with --render-subchart-notes -- this chart's safety warnings live there."
+      description: "New `imagePullSecrets` value, applied to both pods the chart renders: the readout Deployment and the `helm test` pod (which pulls a different image, from a different registry). Kubernetes-native shape -- a list of `{name: <secret>}`."
+    - kind: security
+      description: "The `helm test` pod no longer mounts the namespace default ServiceAccount's token. It curls the release's Service and never calls the apiserver, so the token was unnecessary. The readout pod's own automountServiceAccountToken is unchanged -- Live/in-cluster mode needs it."

--- a/chart/README.md
+++ b/chart/README.md
@@ -14,14 +14,14 @@ support subpath deployment, and `publicUrl` is validated as origin-only (scheme
 The chart is published as an OCI artifact:
 
 ```sh
-helm install readout oci://ghcr.io/kbelokon/charts/readout --version 0.13.1
+helm install readout oci://ghcr.io/kbelokon/charts/readout --version 0.14.0
 ```
 
 Or, with your own values:
 
 ```sh
 helm upgrade --install readout oci://ghcr.io/kbelokon/charts/readout \
-  --version 0.13.1 -f my-values.yaml
+  --version 0.14.0 -f my-values.yaml
 ```
 
 The smallest honest install (single replica, no auth, no exposure — reach it
@@ -38,7 +38,7 @@ The chart works as a dependency of an umbrella chart:
 # the parent's Chart.yaml
 dependencies:
   - name: readout
-    version: 0.13.1
+    version: 0.14.0
     repository: oci://ghcr.io/kbelokon/charts
 ```
 
@@ -50,7 +50,8 @@ Four things are worth knowing.
   `global.imagePullSecrets`, `global.commonLabels` and `global.commonAnnotations`
   have no meaning here. Use the chart's own values instead —
   `readout.image.repository` (and `readout.testFramework.image.repository` when
-  `testFramework.enabled`) point the images at a mirror, and
+  `testFramework.enabled`) point the images at a mirror,
+  `readout.imagePullSecrets` covers both pods the chart renders, and
   `readout.commonLabels` / `readout.commonAnnotations` carry shared metadata.
 - **`condition: readout.enabled` works.** The schema accepts the `enabled` key
   Helm places in the child's namespace for it. The chart implements no
@@ -82,7 +83,7 @@ migration is a clean reinstall with **no data loss**:
 
 ```sh
 helm uninstall readout
-helm install readout oci://ghcr.io/kbelokon/charts/readout --version 0.13.1 -f my-values.yaml
+helm install readout oci://ghcr.io/kbelokon/charts/readout --version 0.14.0 -f my-values.yaml
 ```
 
 Fresh installs of 0.7 are unaffected.
@@ -108,6 +109,7 @@ Every public key in `values.yaml`. Nested keys are described in the parent row.
 | Key | Default | Description |
 | --- | --- | --- |
 | `image` | `{repository: ghcr.io/kbelokon/readout, tag: "", digest: "", pullPolicy: IfNotPresent}` | Container image. `tag` defaults to the chart `appVersion` when empty; `digest`, when set, wins over `tag`. |
+| `imagePullSecrets` | `[]` | Pull secrets for **both** pods the chart renders — the readout Deployment and the `helm test` pod, which pulls a different image from a different registry. Kubernetes-native shape: a list of `{name: <secret>}` naming Secrets that already exist in the release namespace. They live on the PodSpecs rather than on a ServiceAccount — Kubernetes would copy them into the pods from there too, but that ties registry credentials to an account's identity and lifecycle, and behaves differently for a chart-managed, a pre-existing and the namespace default account (the test pod uses the last). |
 | `nameOverride` | `""` | Override the chart name used in generated resource names. |
 | `fullnameOverride` | `""` | Override the fully-qualified release name outright. |
 | `commonLabels` | `{}` | Labels merged into every rendered resource (applied last, so they override standard chart labels of the same name). |
@@ -142,7 +144,7 @@ Every public key in `values.yaml`. Nested keys are described in the parent row.
 | `extraContainers` | `[]` | Extra sidecar containers, rendered verbatim into the pod. |
 | `podDisruptionBudget` | `{enabled: false, minAvailable: "", maxUnavailable: ""}` | PodDisruptionBudget for readout pods. Set exactly one of `minAvailable`/`maxUnavailable` (Kubernetes rejects both). |
 | `extraObjects` | `[]` | Escape hatch for arbitrary Helm-owned objects (platform CRs, extra Secrets). Each entry is one YAML map; string values run through `tpl` with the chart root context. See [Exposure recipes](#exposure-recipes). |
-| `testFramework` | `{enabled: false, image: {repository: curlimages/curl, tag: "8.11.1"}}` | Opt-in `helm test` connectivity pod. When enabled, `helm test <release>` runs a curl pod against the Service's `/readyz`. The pod carries no `app.kubernetes.io/name`, so it is outside every chart selector; under `networkPolicy.enabled` the policy admits it automatically. |
+| `testFramework` | `{enabled: false, image: {repository: curlimages/curl, tag: "8.11.1"}}` | Opt-in `helm test` connectivity pod. When enabled, `helm test <release>` runs a curl pod against the Service's `/readyz`. The pod carries no `app.kubernetes.io/name`, so it is outside every chart selector; under `networkPolicy.enabled` the policy admits it automatically. It mounts no ServiceAccount token (it only curls the Service) and honours `imagePullSecrets`. |
 
 ## Exposure recipes
 
@@ -390,7 +392,7 @@ Two complementary checks:
 - **Chart values** — render the manifests and let the gates run:
 
   ```sh
-  helm template readout oci://ghcr.io/kbelokon/charts/readout --version 0.13.1 -f my-values.yaml
+  helm template readout oci://ghcr.io/kbelokon/charts/readout --version 0.14.0 -f my-values.yaml
   ```
 
 - **Raw app config** — validate a `readout.yaml` exactly as startup would:

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
         {{- . | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "readout.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- with .Values.priorityClassName }}

--- a/chart/templates/tests/test-connection.yaml
+++ b/chart/templates/tests/test-connection.yaml
@@ -19,6 +19,10 @@ spec:
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  # curl only ever talks to the release's own Service. It has no business with
+  # the apiserver, so the namespace default account's token stays unmounted --
+  # unlike the readout pod, whose deliberate `true` the Live mode needs.
+  automountServiceAccountToken: false
   restartPolicy: Never
   containers:
     - name: test-connection

--- a/chart/templates/tests/test-connection.yaml
+++ b/chart/templates/tests/test-connection.yaml
@@ -15,6 +15,10 @@ metadata:
     helm.sh/hook: test
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   restartPolicy: Never
   containers:
     - name: test-connection

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -36,6 +36,22 @@
         }
       }
     },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
     "nameOverride": {
       "type": "string"
     },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -6,6 +6,17 @@ image:
   digest: ""
   pullPolicy: IfNotPresent
 
+# Pull secrets for BOTH pods this chart renders: the readout Deployment and the
+# `helm test` pod, which pulls a DIFFERENT image from a different registry.
+# They live on the PodSpecs rather than on a ServiceAccount (where Kubernetes
+# would also copy them into the pods) because that would tie registry
+# credentials to the identity and lifecycle of an account, and behave
+# differently again for a chart-managed, a pre-existing and the namespace
+# default one -- the test pod uses the last of those. Kubernetes-native shape:
+# LocalObjectReferences naming Secrets that already exist in the namespace.
+imagePullSecrets: []
+# - name: regcred
+
 # overrides for generated resource names
 nameOverride: ""
 fullnameOverride: ""

--- a/scripts/chart-gate-matrix.sh
+++ b/scripts/chart-gate-matrix.sh
@@ -180,6 +180,13 @@ expect_grep "imagePullSecrets reach the helm-test pod" \
   '^\s*- name: regcred$' \
   --set 'imagePullSecrets[0].name=regcred' --set testFramework.enabled=true \
   -s templates/tests/test-connection.yaml
+# The helm-test pod curls the Service and never calls the apiserver, so it must
+# not carry the default account's projected token. (The readout pod's own
+# `true` is deliberate -- Live mode needs it -- and is asserted separately.)
+expect_grep "helm-test pod mounts no ServiceAccount token" \
+  '^\s*automountServiceAccountToken: false$' \
+  --set testFramework.enabled=true -s templates/tests/test-connection.yaml
+
 # Only the Kubernetes-native shape is accepted: a list of {name: <secret>}.
 # A bare string, a missing name, and an empty name are all rejected rather than
 # rendering a pull secret Kubernetes will silently ignore.

--- a/scripts/chart-gate-matrix.sh
+++ b/scripts/chart-gate-matrix.sh
@@ -169,4 +169,25 @@ expect_pass "schema accepts a parent-injected enabled flag" \
 expect_fail "schema still rejects an unknown top-level key" \
   --set replicaCounttypo=3
 
+# Pull secrets reach BOTH pods that pull an image -- the helm-test pod pulls a
+# different image from a different registry. They are pinned on the PodSpecs
+# rather than on a ServiceAccount, which would tie them to an account's
+# identity and lifecycle and differ per managed/existing/default account.
+expect_grep "imagePullSecrets reach the readout Deployment" \
+  '^\s*- name: regcred$' \
+  --set 'imagePullSecrets[0].name=regcred' -s templates/deployment.yaml
+expect_grep "imagePullSecrets reach the helm-test pod" \
+  '^\s*- name: regcred$' \
+  --set 'imagePullSecrets[0].name=regcred' --set testFramework.enabled=true \
+  -s templates/tests/test-connection.yaml
+# Only the Kubernetes-native shape is accepted: a list of {name: <secret>}.
+# A bare string, a missing name, and an empty name are all rejected rather than
+# rendering a pull secret Kubernetes will silently ignore.
+expect_fail "schema rejects a string-form imagePullSecrets entry" \
+  --set-json 'imagePullSecrets=["regcred"]'
+expect_fail "schema rejects an imagePullSecrets entry without a name" \
+  --set-json 'imagePullSecrets=[{"secret":"regcred"}]'
+expect_fail "schema rejects an empty imagePullSecrets name" \
+  --set-json 'imagePullSecrets=[{"name":""}]'
+
 exit "$fail"


### PR DESCRIPTION
The chart renders two pods and the `helm test` one pulls a different image from a different registry, so a private mirror had no working path: the new `imagePullSecrets` value applies to both PodSpecs, in the Kubernetes-native `{name: <secret>}` shape the schema pins strictly.

Separately, that test pod ran as the namespace default account with Kubernetes' silent automount and took a projected token it never uses — it now sets `automountServiceAccountToken: false`. The readout pod's deliberate `true` is untouched.